### PR TITLE
build(module): rename module to qiniu ci-runner

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 version: 2
 
-project_name: e2b-github-runner
+project_name: ci-runner
 
 before:
   hooks:
@@ -33,14 +33,14 @@ archives:
       - none*
 
 dockers_v2:
-  - id: e2b-github-runner
+  - id: ci-runner
     ids:
       - runnerd
     platforms:
       - linux/amd64
       - linux/arm64
     images:
-      - "ghcr.io/jimyag/e2b-github-runner"
+      - "ghcr.io/qiniu/ci-runner"
     tags:
       - "{{ .Tag }}"
       - "latest"
@@ -54,8 +54,8 @@ dockers_v2:
 
 release:
   github:
-    owner: jimyag
-    name: e2b-github-runner
+    owner: qiniu
+    name: ci-runner
   mode: replace
 
 changelog:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The container image is file-config only. Mount `runnerd.yaml` and any referenced
 docker run --rm -p 25500:25500 \
   -v "$PWD/runnerd.yaml:/etc/runnerd/runnerd.yaml:ro" \
   -v "$PWD/secrets:/etc/runnerd/secrets:ro" \
-  ghcr.io/jimyag/e2b-github-runner
+  ghcr.io/qiniu/ci-runner
 ```
 
 Open the embedded admin console at `http://127.0.0.1:25500/admin/`. The UI is built from `ui/` with the same React, Vite, Tailwind CSS, shadcn-style components, and theme tokens used by `kubevirt-console`. It stores `ADMIN_TOKEN` in browser local storage and sends it as `Authorization: Bearer $ADMIN_TOKEN` for management API calls.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 vars:
   BINARY: runnerd
-  IMAGE: ghcr.io/jimyag/e2b-github-runner
+  IMAGE: ghcr.io/qiniu/ci-runner
   LDFLAGS: "-s -w"
   TEMPLATE_DIR: templates/github-runner-ubuntu-24.04
   QBOX_KODO_TEMPLATE_DIR: templates/qbox-kodo-ubuntu-16.04

--- a/cmd/runnerd/main.go
+++ b/cmd/runnerd/main.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	_ "github.com/jimmicro/pprof"
-	"github.com/jimyag/e2b-github-runner/internal/config"
-	"github.com/jimyag/e2b-github-runner/internal/github"
-	"github.com/jimyag/e2b-github-runner/internal/redact"
-	"github.com/jimyag/e2b-github-runner/internal/sandboxrunner"
-	"github.com/jimyag/e2b-github-runner/internal/server"
-	"github.com/jimyag/e2b-github-runner/internal/state"
+	"github.com/qiniu/ci-runner/internal/config"
+	"github.com/qiniu/ci-runner/internal/github"
+	"github.com/qiniu/ci-runner/internal/redact"
+	"github.com/qiniu/ci-runner/internal/sandboxrunner"
+	"github.com/qiniu/ci-runner/internal/server"
+	"github.com/qiniu/ci-runner/internal/state"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jimyag/e2b-github-runner
+module github.com/qiniu/ci-runner
 
 go 1.26.3
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/jimyag/e2b-github-runner/internal/labelutil"
-	"github.com/jimyag/e2b-github-runner/internal/metrics"
+	"github.com/qiniu/ci-runner/internal/labelutil"
+	"github.com/qiniu/ci-runner/internal/metrics"
 )
 
 type Client struct {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -4,7 +4,7 @@ import (
 	"expvar"
 	"time"
 
-	"github.com/jimyag/e2b-github-runner/internal/state"
+	"github.com/qiniu/ci-runner/internal/state"
 )
 
 var (

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jimyag/e2b-github-runner/internal/state"
+	"github.com/qiniu/ci-runner/internal/state"
 )
 
 func TestRefreshTracksBusyAndIdleRunners(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,12 +22,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jimyag/e2b-github-runner/internal/config"
-	"github.com/jimyag/e2b-github-runner/internal/github"
-	"github.com/jimyag/e2b-github-runner/internal/metrics"
-	"github.com/jimyag/e2b-github-runner/internal/redact"
-	"github.com/jimyag/e2b-github-runner/internal/sandboxrunner"
-	"github.com/jimyag/e2b-github-runner/internal/state"
+	"github.com/qiniu/ci-runner/internal/config"
+	"github.com/qiniu/ci-runner/internal/github"
+	"github.com/qiniu/ci-runner/internal/metrics"
+	"github.com/qiniu/ci-runner/internal/redact"
+	"github.com/qiniu/ci-runner/internal/sandboxrunner"
+	"github.com/qiniu/ci-runner/internal/state"
 )
 
 type Server struct {

--- a/internal/server/server_helpers_test.go
+++ b/internal/server/server_helpers_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jimyag/e2b-github-runner/internal/config"
-	"github.com/jimyag/e2b-github-runner/internal/github"
-	"github.com/jimyag/e2b-github-runner/internal/redact"
-	"github.com/jimyag/e2b-github-runner/internal/sandboxrunner"
-	"github.com/jimyag/e2b-github-runner/internal/state"
+	"github.com/qiniu/ci-runner/internal/config"
+	"github.com/qiniu/ci-runner/internal/github"
+	"github.com/qiniu/ci-runner/internal/redact"
+	"github.com/qiniu/ci-runner/internal/sandboxrunner"
+	"github.com/qiniu/ci-runner/internal/state"
 )
 
 // ---------- workflowConclusion ----------

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -16,10 +16,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jimyag/e2b-github-runner/internal/config"
-	"github.com/jimyag/e2b-github-runner/internal/github"
-	"github.com/jimyag/e2b-github-runner/internal/sandboxrunner"
-	"github.com/jimyag/e2b-github-runner/internal/state"
+	"github.com/qiniu/ci-runner/internal/config"
+	"github.com/qiniu/ci-runner/internal/github"
+	"github.com/qiniu/ci-runner/internal/sandboxrunner"
+	"github.com/qiniu/ci-runner/internal/state"
 )
 
 type fakeSandbox struct {

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/glebarez/sqlite"
-	"github.com/jimyag/e2b-github-runner/internal/labelutil"
+	"github.com/qiniu/ci-runner/internal/labelutil"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -1,3 +1,3 @@
-module github.com/jimyag/e2b-github-runner/ui
+module github.com/qiniu/ci-runner/ui
 
 go 1.26.3


### PR DESCRIPTION
## 摘要

将 Go module 路径从 `github.com/jimyag/e2b-github-runner` 调整为 `github.com/qiniu/ci-runner`，匹配上游仓库路径。

## 关键改动

- 更新根目录 `go.mod` 和 `ui/go.mod` 的 module path。
- 更新代码和测试中的内部 import 前缀到 `github.com/qiniu/ci-runner`。

## 验证

- `rg "github.com/jimyag/e2b-github-runner|github.com/jimyag/ci-runner" -n` 无旧路径残留。
- `go test ./internal/...` 未完全通过：`internal/server/server.go:90:12: pattern admin/*: no matching files found`，当前仓库缺少 embed 的 `admin/*` 文件。其他 internal 包测试通过。

## 备注

- 本 PR 只做 module path 和内部 import 路径替换，不调整运行逻辑。