### PR TITLE
Add local dev hot reload workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ internal/server/ui/
 templates/*/node_modules/
 *.local.yaml
 secrets/
+.smee-url

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ dist/
 var/
 node_modules/
 ui/node_modules/
-internal/server/admin/
+internal/server/ui/
 templates/*/node_modules/
 *.local.yaml
 secrets/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Use this guide for future Codex or agent work in this repository.
 task deps
 task ui-deps
 task dev
+task smee
 task lint
 task test
 task build
@@ -24,13 +25,16 @@ task docker-check
 task release-check
 ```
 
-Use `task dev` for local development. It defaults to `RUNNERD_CONFIG=runnerd.local.yaml` and `RUNNERD_VITE_PORT=5173`.
+Use `task dev` for local development. It defaults to `RUNNERD_CONFIG=runnerd.local.yaml` and `RUNNERD_VITE_PORT=5173`, and starts smee forwarding when `.smee-url` exists.
+
+Use `task smee` for standalone GitHub webhook forwarding. It reads `.smee-url` and defaults to `SMEE_TARGET=http://127.0.0.1:25500/webhooks/github`.
 
 Use `task build` when verifying production embedded UI behavior because it rebuilds `internal/server/ui/` before compiling `bin/runnerd`.
 
 ## Editing Rules
 
 - Do not commit real secrets, local sqlite databases, or local config files.
+- Do not commit `.smee-url`; it is per-developer local webhook state.
 - Do not hand-edit generated files in `internal/server/ui/`; edit `ui/` and rebuild.
 - Keep `README.md`, `docs/testing.md`, and `TODO.md` aligned when changing config, build, development, or deployment workflows.
 - If adding non-admin UI, keep admin routes and role-gated APIs explicit instead of assuming everything under `ui/` is admin-only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Agent Guide
+
+Use this guide for future Codex or agent work in this repository.
+
+## Project Facts
+
+- `runnerd` reads `./runnerd.yaml` by default, or another path passed with `--config`.
+- Local development should use `runnerd.local.yaml` for secrets and sqlite state.
+- UI source lives in `ui/`.
+- Production UI assets are generated into `internal/server/ui/` by `task ui-build` and embedded by `internal/server/ui_assets_production.go`.
+- Development UI assets are proxied to Vite by `internal/server/ui_assets_development.go`.
+- Current browser entry for the admin console is `/admin/`; the `ui/` tree may also host ordinary-user UI later.
+
+## Common Commands
+
+```bash
+task deps
+task ui-deps
+task dev
+task lint
+task test
+task build
+task docker-check
+task release-check
+```
+
+Use `task dev` for local development. It defaults to `RUNNERD_CONFIG=runnerd.local.yaml` and `RUNNERD_VITE_PORT=5173`.
+
+Use `task build` when verifying production embedded UI behavior because it rebuilds `internal/server/ui/` before compiling `bin/runnerd`.
+
+## Editing Rules
+
+- Do not commit real secrets, local sqlite databases, or local config files.
+- Do not hand-edit generated files in `internal/server/ui/`; edit `ui/` and rebuild.
+- Keep `README.md`, `docs/testing.md`, and `TODO.md` aligned when changing config, build, development, or deployment workflows.
+- If adding non-admin UI, keep admin routes and role-gated APIs explicit instead of assuming everything under `ui/` is admin-only.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ Runner state is persisted in a DB-backed store instead of per-request JSON direc
 go run ./cmd/runnerd --config ./runnerd.yaml
 ```
 
+## Development
+
+Install local tooling and UI dependencies once:
+
+```bash
+task deps
+task ui-deps
+```
+
+Use a local config file for development so secrets and local sqlite state stay out of git:
+
+```bash
+cp runnerd.yaml.example runnerd.local.yaml
+task dev
+```
+
+`task dev` starts the Vite UI dev server on `127.0.0.1:5173` by default and runs `runnerd` with the `development` build tag. The Go server still listens on the address from `runnerd.local.yaml`, commonly `:25500`, and proxies embedded UI assets to Vite. Open `http://127.0.0.1:25500/admin/` while developing.
+
+Set `RUNNERD_CONFIG` to use another config file, or `RUNNERD_VITE_PORT` when port `5173` is already in use.
+
 ## Docker
 
 The container image is file-config only. Mount `runnerd.yaml` and any referenced secret files into the container; environment variables such as `HTTP_ADDR` are not used for runtime config.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,17 @@ cp runnerd.yaml.example runnerd.local.yaml
 task dev
 ```
 
-`task dev` starts the Vite UI dev server on `127.0.0.1:5173` by default and runs `runnerd` with the `development` build tag. The Go server still listens on the address from `runnerd.local.yaml`, commonly `:25500`, and proxies embedded UI assets to Vite. Open `http://127.0.0.1:25500/admin/` while developing.
+`task dev` starts the Vite UI dev server on `127.0.0.1:5173` by default, starts the smee webhook forwarder when `.smee-url` exists, and runs `runnerd` with the `development` build tag. The Go server still listens on the address from `runnerd.local.yaml`, commonly `:25500`, and proxies embedded UI assets to Vite. Open `http://127.0.0.1:25500/admin/` while developing.
 
 Set `RUNNERD_CONFIG` to use another config file, or `RUNNERD_VITE_PORT` when port `5173` is already in use.
+
+For local GitHub webhook forwarding, create a per-developer smee channel file:
+
+```bash
+echo 'https://smee.io/<your-channel>' > .smee-url
+```
+
+`task dev` will start the forwarder automatically. `task smee` is also available for standalone webhook forwarding and defaults to `http://127.0.0.1:25500/webhooks/github`. Set `SMEE_TARGET` if runnerd listens on another address.
 
 ## Docker
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,17 @@
+# TODO
+
+This file tracks active project work. Completed behavior should move into `README.md` or `docs/`.
+
+## Active Roadmap
+
+- Add a deployment smoke checklist for a real GitHub App, repository webhook, E2B template, runner pickup, cleanup, and diagnostics.
+- Decide whether GitHub token and basic auth remain supported compatibility modes or should be removed in favor of GitHub App-only operation.
+- Define the ordinary-user UI surface before adding non-admin screens under `ui/`; include routes, navigation visibility, and API permissions.
+- Add an effective-config diagnostics view or config validation workflow if operators need to inspect runtime config from the UI.
+- Verify DB lease behavior with two runnerd processes sharing the same database before documenting multi-instance support.
+- Decide whether expvar diagnostics need a Prometheus/export adapter or histogram-style latency views for deployment observability.
+
+## Maintenance
+
+- Keep `README.md`, `docs/testing.md`, and this roadmap in sync when build, dev, config, or UI asset workflows change.
+- Keep generated production UI assets under `internal/server/ui/` out of hand edits; change source files in `ui/` and rebuild with `task build`.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -139,6 +139,7 @@ tasks:
         echo "Starting UI on ${RUNNERD_VITE_DEV_SERVER_URL}"
         echo "Starting runnerd with ${RUNNERD_CONFIG}"
 
+        ./scripts/smee.sh --check
         (
           cd ui
           exec bun run dev --host 127.0.0.1 --port "${RUNNERD_VITE_PORT}" --strictPort
@@ -159,11 +160,6 @@ tasks:
           echo "UI dev server failed to start on ${RUNNERD_VITE_DEV_SERVER_URL}" >&2
           exit 1
         fi
-        if [ -f .smee-url ] && ! kill -0 "$SMEE_PID" 2>/dev/null; then
-          echo "smee webhook forwarder failed to start" >&2
-          exit 1
-        fi
-
         reflex \
           -d none -s \
           -r '\.go$' \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -127,6 +127,15 @@ tasks:
         export RUNNERD_VITE_PORT="${RUNNERD_VITE_PORT:-5173}"
         export RUNNERD_VITE_DEV_SERVER_URL="${RUNNERD_VITE_DEV_SERVER_URL:-http://127.0.0.1:${RUNNERD_VITE_PORT}}"
 
+        command -v curl >/dev/null 2>&1 || {
+          echo "curl is required for task dev startup checks." >&2
+          exit 1
+        }
+        if curl -fsS "${RUNNERD_VITE_DEV_SERVER_URL}" >/dev/null 2>&1; then
+          echo "UI dev server address is already in use: ${RUNNERD_VITE_DEV_SERVER_URL}" >&2
+          exit 1
+        fi
+
         echo "Starting UI on ${RUNNERD_VITE_DEV_SERVER_URL}"
         echo "Starting runnerd with ${RUNNERD_CONFIG}"
 
@@ -138,9 +147,20 @@ tasks:
         ./scripts/smee.sh &
         SMEE_PID="$!"
         trap 'kill "$UI_PID" "$SMEE_PID" 2>/dev/null || true' EXIT
-        sleep 1
-        if ! kill -0 "$UI_PID" 2>/dev/null; then
+        UI_READY=0
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+          if curl -fsS "${RUNNERD_VITE_DEV_SERVER_URL}" >/dev/null 2>&1; then
+            UI_READY=1
+            break
+          fi
+          sleep 0.5
+        done
+        if [ "$UI_READY" != "1" ]; then
           echo "UI dev server failed to start on ${RUNNERD_VITE_DEV_SERVER_URL}" >&2
+          exit 1
+        fi
+        if [ -f .smee-url ] && ! kill -0 "$SMEE_PID" 2>/dev/null; then
+          echo "smee webhook forwarder failed to start" >&2
           exit 1
         fi
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -139,6 +139,10 @@ tasks:
         SMEE_PID="$!"
         trap 'kill "$UI_PID" "$SMEE_PID" 2>/dev/null || true' EXIT
         sleep 1
+        if ! kill -0 "$UI_PID" 2>/dev/null; then
+          echo "UI dev server failed to start on ${RUNNERD_VITE_DEV_SERVER_URL}" >&2
+          exit 1
+        fi
 
         reflex \
           -d none -s \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -22,6 +22,7 @@ tasks:
       - go install honnef.co/go/tools/cmd/staticcheck@latest
       - go install mvdan.cc/gofumpt@latest
       - go install golang.org/x/tools/cmd/goimports@latest
+      - go install github.com/cespare/reflex@latest
       - go install github.com/go-task/task/v3/cmd/task@latest
       - go install github.com/goreleaser/goreleaser/v2@latest
 
@@ -32,20 +33,20 @@ tasks:
       - goimports -w cmd internal
 
   ui-deps:
-    desc: Install admin UI dependencies
+    desc: Install UI dependencies
     dir: ui
     cmds:
       - bun install --frozen-lockfile
 
   ui-build:
-    desc: Build the embedded admin UI
+    desc: Build the embedded UI
     dir: ui
     cmds:
       - bun install --frozen-lockfile
       - bun run build
 
   ui-lint:
-    desc: Lint and type-check the admin UI
+    desc: Lint and type-check the UI
     dir: ui
     cmds:
       - bun install --frozen-lockfile
@@ -103,6 +104,51 @@ tasks:
       - ui-build
     cmds:
       - go run ./cmd/{{.BINARY}} {{.CLI_ARGS}}
+
+  dev:
+    desc: Start the UI Vite dev server and runnerd with hot reload
+    cmds:
+      - |
+        command -v reflex >/dev/null 2>&1 || {
+          echo "reflex is required for task dev. Run: task deps" >&2
+          exit 1
+        }
+        test -x ui/node_modules/.bin/vite || {
+          echo "UI dependencies are missing. Run: task ui-deps" >&2
+          exit 1
+        }
+
+        export RUNNERD_CONFIG="${RUNNERD_CONFIG:-runnerd.local.yaml}"
+        test -f "${RUNNERD_CONFIG}" || {
+          echo "runnerd config not found: ${RUNNERD_CONFIG}" >&2
+          echo "Create one from runnerd.yaml.example, then update local secrets and OAuth settings." >&2
+          exit 1
+        }
+        export RUNNERD_VITE_PORT="${RUNNERD_VITE_PORT:-5173}"
+        export RUNNERD_VITE_DEV_SERVER_URL="${RUNNERD_VITE_DEV_SERVER_URL:-http://127.0.0.1:${RUNNERD_VITE_PORT}}"
+
+        echo "Starting UI on ${RUNNERD_VITE_DEV_SERVER_URL}"
+        echo "Starting runnerd with ${RUNNERD_CONFIG}"
+
+        (
+          cd ui
+          exec bun run dev --host 127.0.0.1 --port "${RUNNERD_VITE_PORT}"
+        ) &
+        UI_PID="$!"
+        trap 'kill "$UI_PID" 2>/dev/null || true' EXIT
+        sleep 1
+
+        reflex \
+          -d none -s \
+          -r '\.go$' \
+          -R '\.git/' \
+          -R 'bin/' \
+          -R 'dist/' \
+          -R 'docs/' \
+          -R 'templates/' \
+          -R 'ui/' \
+          -R 'var/' \
+          -- go run -trimpath -tags development ./cmd/{{.BINARY}} --config "${RUNNERD_CONFIG}" {{.CLI_ARGS}}
 
   docker-build:
     desc: Build the local Docker image

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -106,7 +106,7 @@ tasks:
       - go run ./cmd/{{.BINARY}} {{.CLI_ARGS}}
 
   dev:
-    desc: Start the UI Vite dev server and runnerd with hot reload
+    desc: Start the UI Vite dev server, smee webhook forwarder, and runnerd with hot reload
     cmds:
       - |
         command -v reflex >/dev/null 2>&1 || {
@@ -132,10 +132,12 @@ tasks:
 
         (
           cd ui
-          exec bun run dev --host 127.0.0.1 --port "${RUNNERD_VITE_PORT}"
+          exec bun run dev --host 127.0.0.1 --port "${RUNNERD_VITE_PORT}" --strictPort
         ) &
         UI_PID="$!"
-        trap 'kill "$UI_PID" 2>/dev/null || true' EXIT
+        ./scripts/smee.sh &
+        SMEE_PID="$!"
+        trap 'kill "$UI_PID" "$SMEE_PID" 2>/dev/null || true' EXIT
         sleep 1
 
         reflex \
@@ -149,6 +151,11 @@ tasks:
           -R 'ui/' \
           -R 'var/' \
           -- go run -trimpath -tags development ./cmd/{{.BINARY}} --config "${RUNNERD_CONFIG}" {{.CLI_ARGS}}
+
+  smee:
+    desc: Start the smee.io webhook forwarder standalone (reads .smee-url)
+    cmds:
+      - ./scripts/smee.sh
 
   docker-build:
     desc: Build the local Docker image

--- a/docs/runner-implementation-review.md
+++ b/docs/runner-implementation-review.md
@@ -1,307 +1,69 @@
 # Runnerd Implementation Review
 
-Date: 2026-05-19
+Date: 2026-06-28
 
 Scope:
 
-- Recent commits reviewed: `19663e8`, `1881790`, `8e7f48e`, `eee1752`.
-- Local references compared:
-  - `bin/actions-runner-controller`
-  - `bin/fireactions`
-- Main target architecture referenced: database-backed runner state, file-free config, GitHub App auth, profile/policy management, retryable E2B operations, restart recovery, public deployment safety, and admin operations.
+- Current branch: `refactor/dev`
+- Review target: implementation status after file-based config, DB-backed runner state, retry/lease/audit handling, admin console, embedded UI assets, and local development workflow updates.
+- Local references still useful for future comparison: actions-runner-controller style reconciliation and fireactions style pool/config modeling.
 
 ## Executive Summary
 
-The recent commits move the project in the right direction: runner state is now DB-backed, profile and repository policy concepts exist, the admin UI can manage basic profile/policy data, GitHub App auth was added, status now uses `queued -> creating -> running -> stopping -> completed/failed`, and `github.com/jimmicro/pprof` is wired in.
+Runnerd has moved past the original 2026-05-19 gap list. Runtime configuration is now file-first, runner state is DB-backed, retry/lease/audit fields exist, GitHub App auth can resolve installations dynamically, the admin console covers the core management workflow, diagnostics expose pprof/expvar state, and the documented local workflow includes `task dev`.
 
-However, the implementation is not yet aligned with the current architecture. The largest gaps are:
+The remaining work is no longer a basic architecture catch-up. The next decisions are product and operations hardening: whether to keep token/basic auth as local compatibility modes, how to introduce non-admin UI surfaces under the shared `ui/` tree, how much config management belongs in the admin console, and what deployment smoke tests are required before treating the service as production-ready.
 
-- Configuration is still environment-variable driven, while the design now says all configuration should come from config files.
-- PAT/token mode still exists, while the design decision was GitHub App only.
-- E2B API failures are not retried; requests fail immediately.
-- The DB state model has no retry, lease, or audit fields, so it is not ready for reliable multi-instance or public deployment.
-- The worker loop is still in-memory driven and scans all states, instead of claiming work through the database.
-- Repository policy checks can be bypassed by manually selecting a profile.
-- Admin management is incomplete: no retry action, audit events, config reload, or full diagnostics workflow.
-- `task lint` currently fails.
+## Current Baseline
 
-## Findings
+- Configuration is loaded from `runnerd.yaml` by default, or from `--config`. Relative sqlite database paths and GitHub App private-key paths resolve from the config file directory.
+- The config schema covers server, database, OAuth session auth, E2B, GitHub webhook/auth/OAuth, allowed repositories, and worker retry/lease/concurrency behavior.
+- Exactly one GitHub API auth mode is allowed: GitHub App, token, or basic auth. GitHub App mode supports optional static `installation_id`; when omitted, runnerd resolves installation access per job repository and caches transports.
+- Runner requests, events, specs, groups, policies, retry metadata, leases, and audit events are stored in the configured database backend.
+- Worker processing uses DB claim/lease semantics and retry scheduling instead of only in-memory queue ownership.
+- Transient E2B, GitHub, rate-limit, timeout, and temporary network failures are classified for retry or queue deferral. Deterministic auth/config/template failures fail immediately.
+- Admin routes expose runner request management, retry/stop/log access, runner specs, runner groups, repository policies, match tests, audit events, and diagnostics.
+- The React UI in `ui/` is embedded for production from `internal/server/ui/*`; development builds proxy UI assets to Vite through `internal/server/ui_assets_development.go`.
+- `task dev` starts Vite and the Go service together in development mode. `task build` builds the UI first, then compiles `bin/runnerd` with embedded production assets.
+- Diagnostics are available through the admin UI and `/diagnostics/pprof` / `/diagnostics/vars`, backed by `github.com/jimmicro/pprof` and expvar.
 
-### P0: Config Is Still Env-Based, Not File-Based
+## Remaining Decisions
 
-The architecture says all settings should be configurable and environment variables should no longer be supported as the primary configuration surface. Current code still loads nearly all runtime configuration from environment variables:
+### 1. Auth Policy
 
-- `internal/config/config.go:62-91` reads `HTTP_ADDR`, `STATE_DIR`, `ADMIN_TOKEN`, `E2B_API_KEY`, `E2B_API_URL`, `E2B_DOMAIN`, GitHub auth, sandbox timeouts, runner labels, and concurrency from env.
-- `internal/config/config.go:96-140` validates missing values as `missing required env`.
-- `internal/config/config.go:168-180` only uses `RUNNERD_CONFIG_FILE` for seed profiles and repository policies, not for the full service config.
+Token and basic auth are still supported alongside GitHub App auth. That is useful for local verification or legacy credentials, but it means the product is not GitHub-App-only. Decide whether these modes are intentional compatibility paths or should be removed before production hardening.
 
-Impact:
+### 2. UI Product Boundary
 
-- Public deployment remains hard to reason about because secrets, auth, DB backend, timeouts, and routing are split across env and DB.
-- The admin UI cannot represent the effective config accurately.
-- It diverges from `fireactions`, which loads a YAML config file with validation in `bin/fireactions/server/config.go:78-112`.
+The asset package has been generalized from admin-only assets to `ui/*`, which leaves room for future ordinary-user screens. The current routed product is still admin-focused under `/admin/*`. Before adding non-admin UI, define route ownership, role-aware navigation, and API permissions so the shared UI tree does not become an accidental admin surface.
 
-Recommendation:
+### 3. Config Management
 
-- Introduce a single `runnerd.yaml` schema for server, auth, database, E2B, GitHub App, profiles, policies, worker, retry, and diagnostics.
-- Keep env support only for explicit secret-file indirection if needed, not as the primary config model.
-- Change validation errors from env names to config paths.
+Runtime config is file-first, but the admin console does not yet provide an effective-config view, config validation preview, reload workflow, or import/export flow. Keep the current file-only operations model unless live config operations become a clear requirement.
 
-### P0: GitHub PAT/Token Mode Still Exists
+### 4. Deployment Smoke
 
-The current decision was to not support PAT migration and use GitHub App auth. Current code still supports token mode:
+Local build/lint/test coverage validates the code path, but production readiness still depends on a real GitHub App installation, real E2B templates, webhook delivery, and sandbox runner execution. Keep a deployment smoke checklist that verifies webhook signature handling, installation resolution, runner spec matching, sandbox creation, GitHub job pickup, cleanup, and diagnostics.
 
-- `internal/config/config.go:23` keeps `GitHubToken`.
-- `internal/config/config.go:109-119` accepts either `GITHUB_TOKEN` or GitHub App fields.
-- `internal/config/config.go:151-156` selects `"token"` when `GitHubToken` is present.
-- `cmd/runnerd/main.go:37-49` creates either `NewAppClient` or token `NewClient`.
-- `internal/github/client.go:96-98` always sets an `Authorization` header using `c.token`.
+### 5. Multi-Instance And Operations
 
-Impact:
+The DB lease model is in place, but multi-process behavior should be verified with two runnerd instances against the same database before documenting multi-instance support. Expvar diagnostics cover useful counters and gauges; add histogram/export adapters only if deployment observability needs them.
 
-- The implementation no longer matches the chosen security model.
-- The GitHub client still mixes token and App transport behavior. `ghinstallation` likely overwrites the auth header, but the code path is confusing and under-tested.
-- It misses the cleaner fireactions model: app transport plus cached installation clients and retryable HTTP in `bin/fireactions/helper/github/client.go:14-77`.
+## Suggested Next Order
 
-Recommendation:
+1. Keep `task dev`, `task build`, `task lint`, and `task test` green on every branch that touches backend/UI boundaries.
+2. Add or update a deployment smoke checklist using a real GitHub App, one repository, and one E2B template.
+3. Decide whether token/basic auth remain supported modes.
+4. Define the non-admin UI route and permission model before adding ordinary-user screens.
+5. Add an effective-config diagnostics view only after the desired config operations model is clear.
+6. Stress DB lease behavior with concurrent runnerd processes before advertising multi-instance support.
 
-- Remove PAT mode entirely from config, validation, client construction, tests, docs, and UI.
-- Make `GitHubApp` the only auth config.
-- Add tests that prove registration token calls work through the app transport without a PAT.
+## Verification Notes
 
-### P0: E2B API Retry Is Not Implemented
-
-The architecture calls for retrying E2B API failures with retry state. Current worker fails immediately:
-
-- `internal/server/server.go:858-865` marks failed immediately when GitHub registration token creation fails.
-- `internal/server/server.go:873-893` marks failed immediately when sandbox start fails.
-- `internal/server/server.go:1089-1103` marks failed immediately on non-404 sandbox stop errors.
-- `internal/server/server.go:206-218` converts creating timeout directly to failed.
-
-The DB schema has no retry fields:
-
-- `internal/state/store.go:135-160` has no `retry_count`, `next_retry_at`, retryable error fields, or lease fields.
-- `internal/state/store.go:880-940` and `internal/state/store.go:942-1002` migrations have no retry indexes.
-
-Impact:
-
-- Transient placement errors like `Failed to place sandbox`, E2B 429/5xx, network timeouts, and temporary stop failures become terminal failures.
-- Admin cannot retry failed requests because there is no retry state or endpoint.
-- Restart recovery cannot distinguish retryable from terminal failures.
-
-Recommendation:
-
-- Add retry fields to `runner_requests`: `retry_count`, `next_retry_at`, `last_error_code`, `last_error_message`, `last_error_retryable`, `last_attempt_at`.
-- Add manual indexes for `(status, next_retry_at, queued_at)` and `(status, updated_at)`.
-- Classify retryable errors: E2B 408/409/425/429/5xx, timeout, temporary network failures; GitHub 5xx/secondary rate limit; non-retryable auth/config errors.
-- Add `POST /runner_requests/{id}/retry` and UI action.
-
-### P1: Worker Claiming Is In-Memory, Not DB-Leased
-
-The worker still scans all states and uses in-process memory to prevent duplicates:
-
-- `internal/server/server.go:144-176` starts three unbounded background loops without a stop context.
-- `internal/server/server.go:178-191` lists all states and starts a goroutine for every queued state.
-- The `Store` interface in `internal/state/store.go:102-120` has no claim/lease method.
-- The request record in `internal/state/store.go:135-160` has no `lease_owner` or `lease_expires_at`.
-
-Impact:
-
-- A Postgres deployment with two runnerd instances can start the same queued request twice.
-- If the process dies after claiming in memory but before starting a sandbox, the DB does not know who owns the request or when it can be retried.
-- Tests can leak background goroutines because server loops have no lifecycle control.
-
-Comparison:
-
-- ARC uses controller-runtime reconciliation and leader/concurrency controls (`bin/actions-runner-controller/main.go:133-155`).
-- fireactions has explicit pool lifecycle state, stop channels, done channels, pending create/delete counters, and cleanup wait groups (`bin/fireactions/server/pool.go:35-57`, `129-180`, `182-220`).
-
-Recommendation:
-
-- Add DB-backed claim APIs:
-  - `ClaimNextQueued(workerID, now, leaseTTL)`.
-  - `ExtendLease(requestID, workerID)`.
-  - `ReleaseLease(requestID, workerID)`.
-- Drive workers from `next_retry_at <= now` and `lease_expires_at < now`.
-- Add a server context and graceful shutdown for loops.
-
-### P1: Repository Policy Can Be Bypassed By Manual Profile Selection
-
-Webhook admission uses profile matching, but manual runner creation can directly request a profile:
-
-- The admin policy endpoints exist in `internal/server/server.go:574-675`.
-- Matching is exposed at `internal/server/server.go:678-692`.
-- Manual creation with explicit `runner_spec_name` loads that profile directly later at `internal/server/server.go:868-872`; it does not enforce that the requested repository is allowed to use that profile.
-
-Impact:
-
-- The policy model cannot be treated as an authorization boundary.
-- A caller with admin API access can create a runner for a repo/profile combination that repository policies would reject.
-
-Recommendation:
-
-- Run repository policy validation for all requests, including manual API calls.
-- If `runner_spec_name` is supplied, check it is one of the profiles allowed by the repository policy.
-- Store both requested labels and selected profile labels separately so admission decisions are auditable.
-
-### P1: Recovery Marks Interrupted Active Jobs As Completed
-
-Restart recovery stops any active sandbox and then marks the request completed:
-
-- `cmd/runnerd/main.go:55-62` calls recovery before serving.
-- `internal/server/server.go:1016-1049` stops the sandbox and writes `StatusCompleted`.
-
-Impact:
-
-- A request that was `creating`, `running`, or `stopping` before process restart can be marked completed even if the GitHub job did not complete.
-- This hides interrupted jobs and makes admin history misleading.
-
-Recommendation:
-
-- Use `stopping` while cleanup is in progress.
-- Mark `failed` for interrupted `creating/running` states unless GitHub confirms the job completed successfully.
-- Reconcile by sandbox metadata `request_id` and GitHub workflow job state where possible.
-
-### P1: DB Schema Is Missing Audit Events And Operational Fields
-
-The current DB schema captures runner state, events, profiles, and repository policies, but not the full control-plane model:
-
-- `internal/state/store.go:880-940` SQLite migration has no `audit_events`.
-- `internal/state/store.go:942-1002` Postgres migration has no `audit_events`.
-- There are no actor/source fields on profile/policy changes.
-- Admin mutations in `internal/server/server.go:522-675` do not write audit events.
-
-Impact:
-
-- Public admin deployment cannot answer who changed a profile, disabled a policy, retried a request, or stopped a sandbox.
-- It weakens incident/debug trails.
-
-Recommendation:
-
-- Add `audit_events` with `id`, `actor`, `action`, `resource_type`, `resource_id`, `payload_json`, `created_at`.
-- Record profile/policy create/patch/delete, runner retry/stop, config reload, and recovery cleanup.
-- Expose `GET /audit-events` in admin.
-
-### P2: Metrics And Diagnostics Coverage
-
-The project intentionally uses `github.com/jimmicro/pprof` and `expvar`, not Prometheus. That difference is acceptable because it follows the current user requirement. The implementation now covers the main ARC and Fireactions signal families through expvar:
-
-- Profile gauges: current, busy, idle, desired, pending, enabled status.
-- Request gauges: profile/status, repository/status, retry state, worker leases.
-- Runner operation metrics: create/stop duration totals and counts, generic operation totals.
-- GitHub operation metrics: API operation totals and duration totals.
-- Runner lifecycle metrics: registration and cleanup counters.
-- Workflow job metrics: queued/started/completed counters, conclusions, failures, queue duration totals/counts, run duration totals/counts.
-
-Remaining differences:
-
-- expvar exposes cumulative totals and counts, not Prometheus histogram buckets.
-- Workflow names can be `unknown` on paths where GitHub only provides runner state, because workflow name is not persisted in `RunnerState`.
-- Metrics are refreshed only when selected endpoints or state transitions call `refreshMetrics`.
-- `internal/server/server.go:695-710` diagnostics hardcode DB assumptions in the response path and do not fully reflect a configurable DB backend.
-
-Comparison:
-
-- ARC tracks queue duration, run duration, conclusions, started/completed/queued counts, and workflow failures in `bin/actions-runner-controller/pkg/actionsmetrics/metrics.go:76-129`.
-- fireactions tracks current/desired/pending pool state directly inside pool reconciliation (`bin/fireactions/server/pool.go:117-124`, `155-165`).
-
-Recommendation:
-
-- Keep jimmicro/pprof and expvar unless a Prometheus endpoint becomes a deployment requirement.
-- If richer latency analysis is needed, add histogram buckets or export expvar to Prometheus in a separate adapter.
-- Refresh gauges periodically from the reconciler, not only through API reads.
-
-### P2: Admin UI Does Not Cover The Full Control Plane
-
-The admin UI can manage basic profiles/policies and view diagnostics, but important operations are missing:
-
-- No retry failed request action.
-- No audit event viewer.
-- No config preview/reload/import workflow.
-- No DB backend/status view.
-- No worker/retry queue view.
-- No repository policy enforcement test that includes explicit profile selection.
-
-Recommendation:
-
-- Add admin screens/actions after the backend APIs exist:
-  - retry request.
-  - stop request idempotently.
-  - audit timeline.
-  - config effective view.
-  - profile policy test with repository, labels, and requested profile.
-
-### P2: Lint Currently Fails
-
-`task lint` fails:
-
-```text
-internal/state/store.go:527:31: should convert record (type repositoryPolicyRecord) to RepositoryPolicy instead of using struct literal (S1016)
-internal/state/store.go:566:10: should convert saved (type repositoryPolicyRecord) to RepositoryPolicy instead of using struct literal (S1016)
-internal/state/store.go:576:9: should convert saved (type repositoryPolicyRecord) to RepositoryPolicy instead of using struct literal (S1016)
-```
-
-Impact:
-
-- Local checks are not green.
-- This should be fixed before relying on the branch.
-
-## Comparison With fireactions
-
-| Area | fireactions | Current runnerd | Gap |
-| --- | --- | --- | --- |
-| Config | YAML file with validation | Env-first, config file only seeds profiles/policies | Need full config file model |
-| GitHub auth | GitHub App transport | App plus PAT/token fallback | Remove PAT/token |
-| HTTP retries | `hashicorp/go-retryablehttp` | No retryable GitHub/E2B client | Add retry policy |
-| Installation handling | Cached installation clients | Single installation id/client | OK for single install, weak for org/multi-repo |
-| Pool model | Desired/current/pending, active/pause, graceful stop | Queue scan plus global slots | Need DB leases and profile concurrency |
-| Metrics | Prometheus pool metrics | expvar partial metrics | Keep expvar, expand coverage |
-
-## Comparison With actions-runner-controller
-
-| Area | ARC | Current runnerd | Gap |
-| --- | --- | --- | --- |
-| Reconciliation | Controller reconciliation with concurrency controls | Polling loops and in-memory pending map | Need DB claim/lease reconcile |
-| Metrics | Queue/run durations, conclusions, failures | Basic counts and duration totals | Need queue/run/failure metrics |
-| pprof | Configurable address flag | jimmicro pprof auto artifact discovery | Acceptable, but expose in config/admin |
-| Runner groups | Models GitHub runner group visibility | Local `runner_group` string only | Need decide whether to enforce via GitHub API |
-| Multi-instance | Kubernetes leader/concurrency model | Not safe on shared DB | Add lease or single-instance guarantee |
-
-## Missing Design Points
-
-- Full config file schema and validation.
-- DB backend selection from config.
-- Retry state and retry worker.
-- DB-backed worker lease.
-- Audit event table and admin audit viewer.
-- Config reload/preview/apply.
-- Manual request admission through repository policies.
-- Per-profile concurrency enforcement. Current slot limit is global.
-- GitHub App installation discovery or per-repo installation mapping.
-- Runner group visibility validation if org-level runner groups are expected.
-- Idempotent retry/stop semantics across restarts and multiple instances.
-
-## Suggested Fix Order
-
-1. Make local checks green.
-2. Replace env config with `runnerd.yaml` and wire DB backend selection.
-3. Remove PAT/token mode and simplify GitHub client around GitHub App only.
-4. Add retry/lease schema and migration SQL.
-5. Replace in-memory worker claiming with DB claims.
-6. Add E2B/GitHub retry classification and retry worker.
-7. Enforce repository policies for manual and webhook requests.
-8. Add audit events and admin views/actions.
-9. Expand diagnostics and expvar metrics.
-10. Improve restart recovery with sandbox/GitHub reconciliation.
-
-## Verification
-
-Executed locally:
+The stale findings from the 2026-05-19 review have been retired because the referenced implementation has changed materially. Re-run the current verification commands when this document is updated:
 
 ```bash
 task lint
+task test
+task build
 ```
-
-Result: failed with staticcheck `S1016` in `internal/state/store.go`.
-
-The UI build step inside `task lint` completed successfully before staticcheck failed.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -238,11 +238,27 @@ curl -fsS -b "$COOKIE_JAR" http://127.0.0.1:25500/diagnostics/pprof | jq
 
 GitHub webhook 必须能访问到本地服务。任选一种方式：
 
+使用 smee：
+
+```bash
+open https://smee.io/new
+echo 'https://smee.io/<your-channel>' > .smee-url
+task dev
+```
+
+把同一个 smee URL 填到 GitHub webhook 的 Payload URL。`.smee-url` 存在时，`task dev` 会自动启动 smee forwarder。也可以用 `task smee` 单独启动转发。默认转发到 `http://127.0.0.1:25500/webhooks/github`；如果 `runnerd.yaml` 使用了其他监听地址，可以设置 `SMEE_TARGET`：
+
+```bash
+SMEE_TARGET=http://127.0.0.1:25501/webhooks/github task smee
+```
+
+也可以使用 ngrok：
+
 ```bash
 ngrok http 25500
 ```
 
-或：
+或 cloudflared：
 
 ```bash
 cloudflared tunnel create e2b-local-runner

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -147,7 +147,7 @@ go run ./cmd/runnerd --config ./runnerd.yaml --bootstrap-admin github:<your-gith
 export COOKIE_JAR=./runnerd.cookies
 ```
 
-后台页面源码在 `ui/`，使用和 `kubevirt-console` 相同的 React、Vite、Tailwind CSS、shadcn 风格组件和主题 CSS。`task build` 会先执行 `task ui-build`，把前端产物写入 `internal/server/admin/` 后再编译 `runnerd`。管理面现在包含 runners、runner specs、runner policies、retry、audit、label match test 和 diagnostics 页面。
+后台页面源码在 `ui/`，使用和 `kubevirt-console` 相同的 React、Vite、Tailwind CSS、shadcn 风格组件和主题 CSS。`task build` 会先执行 `task ui-build`，把前端产物写入 `internal/server/ui/` 后再编译 `runnerd`。管理面现在包含 runners、runner specs、runner policies、retry、audit、label match test 和 diagnostics 页面。
 
 先创建一个默认 runner spec：
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -119,6 +119,29 @@ github:
 
 ## 3. 启动服务
 
+开发 UI 或后端时，优先使用开发模式：
+
+```bash
+task deps
+task ui-deps
+cp runnerd.yaml.example runnerd.local.yaml
+task dev
+```
+
+`task dev` 默认读取 `runnerd.local.yaml`，启动 Vite dev server 到 `127.0.0.1:5173`，并用 `development` build tag 启动 Go 服务。浏览器仍然访问 runnerd 的地址，例如：
+
+```text
+http://127.0.0.1:25500/admin/
+```
+
+如需换配置文件：
+
+```bash
+RUNNERD_CONFIG=./runnerd.yaml task dev
+```
+
+生产模式或验证嵌入式前端资源时，直接启动 Go 服务：
+
 ```bash
 go run ./cmd/runnerd --config ./runnerd.yaml
 ```
@@ -147,7 +170,7 @@ go run ./cmd/runnerd --config ./runnerd.yaml --bootstrap-admin github:<your-gith
 export COOKIE_JAR=./runnerd.cookies
 ```
 
-后台页面源码在 `ui/`，使用和 `kubevirt-console` 相同的 React、Vite、Tailwind CSS、shadcn 风格组件和主题 CSS。`task build` 会先执行 `task ui-build`，把前端产物写入 `internal/server/ui/` 后再编译 `runnerd`。管理面现在包含 runners、runner specs、runner policies、retry、audit、label match test 和 diagnostics 页面。
+后台页面源码在 `ui/`，使用和 `kubevirt-console` 相同的 React、Vite、Tailwind CSS、shadcn 风格组件和主题 CSS。`task build` 会先执行 `task ui-build`，把前端产物写入 `internal/server/ui/` 后再编译 `runnerd`。开发模式下 `internal/server/ui_assets_development.go` 会把 UI 资源代理到 Vite；生产构建下 `internal/server/ui_assets_production.go` 会嵌入 `internal/server/ui/*`。管理面现在包含 runners、runner specs、runner policies、retry、audit、label match test 和 diagnostics 页面。
 
 先创建一个默认 runner spec：
 
@@ -249,7 +272,7 @@ Settings -> Webhooks -> Add webhook
 
 - Payload URL：`https://<public-host>/webhooks/github`
 - Content type：`application/json`
-- Secret：和 `GITHUB_WEBHOOK_SECRET` 完全一致。
+- Secret：和 `runnerd.yaml` 里的 `github.webhook_secret` 完全一致。
 - Which events：选择 `Workflow jobs`。如果希望开启补偿路径，也可以同时选择 `Workflow runs`。
 - Active：勾选。
 
@@ -309,10 +332,10 @@ curl -fsS -b "$COOKIE_JAR" \
 
 常见问题：
 
-- `invalid signature`：GitHub webhook secret 和 `GITHUB_WEBHOOK_SECRET` 不一致。
+- `invalid signature`：GitHub webhook secret 和 `github.webhook_secret` 不一致。
 - `runner concurrency limit reached`：活跃 request 数量达到 `worker.max_concurrent_runners`。
 - GitHub job 一直 queued：workflow 的 `runs-on` labels 必须包含 `self-hosted` 和 `e2b`。
-- sandbox 创建失败：确认 `E2B_API_KEY`、`E2B_API_URL`、`E2B_DOMAIN` 是否匹配本地环境。
+- sandbox 创建失败：确认 `e2b.api_key`、`e2b.api_url` 和 template 配置是否匹配本地环境。
 - registration token 失败：确认 GitHub App installation 对目标仓库有对应的 administration/self-hosted runner 权限。
 
 ## 9. GitHub Actions 日志怎么看

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
-	"embed"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -15,7 +14,6 @@ import (
 	"hash/fnv"
 	"io"
 	"log/slog"
-	"mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -99,9 +97,6 @@ type adminSession struct {
 	AvatarURL string `json:"avatar_url,omitempty"`
 	ExpiresAt int64  `json:"expires_at"`
 }
-
-//go:embed admin/*
-var adminAssets embed.FS
 
 const runnerJobStartedMarker = "__runner_job_started__"
 
@@ -559,24 +554,9 @@ func (s *Server) handleAdmin(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	data, err := adminAssets.ReadFile("admin" + name)
-	if err != nil {
-		if path.Ext(name) != "" {
-			http.NotFound(w, r)
-			return
-		}
-		data, err = adminAssets.ReadFile("admin/index.html")
-		if err != nil {
-			http.NotFound(w, r)
-			return
-		}
-		name = "/index.html"
+	if !s.serveUIAsset(w, r, name) {
+		http.NotFound(w, r)
 	}
-	if contentType := mime.TypeByExtension(path.Ext(name)); contentType != "" {
-		w.Header().Set("Content-Type", contentType)
-	}
-	w.Header().Set("Cache-Control", "no-store")
-	_, _ = w.Write(data)
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -168,6 +168,10 @@ func (w *loggingResponseWriter) Write(data []byte) (int, error) {
 	return n, err
 }
 
+func (w *loggingResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 func (s *Server) Close() {
 	if s.loopCancel != nil {
 		s.logger.Info("stopping background loops")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -541,6 +541,10 @@ func TestListRunnerRequestsIsPaginated(t *testing.T) {
 }
 
 func TestAdminUIIsServedWithoutAPIAccess(t *testing.T) {
+	if uiAssetsDevelopment {
+		t.Skip("embedded UI is served only in production asset mode")
+	}
+
 	store := state.New(t.TempDir())
 	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/hmac"
@@ -10,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -566,6 +568,34 @@ func TestAdminUIIsServedWithoutAPIAccess(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `<div id="root">`) {
 		t.Fatalf("admin route fallback did not serve vite shell")
+	}
+}
+
+func TestLoggingResponseWriterSupportsResponseControllerHijack(t *testing.T) {
+	base := newHijackableResponseWriter()
+	t.Cleanup(base.close)
+	wrapped := &loggingResponseWriter{ResponseWriter: base, status: http.StatusOK}
+
+	conn, _, err := http.NewResponseController(wrapped).Hijack()
+	if err != nil {
+		t.Fatalf("expected logging response writer to delegate hijack: %v", err)
+	}
+	_ = conn.Close()
+	if !base.hijacked {
+		t.Fatal("expected underlying response writer to be hijacked")
+	}
+}
+
+func TestLoggingResponseWriterSupportsResponseControllerFlush(t *testing.T) {
+	base := newHijackableResponseWriter()
+	t.Cleanup(base.close)
+	wrapped := &loggingResponseWriter{ResponseWriter: base, status: http.StatusOK}
+
+	if err := http.NewResponseController(wrapped).Flush(); err != nil {
+		t.Fatalf("expected logging response writer to delegate flush: %v", err)
+	}
+	if !base.flushed {
+		t.Fatal("expected underlying response writer to be flushed")
 	}
 }
 
@@ -1998,6 +2028,48 @@ func waitForStops(t *testing.T, fake *fakeSandbox, want int) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("sandbox stops did not reach %d, got %d", want, fake.stoppedCount())
+}
+
+type hijackableResponseWriter struct {
+	header   http.Header
+	client   net.Conn
+	server   net.Conn
+	flushed  bool
+	hijacked bool
+}
+
+func newHijackableResponseWriter() *hijackableResponseWriter {
+	client, server := net.Pipe()
+	return &hijackableResponseWriter{
+		header: http.Header{},
+		client: client,
+		server: server,
+	}
+}
+
+func (w *hijackableResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *hijackableResponseWriter) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (w *hijackableResponseWriter) WriteHeader(statusCode int) {}
+
+func (w *hijackableResponseWriter) Flush() {
+	w.flushed = true
+}
+
+func (w *hijackableResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.hijacked = true
+	rw := bufio.NewReadWriter(bufio.NewReader(w.server), bufio.NewWriter(w.server))
+	return w.server, rw, nil
+}
+
+func (w *hijackableResponseWriter) close() {
+	_ = w.client.Close()
+	_ = w.server.Close()
 }
 
 func sign(secret string, body []byte) string {

--- a/internal/server/ui_assets_development.go
+++ b/internal/server/ui_assets_development.go
@@ -20,10 +20,11 @@ func (s *Server) serveUIAsset(w http.ResponseWriter, r *http.Request, _ string) 
 	}
 	proxy := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
-			req.Header.Add("X-Forwarded-Host", req.Host)
-			req.Header.Add("X-Origin-Host", origin.Host)
+			req.Header.Set("X-Forwarded-Host", req.Host)
+			req.Header.Set("X-Origin-Host", origin.Host)
 			req.URL.Scheme = origin.Scheme
 			req.URL.Host = origin.Host
+			req.Host = origin.Host
 		},
 	}
 	proxy.ServeHTTP(w, r)

--- a/internal/server/ui_assets_development.go
+++ b/internal/server/ui_assets_development.go
@@ -1,0 +1,43 @@
+//go:build development
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+)
+
+const uiAssetsDevelopment = true
+
+func (s *Server) serveUIAsset(w http.ResponseWriter, r *http.Request, _ string) bool {
+	origin, err := uiDevServerURL()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return true
+	}
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.Header.Add("X-Forwarded-Host", req.Host)
+			req.Header.Add("X-Origin-Host", origin.Host)
+			req.URL.Scheme = origin.Scheme
+			req.URL.Host = origin.Host
+		},
+	}
+	proxy.ServeHTTP(w, r)
+	return true
+}
+
+func uiDevServerURL() (*url.URL, error) {
+	raw := os.Getenv("RUNNERD_VITE_DEV_SERVER_URL")
+	if raw == "" {
+		port := os.Getenv("RUNNERD_VITE_PORT")
+		if port == "" {
+			port = "5173"
+		}
+		raw = fmt.Sprintf("http://127.0.0.1:%s", port)
+	}
+	return url.Parse(raw)
+}

--- a/internal/server/ui_assets_development_test.go
+++ b/internal/server/ui_assets_development_test.go
@@ -1,0 +1,34 @@
+//go:build development
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleAdminServesUIDevServerInDevelopment(t *testing.T) {
+	devServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/admin/" {
+			t.Fatalf("expected proxy to preserve admin path, got %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html>dev admin shell</html>"))
+	}))
+	t.Cleanup(devServer.Close)
+	t.Setenv("RUNNERD_VITE_DEV_SERVER_URL", devServer.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/", nil)
+	rec := httptest.NewRecorder()
+
+	(&Server{}).handleAdmin(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected development admin proxy to return 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "dev admin shell") {
+		t.Fatalf("expected Vite dev server response, got %q", rec.Body.String())
+	}
+}

--- a/internal/server/ui_assets_development_test.go
+++ b/internal/server/ui_assets_development_test.go
@@ -5,22 +5,38 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
 
 func TestHandleAdminServesUIDevServerInDevelopment(t *testing.T) {
+	var devServerHost string
 	devServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/admin/" {
 			t.Fatalf("expected proxy to preserve admin path, got %q", r.URL.Path)
+		}
+		if r.Host != devServerHost {
+			t.Fatalf("expected proxy to set request host to Vite host, got host=%q want %q", r.Host, devServerHost)
+		}
+		if r.Header.Get("X-Forwarded-Host") != "runnerd.test" {
+			t.Fatalf("expected original host to be forwarded, got %q", r.Header.Get("X-Forwarded-Host"))
+		}
+		if r.Header.Get("X-Origin-Host") != devServerHost {
+			t.Fatalf("expected Vite host to be recorded, got %q want %q", r.Header.Get("X-Origin-Host"), devServerHost)
 		}
 		w.Header().Set("Content-Type", "text/html")
 		_, _ = w.Write([]byte("<html>dev admin shell</html>"))
 	}))
 	t.Cleanup(devServer.Close)
+	devServerURL, err := url.Parse(devServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	devServerHost = devServerURL.Host
 	t.Setenv("RUNNERD_VITE_DEV_SERVER_URL", devServer.URL)
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/", nil)
+	req := httptest.NewRequest(http.MethodGet, "http://runnerd.test/admin/", nil)
 	rec := httptest.NewRecorder()
 
 	(&Server{}).handleAdmin(rec, req)

--- a/internal/server/ui_assets_production.go
+++ b/internal/server/ui_assets_production.go
@@ -1,0 +1,35 @@
+//go:build !development
+
+package server
+
+import (
+	"embed"
+	"mime"
+	"net/http"
+	"path"
+)
+
+const uiAssetsDevelopment = false
+
+//go:embed ui/*
+var uiAssets embed.FS
+
+func (s *Server) serveUIAsset(w http.ResponseWriter, _ *http.Request, name string) bool {
+	data, err := uiAssets.ReadFile("ui" + name)
+	if err != nil {
+		if path.Ext(name) != "" {
+			return false
+		}
+		data, err = uiAssets.ReadFile("ui/index.html")
+		if err != nil {
+			return false
+		}
+		name = "/index.html"
+	}
+	if contentType := mime.TypeByExtension(path.Ext(name)); contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write(data)
+	return true
+}

--- a/internal/server/ui_assets_production.go
+++ b/internal/server/ui_assets_production.go
@@ -29,7 +29,31 @@ func (s *Server) serveUIAsset(w http.ResponseWriter, _ *http.Request, name strin
 	if contentType := mime.TypeByExtension(path.Ext(name)); contentType != "" {
 		w.Header().Set("Content-Type", contentType)
 	}
+	if w.Header().Get("Content-Type") == "" {
+		if contentType := fallbackContentType(path.Ext(name)); contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+	}
 	w.Header().Set("Cache-Control", "no-store")
 	_, _ = w.Write(data)
 	return true
+}
+
+func fallbackContentType(ext string) string {
+	switch ext {
+	case ".html":
+		return "text/html; charset=utf-8"
+	case ".js", ".mjs":
+		return "text/javascript; charset=utf-8"
+	case ".css":
+		return "text/css; charset=utf-8"
+	case ".svg":
+		return "image/svg+xml"
+	case ".png":
+		return "image/png"
+	case ".json":
+		return "application/json"
+	default:
+		return ""
+	}
 }

--- a/internal/server/ui_assets_production_test.go
+++ b/internal/server/ui_assets_production_test.go
@@ -1,0 +1,25 @@
+//go:build !development
+
+package server
+
+import "testing"
+
+func TestFallbackContentTypeForWebAssets(t *testing.T) {
+	tests := map[string]string{
+		".html": "text/html; charset=utf-8",
+		".js":   "text/javascript; charset=utf-8",
+		".mjs":  "text/javascript; charset=utf-8",
+		".css":  "text/css; charset=utf-8",
+		".svg":  "image/svg+xml",
+		".png":  "image/png",
+		".json": "application/json",
+	}
+	for ext, want := range tests {
+		if got := fallbackContentType(ext); got != want {
+			t.Fatalf("fallbackContentType(%q) = %q, want %q", ext, got, want)
+		}
+	}
+	if got := fallbackContentType(".txt"); got != "" {
+		t.Fatalf("fallbackContentType for unknown extension = %q, want empty", got)
+	}
+}

--- a/scripts/smee.sh
+++ b/scripts/smee.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Start the smee client based on .smee-url.
+#
+# .smee-url is per-developer local state. When it is missing, this script exits
+# successfully so webhook forwarding stays opt-in for local development.
+set -euo pipefail
+
+URL_FILE=".smee-url"
+TARGET="${SMEE_TARGET:-http://127.0.0.1:25500/webhooks/github}"
+
+if [ ! -f "$URL_FILE" ]; then
+  cat <<'EOF'
+[smee] .smee-url not found; skipping webhook forwarder.
+
+To enable GitHub webhook forwarding:
+
+  1. Get a channel URL: open https://smee.io/new
+  2. Save it to .smee-url: echo 'https://smee.io/<your-channel>' > .smee-url
+  3. Configure the same URL as the GitHub webhook URL.
+  4. Run task smee.
+
+Set SMEE_TARGET if runnerd is not listening on http://127.0.0.1:25500.
+EOF
+  exit 0
+fi
+
+URL="$(head -n1 "$URL_FILE" | tr -d '[:space:]')"
+if [ -z "$URL" ]; then
+  echo "[smee] .smee-url is empty; refusing to start." >&2
+  exit 1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "[smee] npx is required to run smee-client. Install Node.js/npm first." >&2
+  exit 1
+fi
+
+echo "[smee] forwarding ${URL} -> ${TARGET}"
+exec npx --yes smee-client --url "$URL" --target "$TARGET"

--- a/scripts/smee.sh
+++ b/scripts/smee.sh
@@ -8,7 +8,16 @@ set -euo pipefail
 URL_FILE=".smee-url"
 TARGET="${SMEE_TARGET:-http://127.0.0.1:25500/webhooks/github}"
 
+CHECK_ONLY=0
+if [ "${1:-}" = "--check" ]; then
+  CHECK_ONLY=1
+fi
+
 if [ ! -f "$URL_FILE" ]; then
+  if [ "$CHECK_ONLY" = "1" ]; then
+    exit 0
+  fi
+
   cat <<'EOF'
 [smee] .smee-url not found; skipping webhook forwarder.
 
@@ -33,6 +42,11 @@ fi
 if ! command -v npx >/dev/null 2>&1; then
   echo "[smee] npx is required to run smee-client. Install Node.js/npm first." >&2
   exit 1
+fi
+
+if [ "$CHECK_ONLY" = "1" ]; then
+  npx --yes smee-client --help >/dev/null
+  exit 0
 fi
 
 echo "[smee] forwarding ${URL} -> ${TARGET}"

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   },
   build: {
     target: "esnext",
-    outDir: "../internal/server/admin",
+    outDir: "../internal/server/ui",
     emptyOutDir: true,
     modulePreload: false,
     rollupOptions: {


### PR DESCRIPTION
## Summary

- add development UI asset proxying to Vite while keeping production assets embedded from `internal/server/ui`
- add `task dev` for Vite + runnerd hot reload, including websocket proxy support and fail-fast Vite startup checks
- add smee webhook forwarding via `task smee` and automatic `task dev` startup when `.smee-url` exists
- refresh development/testing docs plus project agent and TODO guidance

## Validation

- `task lint`
- `task test`
- `task build`
- verified `task dev` with temporary ports, smee forwarding, and `/healthz`
- verified `task dev` fails fast when the Vite port is already in use
