### PR TITLE
Implement GitHub App setup and user dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ templates/*/node_modules/
 *.local.yaml
 secrets/
 .smee-url
+tmp/

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ Relative sqlite `database.dsn` and `github.app.private_key_file` paths are resol
 Use sqlite for local and small single-node deployments. Postgres and MySQL are supported by the state store, but shared-database multi-instance operation should be verified in your deployment before advertising it as supported.
 GitHub Enterprise Server is not currently supported; configure a GitHub.com App installation.
 Configure exactly one GitHub auth method: `github.app`, `github.token`, or `github.basic_auth`. For GitHub App auth, `github.app.installation_id` is optional. When it is omitted, runnerd resolves the installation from each job repository and caches installation transports, allowing one GitHub App to serve multiple installed accounts.
+Set `github.app.slug` to the GitHub App URL slug when you want the ordinary-user UI to show an Install GitHub App link.
 `github.allowed_repositories` is an optional allowlist of `owner/repo` or `owner/*` patterns. Empty means all repositories that can deliver valid webhooks and match runner labels/policies are allowed.
 
-`github.oauth` enables GitHub App OAuth login for the embedded admin console. Use the GitHub App's Client ID and Client secret, set a separate `auth.session_secret`, and configure the app callback URL as `/auth/github/callback` on your runnerd origin. Local accounts carry roles, while OAuth identities are matched by provider and stable subject; for GitHub this is the numeric user ID, while login is stored as display metadata. The first OAuth callback creates an account with `role: user` and links the GitHub identity when none exists, and only accounts with `role: admin` can access the admin console and management API. Bootstrap the first admin with `runnerd --bootstrap-admin github:<github-user-id>`. OAuth sessions are stored as signed HttpOnly cookies.
+`github.oauth` enables GitHub App OAuth login for the embedded console. Use the GitHub App's Client ID and Client secret, set a separate `auth.session_secret`, and configure the app callback URL as `/auth/github/callback` on your runnerd origin. Local accounts carry roles, while OAuth identities are matched by provider and stable subject; for GitHub this is the numeric user ID, while login is stored as display metadata. The first OAuth callback creates an account with `role: user` and links the GitHub identity when none exists. Ordinary users install the configured GitHub App; runnerd records the returned installation id and uses workflow job installation ids to decide which jobs the user can see. It does not copy the full GitHub App repository authorization scope into state. Only accounts with `role: admin` can access management APIs. Bootstrap the first admin with `runnerd --bootstrap-admin github:<github-user-id>`. OAuth sessions are stored as signed HttpOnly cookies.
 
 `/webhooks/github` uses GitHub HMAC signature verification. The manual management API under `/runner_requests` requires a valid GitHub OAuth admin session cookie.
 
@@ -56,7 +57,7 @@ cp runnerd.yaml.example runnerd.local.yaml
 task dev
 ```
 
-`task dev` starts the Vite UI dev server on the first available localhost port at or after `5173`, starts the smee webhook forwarder when `.smee-url` exists, and runs `runnerd` with the `development` build tag. The Go server still listens on the address from `runnerd.local.yaml`, commonly `:25500`, and proxies embedded UI assets to Vite. Open `http://127.0.0.1:25500/admin/` while developing.
+`task dev` starts the Vite UI dev server on the first available localhost port at or after `5173`, starts the smee webhook forwarder when `.smee-url` exists, and runs `runnerd` with the `development` build tag. The Go server still listens on the address from `runnerd.local.yaml`, commonly `:25500`, and proxies embedded UI assets to Vite. Open `http://127.0.0.1:25500/` for the ordinary-user PR/job view, `http://127.0.0.1:25500/repositories` for ordinary-user activity repositories, `http://127.0.0.1:25500/accounts` for GitHub App accounts and authorized repositories, or `http://127.0.0.1:25500/admin/` for the admin console while developing.
 
 Set `RUNNERD_CONFIG` to use another config file, or `RUNNERD_VITE_PORT` to require a specific Vite port.
 
@@ -79,7 +80,7 @@ docker run --rm -p 25500:25500 \
   ghcr.io/qiniu/ci-runner
 ```
 
-Open the embedded admin console at `http://127.0.0.1:25500/admin/`. The UI is built from `ui/` with the same React, Vite, Tailwind CSS, shadcn-style components, and theme tokens used by `kubevirt-console`. The console offers GitHub sign-in and uses a signed HttpOnly cookie for management API calls.
+Open the ordinary-user console at `http://127.0.0.1:25500/` or the admin console at `http://127.0.0.1:25500/admin/`. The UI is built from `ui/` with the same React, Vite, Tailwind CSS, shadcn-style components, and theme tokens used by `kubevirt-console`. The console offers GitHub sign-in and uses a signed HttpOnly cookie for API calls. Ordinary users see a two-column repository/PR job view at `/`, local activity repositories at `/repositories`, and GitHub App accounts plus on-demand authorized repositories at `/accounts`. Admin users see the management console.
 
 The admin console manages runner requests, runner specs, runner groups, runner policies, retry actions, audit history, runner-spec match tests, and diagnostics. Runner specs, groups, and repository policies are created through the admin API/UI rather than `runnerd.yaml`. runnerd creates repository runners by default; when a matched runner spec has a GitHub runner group, it creates an organization runner for the job repository owner and passes that group as `--runnergroup`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ This file tracks active project work. Completed behavior should move into `READM
 ## Active Roadmap
 
 - Decide whether GitHub token and basic auth remain supported compatibility modes or should be removed in favor of GitHub App-only operation.
-- Define the ordinary-user UI surface before adding non-admin screens under `ui/`; include routes, navigation visibility, and API permissions.
+- Decide whether ordinary-user Activity repositories should include repository-policy configuration rows in addition to repositories observed from runner jobs.
 - Add an effective-config diagnostics view or config validation workflow if operators need to inspect runtime config from the UI.
 - Verify DB lease behavior with two runnerd processes sharing the same database before documenting multi-instance support.
 - Decide whether expvar diagnostics need a Prometheus/export adapter or histogram-style latency views for deployment observability.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,6 +80,7 @@ GitHub App 需要能调用 runner registration token API。Repository runner 需
 2. 基础信息：
    - GitHub App name：例如 `runnerd-local`
    - Homepage URL：先填仓库地址或本地项目文档地址
+   - Setup URL：填 runnerd 的 `/github-app/setup` 地址，例如 `http://127.0.0.1:25500/github-app/setup`
    - Webhook：如果 runnerd 自己收 webhook，可以先不开 App webhook，这里和 `workflow_job` webhook 不是一回事
 3. Repository permissions：
    - `Administration` 设为 `Read and write`
@@ -94,6 +95,7 @@ GitHub App 需要能调用 runner registration token API。Repository runner 需
    - 选择要授权的仓库
 8. 记录这些值：
    - App ID
+   - App slug（App URL 里的短名称，例如 `https://github.com/apps/<slug>`）
    - Installation ID（可选；不配置时 runnerd 会按仓库动态解析）
    - private key 文件路径
 
@@ -103,6 +105,7 @@ GitHub App 需要能调用 runner registration token API。Repository runner 需
 github:
   app:
     id: <app id>
+    slug: <app slug>
     # installation_id: <installation id>
     private_key_file: ./secrets/github-app.pem
 ```
@@ -138,7 +141,27 @@ cp runnerd.yaml.example runnerd.local.yaml
 task dev
 ```
 
-`task dev` 默认读取 `runnerd.local.yaml`，从 `127.0.0.1:5173` 开始选择第一个可用端口启动 Vite dev server，并用 `development` build tag 启动 Go 服务。浏览器仍然访问 runnerd 的地址，例如：
+`task dev` 默认读取 `runnerd.local.yaml`，从 `127.0.0.1:5173` 开始选择第一个可用端口启动 Vite dev server，并用 `development` build tag 启动 Go 服务。浏览器仍然访问 runnerd 的地址。
+
+普通用户界面：
+
+```text
+http://127.0.0.1:25500/
+```
+
+普通用户 Activity repositories 页面：
+
+```text
+http://127.0.0.1:25500/repositories
+```
+
+普通用户 Accounts 页面：
+
+```text
+http://127.0.0.1:25500/accounts
+```
+
+管理员界面：
 
 ```text
 http://127.0.0.1:25500/admin/
@@ -168,10 +191,10 @@ go run ./cmd/runnerd --config ./runnerd.yaml
 curl -fsS http://127.0.0.1:25500/healthz
 ```
 
-后台管理页面：
+普通用户页面：
 
 ```text
-http://127.0.0.1:25500/admin/
+http://127.0.0.1:25500/
 ```
 
 页面会跳转到 GitHub OAuth 登录。首次登录会在数据库中创建 `role=user` 的本地 account，并把 GitHub OAuth identity 绑定到该 account；首个管理员需要在启动时显式 bootstrap：
@@ -180,13 +203,13 @@ http://127.0.0.1:25500/admin/
 go run ./cmd/runnerd --config ./runnerd.yaml --bootstrap-admin github:<your-github-user-id>
 ```
 
-`<your-github-user-id>` 是 GitHub `/user` 返回的稳定 numeric `id`，不是可修改的 login。role 属于本地 account，OAuth identity 只保存 provider、stable subject 和 login 展示信息，因此后续可以把其他 provider identity 绑定到同一个 account。管理员登录后，浏览器会保存 signed HttpOnly session cookie，并自动带上该 cookie 访问 `/runner_requests` 等管理接口。需要用 `curl` 调管理 API 时，可以从浏览器或 OAuth 调试流程导出 cookie 到 `COOKIE_JAR`，后续示例统一使用：
+`<your-github-user-id>` 是 GitHub `/user` 返回的稳定 numeric `id`，不是可修改的 login。role 属于本地 account，OAuth identity 只保存 provider、stable subject 和 login 展示信息，因此后续可以把其他 provider identity 绑定到同一个 account。普通用户登录后可以在 `/accounts` 安装配置文件中定义的 GitHub App；GitHub 带 `installation_id` 回调后，runnerd 会记录该 account 绑定的 GitHub App installation。普通用户能看到的 job 按 workflow job payload 里的 installation id 过滤，runnerd 不会把该 installation 授权的全部仓库列表复制到本地状态中；Accounts 页面点击安装账户时，会按需通过 GitHub App API 获取该账户当前授权的 repositories。管理员登录后，浏览器会保存 signed HttpOnly session cookie，并自动带上该 cookie 访问 `/runner_requests` 等管理接口。需要用 `curl` 调管理 API 时，可以从浏览器或 OAuth 调试流程导出 cookie 到 `COOKIE_JAR`，后续示例统一使用：
 
 ```bash
 export COOKIE_JAR=./runnerd.cookies
 ```
 
-后台页面源码在 `ui/`，使用和 `kubevirt-console` 相同的 React、Vite、Tailwind CSS、shadcn 风格组件和主题 CSS。`task build` 会先执行 `task ui-build`，把前端产物写入 `internal/server/ui/` 后再编译 `runnerd`。开发模式下 `internal/server/ui_assets_development.go` 会把 UI 资源代理到 Vite；生产构建下 `internal/server/ui_assets_production.go` 会嵌入 `internal/server/ui/*`。管理面现在包含 runners、runner specs、runner groups、runner policies、retry、audit、label match test 和 diagnostics 页面。
+页面源码在 `ui/`，使用和 `kubevirt-console` 相同的 React、Vite、Tailwind CSS、shadcn 风格组件和主题 CSS。`task build` 会先执行 `task ui-build`，把前端产物写入 `internal/server/ui/` 后再编译 `runnerd`。开发模式下 `internal/server/ui_assets_development.go` 会把 UI 资源代理到 Vite；生产构建下 `internal/server/ui_assets_production.go` 会嵌入 `internal/server/ui/*`。普通用户界面包含 `/accounts` 的 GitHub App accounts 和按需加载的授权 repositories、`/repositories` 的本地 activity repositories，以及 `/` 的 Repo/PR 列表和 PR job 明细；管理面包含 runners、runner specs、runner groups、runner policies、retry、audit、label match test 和 diagnostics 页面。
 
 先创建一个默认 runner spec：
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	E2BAPIURL                 string
 	GitHubAppID               int64
 	GitHubAppInstallationID   int64
+	GitHubAppSlug             string
 	GitHubAppPrivateKeyFile   string
 	GitHubToken               string
 	GitHubBasicAuthUsername   string
@@ -86,6 +87,7 @@ type fileConfig struct {
 		App struct {
 			ID             int64  `yaml:"id"`
 			InstallationID int64  `yaml:"installation_id"`
+			Slug           string `yaml:"slug"`
 			PrivateKeyFile string `yaml:"private_key_file"`
 		} `yaml:"app"`
 		OAuth struct {
@@ -139,6 +141,7 @@ func LoadFile(path string) (Config, error) {
 		E2BAPIURL:                 raw.E2B.APIURL,
 		GitHubAppID:               raw.GitHub.App.ID,
 		GitHubAppInstallationID:   raw.GitHub.App.InstallationID,
+		GitHubAppSlug:             strings.TrimSpace(raw.GitHub.App.Slug),
 		GitHubAppPrivateKeyFile:   resolveConfigPath(configDir, raw.GitHub.App.PrivateKeyFile),
 		GitHubToken:               raw.GitHub.Token,
 		GitHubBasicAuthUsername:   raw.GitHub.BasicAuth.Username,

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -59,9 +59,11 @@ type Runner struct {
 }
 
 type Installation struct {
-	ID           int64    `json:"id"`
-	AccountLogin string   `json:"account_login,omitempty"`
-	Repositories []string `json:"repositories"`
+	ID            int64    `json:"id"`
+	AccountLogin  string   `json:"account_login,omitempty"`
+	AccountName   string   `json:"account_name,omitempty"`
+	AccountAvatar string   `json:"account_avatar,omitempty"`
+	Repositories  []string `json:"repositories"`
 }
 
 type runnerTarget struct {
@@ -96,7 +98,9 @@ func (c *Client) GetInstallation(ctx context.Context, installationID int64) (Ins
 	var out struct {
 		ID      int64 `json:"id"`
 		Account struct {
-			Login string `json:"login"`
+			Login     string `json:"login"`
+			Name      string `json:"name"`
+			AvatarURL string `json:"avatar_url"`
 		} `json:"account"`
 	}
 	if err := json.Unmarshal(body, &out); err != nil {
@@ -105,7 +109,12 @@ func (c *Client) GetInstallation(ctx context.Context, installationID int64) (Ins
 	if out.ID == 0 {
 		return Installation{}, fmt.Errorf("github installation response missing id")
 	}
-	return Installation{ID: out.ID, AccountLogin: out.Account.Login}, nil
+	return Installation{
+		ID:            out.ID,
+		AccountLogin:  out.Account.Login,
+		AccountName:   out.Account.Name,
+		AccountAvatar: out.Account.AvatarURL,
+	}, nil
 }
 
 func (c *Client) ListInstallationRepositories(ctx context.Context, installationID int64) ([]string, error) {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -58,11 +58,100 @@ type Runner struct {
 	Busy   bool   `json:"busy"`
 }
 
+type Installation struct {
+	ID           int64    `json:"id"`
+	AccountLogin string   `json:"account_login,omitempty"`
+	Repositories []string `json:"repositories"`
+}
+
 type runnerTarget struct {
 	repositoryFullName string
 	apiPath            string
 	webURL             string
 	cacheKey           string
+}
+
+func (c *Client) GetInstallation(ctx context.Context, installationID int64) (Installation, error) {
+	if c.appAuth == nil {
+		return Installation{}, fmt.Errorf("github app auth is required")
+	}
+	if installationID <= 0 {
+		return Installation{}, fmt.Errorf("installation id is required")
+	}
+	url := fmt.Sprintf("%s/app/installations/%d", c.baseURL, installationID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return Installation{}, err
+	}
+	setGitHubHeaders(req)
+	resp, err := c.appAuth.appHTTP.Do(req)
+	if err != nil {
+		return Installation{}, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Installation{}, fmt.Errorf("github installation: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out struct {
+		ID      int64 `json:"id"`
+		Account struct {
+			Login string `json:"login"`
+		} `json:"account"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return Installation{}, err
+	}
+	if out.ID == 0 {
+		return Installation{}, fmt.Errorf("github installation response missing id")
+	}
+	return Installation{ID: out.ID, AccountLogin: out.Account.Login}, nil
+}
+
+func (c *Client) ListInstallationRepositories(ctx context.Context, installationID int64) ([]string, error) {
+	if c.appAuth == nil {
+		return nil, fmt.Errorf("github app auth is required")
+	}
+	if installationID <= 0 {
+		return nil, fmt.Errorf("installation id is required")
+	}
+	client, err := c.appAuth.clientForInstallation(ctx, installationID)
+	if err != nil {
+		return nil, err
+	}
+	nextURL := fmt.Sprintf("%s/installation/repositories?per_page=100", c.baseURL)
+	var repositories []string
+	for nextURL != "" {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		setGitHubHeaders(req)
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		_ = resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("github installation repositories: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		var out struct {
+			Repositories []struct {
+				FullName string `json:"full_name"`
+			} `json:"repositories"`
+		}
+		if err := json.Unmarshal(body, &out); err != nil {
+			return nil, err
+		}
+		for _, repo := range out.Repositories {
+			if fullName := strings.TrimSpace(repo.FullName); fullName != "" {
+				repositories = append(repositories, fullName)
+			}
+		}
+		nextURL = nextLink(resp.Header.Get("Link"))
+	}
+	return repositories, nil
 }
 
 func NewClient(baseURL string, httpClient *http.Client) *Client {
@@ -349,6 +438,13 @@ func (a *appAuthenticator) clientForRepository(ctx context.Context, repositoryFu
 	if err != nil {
 		return nil, err
 	}
+	return a.clientForInstallation(ctx, installationID)
+}
+
+func (a *appAuthenticator) clientForInstallation(_ context.Context, installationID int64) (*http.Client, error) {
+	if installationID <= 0 {
+		return nil, fmt.Errorf("installation id is required")
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	transport, ok := a.transports[installationID]
@@ -558,16 +654,18 @@ func VerifyWebhookSignature(secret string, body []byte, signature string) bool {
 }
 
 type WorkflowJobEvent struct {
-	Action      string      `json:"action"`
-	WorkflowJob WorkflowJob `json:"workflow_job"`
-	Repository  Repository  `json:"repository"`
-	WorkflowRun WorkflowRun `json:"workflow_run"`
+	Action       string          `json:"action"`
+	WorkflowJob  WorkflowJob     `json:"workflow_job"`
+	Repository   Repository      `json:"repository"`
+	WorkflowRun  WorkflowRun     `json:"workflow_run"`
+	Installation InstallationRef `json:"installation"`
 }
 
 type WorkflowRunEvent struct {
-	Action      string      `json:"action"`
-	WorkflowRun WorkflowRun `json:"workflow_run"`
-	Repository  Repository  `json:"repository"`
+	Action       string          `json:"action"`
+	WorkflowRun  WorkflowRun     `json:"workflow_run"`
+	Repository   Repository      `json:"repository"`
+	Installation InstallationRef `json:"installation"`
 }
 
 type WorkflowJob struct {
@@ -590,6 +688,10 @@ type WorkflowRun struct {
 	ID         int64  `json:"id"`
 	Name       string `json:"name"`
 	HeadBranch string `json:"head_branch"`
+}
+
+type InstallationRef struct {
+	ID int64 `json:"id"`
 }
 
 type Labels []string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -191,13 +191,22 @@ func (s *Server) Recover(ctx context.Context) error {
 }
 
 func (s *Server) routes() {
+	s.mux.HandleFunc("GET /", s.handleRoot)
 	s.mux.HandleFunc("GET /admin", s.handleAdminRedirect)
 	s.mux.HandleFunc("GET /admin/", s.handleAdmin)
+	s.mux.HandleFunc("GET /user", s.handleUserRedirect)
+	s.mux.HandleFunc("GET /user/", s.handleUserRedirect)
 	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
 	s.mux.HandleFunc("GET /auth/session", s.handleAuthSession)
 	s.mux.HandleFunc("GET /auth/github/login", s.handleGitHubOAuthLogin)
 	s.mux.HandleFunc("GET /auth/github/callback", s.handleGitHubOAuthCallback)
 	s.mux.HandleFunc("POST /auth/logout", s.handleAuthLogout)
+	s.mux.HandleFunc("GET /github-app/setup", s.handleGitHubAppSetupRedirect)
+	s.mux.HandleFunc("GET /user/github-app", s.handleUserGitHubApp)
+	s.mux.HandleFunc("POST /user/github-app/installations", s.handleUserSaveGitHubInstallation)
+	s.mux.HandleFunc("GET /user/github-app/installations/{id}/repositories", s.handleUserListGitHubInstallationRepositories)
+	s.mux.HandleFunc("DELETE /user/github-app/installations/{id}", s.handleUserDeleteGitHubInstallation)
+	s.mux.HandleFunc("GET /user/runner_requests", s.handleUserListRunners)
 	s.mux.HandleFunc("POST /webhooks/github", s.handleGitHubWebhook)
 	s.mux.HandleFunc("POST /runner_requests", s.handleCreateRunner)
 	s.mux.HandleFunc("GET /runner_requests", s.handleListRunners)
@@ -231,6 +240,22 @@ func (s *Server) handleAdminRedirect(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleAdmin(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimPrefix(r.URL.Path, "/admin/")
+	s.handleUI(w, r, name)
+}
+
+func (s *Server) handleUserRedirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/", http.StatusMovedPermanently)
+}
+
+func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimPrefix(r.URL.Path, "/")
+	if name == "accounts" || name == "repositories" {
+		name = "index.html"
+	}
+	s.handleUI(w, r, name)
+}
+
+func (s *Server) handleUI(w http.ResponseWriter, r *http.Request, name string) {
 	if name == "" {
 		name = "index.html"
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -91,6 +91,7 @@ const (
 	defaultRunnerRequestListLimit = 100
 	maxRunnerRequestListLimit     = 500
 	oauthStateCookieName          = "runnerd_oauth_state"
+	githubAppSetupStateCookieName = "runnerd_github_app_setup_state"
 	adminSessionCookieName        = "runnerd_admin_session"
 )
 
@@ -201,6 +202,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /auth/github/login", s.handleGitHubOAuthLogin)
 	s.mux.HandleFunc("GET /auth/github/callback", s.handleGitHubOAuthCallback)
 	s.mux.HandleFunc("POST /auth/logout", s.handleAuthLogout)
+	s.mux.HandleFunc("GET /github-app/install", s.handleGitHubAppInstallRedirect)
 	s.mux.HandleFunc("GET /github-app/setup", s.handleGitHubAppSetupRedirect)
 	s.mux.HandleFunc("GET /user/github-app", s.handleUserGitHubApp)
 	s.mux.HandleFunc("POST /user/github-app/installations", s.handleUserSaveGitHubInstallation)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -249,7 +249,8 @@ func (s *Server) handleUserRedirect(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimPrefix(r.URL.Path, "/")
-	if name == "accounts" || name == "repositories" {
+	if name == "accounts" || name == "repositories" || name == "settings" ||
+		strings.HasPrefix(name, "account/") || strings.HasPrefix(name, "organizations/") {
 		name = "index.html"
 	}
 	s.handleUI(w, r, name)

--- a/internal/server/server_auth.go
+++ b/internal/server/server_auth.go
@@ -61,6 +61,10 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 		http.NotFound(w, r)
 		return
 	}
+	if s.isGitHubAppSetupCallback(r) {
+		s.handleGitHubAppSetupRedirect(w, r)
+		return
+	}
 	if problem := strings.TrimSpace(r.URL.Query().Get("error")); problem != "" {
 		writeError(w, http.StatusUnauthorized, "github oauth rejected: "+problem)
 		return
@@ -119,7 +123,11 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 		Secure:   requestIsSecure(r),
 		MaxAge:   int(s.cfg.AuthSessionTTL.Seconds()),
 	})
-	http.Redirect(w, r, "/admin/", http.StatusFound)
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+func (s *Server) isGitHubAppSetupCallback(r *http.Request) bool {
+	return strings.TrimSpace(r.URL.Query().Get("installation_id")) != ""
 }
 
 func (s *Server) handleAuthLogout(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_auth_helpers.go
+++ b/internal/server/server_auth_helpers.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/qiniu/ci-runner/internal/state"
 )
 
 func (s *Server) requireAdminAuth(w http.ResponseWriter, r *http.Request) bool {
@@ -22,6 +24,26 @@ func (s *Server) requireAdminAuth(w http.ResponseWriter, r *http.Request) bool {
 	s.logger.Warn("admin auth rejected", "method", r.Method, "path", r.URL.Path, "remote_addr", r.RemoteAddr, "has_authorization", r.Header.Get("Authorization") != "")
 	writeError(w, http.StatusUnauthorized, "missing or invalid github oauth session")
 	return false
+}
+
+func (s *Server) requireUserSession(w http.ResponseWriter, r *http.Request) (adminSession, state.Account, bool) {
+	session, ok := s.sessionFromRequest(r)
+	if !ok {
+		s.logger.Warn("user auth rejected", "method", r.Method, "path", r.URL.Path, "remote_addr", r.RemoteAddr)
+		writeError(w, http.StatusUnauthorized, "missing or invalid github oauth session")
+		return adminSession{}, state.Account{}, false
+	}
+	provider := strings.TrimSpace(session.Provider)
+	if provider == "" {
+		provider = "github"
+	}
+	account, _, err := s.store.GetAccountByOAuthIdentity(provider, session.Subject)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "missing or invalid github oauth session")
+		return adminSession{}, state.Account{}, false
+	}
+	session.Role = account.Role
+	return session, account, true
 }
 
 func (s *Server) adminSessionFromRequest(r *http.Request) (adminSession, bool) {

--- a/internal/server/server_helpers_test.go
+++ b/internal/server/server_helpers_test.go
@@ -500,6 +500,22 @@ func TestAdminRedirectReturns301(t *testing.T) {
 	}
 }
 
+func TestUserRedirectReturns301(t *testing.T) {
+	store := state.New(t.TempDir())
+	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+
+	req := httptest.NewRequest(http.MethodGet, "/user", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMovedPermanently {
+		t.Fatalf("GET /user: expected 301, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/" {
+		t.Errorf("GET /user: Location = %q, want /", loc)
+	}
+}
+
 // ---------- handleGetRunner ----------
 
 func TestGetRunnerReturnsStateAfterCreate(t *testing.T) {

--- a/internal/server/server_runner_lifecycle.go
+++ b/internal/server/server_runner_lifecycle.go
@@ -35,16 +35,17 @@ func (s *Server) createAndStart(w http.ResponseWriter, r *http.Request, req stat
 	writeJSON(w, http.StatusOK, st)
 }
 
-func (s *Server) enqueueWorkflowJob(repositoryFullName, workflowRunName string, job github.WorkflowJob, payload []byte) (state.RunnerState, bool, error) {
+func (s *Server) enqueueWorkflowJob(repositoryFullName string, githubInstallationID int64, workflowRunName string, job github.WorkflowJob, payload []byte) (state.RunnerState, bool, error) {
 	id := strconv.FormatInt(job.ID, 10)
 	req := state.RunnerRequest{
-		ID:                 id,
-		Source:             "github_webhook",
-		JobID:              job.ID,
-		RepositoryFullName: repositoryFullName,
-		RequestedLabels:    append([]string(nil), job.Labels...),
-		Labels:             []string(job.Labels),
-		RunnerName:         "e2b-" + id,
+		ID:                   id,
+		Source:               "github_webhook",
+		JobID:                job.ID,
+		GitHubInstallationID: githubInstallationID,
+		RepositoryFullName:   repositoryFullName,
+		RequestedLabels:      append([]string(nil), job.Labels...),
+		Labels:               []string(job.Labels),
+		RunnerName:           "e2b-" + id,
 	}
 	if !s.cfg.RepositoryAllowed(repositoryFullName) {
 		s.logger.Info("runner repository rejected by allowlist", "id", req.ID, "repository", repositoryFullName, "labels", []string(job.Labels))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -268,7 +268,7 @@ func TestUserGitHubAppConfigurationAndRunnerList(t *testing.T) {
 			if r.Header.Get("Authorization") == "" {
 				t.Fatal("expected app JWT authorization for installation lookup")
 			}
-			w.Write([]byte(`{"id":987,"account":{"login":"o"}}`))
+			w.Write([]byte(`{"id":987,"account":{"login":"o","name":"Octo Org","avatar_url":"https://avatars.example/o.png"}}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/987/access_tokens":
 			if r.Header.Get("Authorization") == "" {
 				t.Fatal("expected app JWT authorization for installation token")
@@ -341,7 +341,7 @@ func TestUserGitHubAppConfigurationAndRunnerList(t *testing.T) {
 	if rec.Code != http.StatusFound {
 		t.Fatalf("unexpected setup status: %d body=%s", rec.Code, rec.Body.String())
 	}
-	if rec.Header().Get("Location") != "/accounts?installation_id=987&setup_action=install" {
+	if rec.Header().Get("Location") != "/account/repositories?installation_id=987&setup_action=install" {
 		t.Fatalf("unexpected setup redirect: %q", rec.Header().Get("Location"))
 	}
 	req = httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=oauth-code&installation_id=987&setup_action=install", nil)
@@ -351,7 +351,7 @@ func TestUserGitHubAppConfigurationAndRunnerList(t *testing.T) {
 	if rec.Code != http.StatusFound {
 		t.Fatalf("unexpected callback setup status: %d body=%s", rec.Code, rec.Body.String())
 	}
-	if rec.Header().Get("Location") != "/accounts?installation_id=987&setup_action=install" {
+	if rec.Header().Get("Location") != "/account/repositories?installation_id=987&setup_action=install" {
 		t.Fatalf("unexpected callback setup redirect: %q", rec.Header().Get("Location"))
 	}
 	req = httptest.NewRequest(http.MethodGet, "/auth/github/callback?installation_id=987&setup_action=install&state=github-app-state", nil)
@@ -361,7 +361,7 @@ func TestUserGitHubAppConfigurationAndRunnerList(t *testing.T) {
 	if rec.Code != http.StatusFound {
 		t.Fatalf("unexpected callback setup status with state: %d body=%s", rec.Code, rec.Body.String())
 	}
-	if rec.Header().Get("Location") != "/accounts?installation_id=987&setup_action=install" {
+	if rec.Header().Get("Location") != "/account/repositories?installation_id=987&setup_action=install" {
 		t.Fatalf("unexpected callback setup redirect with state: %q", rec.Header().Get("Location"))
 	}
 	req = httptest.NewRequest(http.MethodGet, "/auth/github/callback?installation_id=987&state=github-app-state", nil)
@@ -371,7 +371,7 @@ func TestUserGitHubAppConfigurationAndRunnerList(t *testing.T) {
 	if rec.Code != http.StatusFound {
 		t.Fatalf("unexpected callback setup status without setup_action: %d body=%s", rec.Code, rec.Body.String())
 	}
-	if rec.Header().Get("Location") != "/accounts?installation_id=987" {
+	if rec.Header().Get("Location") != "/account/repositories?installation_id=987" {
 		t.Fatalf("unexpected callback setup redirect without setup_action: %q", rec.Header().Get("Location"))
 	}
 	account, _, err := store.GetAccountByOAuthIdentity("github", "hubot-id")
@@ -384,6 +384,9 @@ func TestUserGitHubAppConfigurationAndRunnerList(t *testing.T) {
 	}
 	if len(installations) != 1 {
 		t.Fatalf("expected one installation, got %#v", installations)
+	}
+	if installations[0].AccountName != "Octo Org" || installations[0].AccountAvatar != "https://avatars.example/o.png" {
+		t.Fatalf("unexpected installation account metadata: %#v", installations[0])
 	}
 	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/user/github-app/installations/%d/repositories", installations[0].ID), nil)
 	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
@@ -750,7 +753,7 @@ func TestAdminUIIsServedWithoutAPIAccess(t *testing.T) {
 		t.Fatalf("root user ui did not serve vite shell")
 	}
 
-	for _, path := range []string{"/repositories", "/accounts"} {
+	for _, path := range []string{"/repositories", "/account/repositories", "/account/preferences", "/organizations/qiniu/repositories", "/organizations/qiniu/preferences", "/settings", "/accounts"} {
 		req = httptest.NewRequest(http.MethodGet, path, nil)
 		rec = httptest.NewRecorder()
 		srv.ServeHTTP(rec, req)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,15 +5,22 @@ import (
 	"bytes"
 	"context"
 	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -253,6 +260,163 @@ func TestManagementEndpointsRequireAdminAuth(t *testing.T) {
 	}
 }
 
+func TestUserGitHubAppConfigurationAndRunnerList(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/app/installations/987":
+			if r.Header.Get("Authorization") == "" {
+				t.Fatal("expected app JWT authorization for installation lookup")
+			}
+			w.Write([]byte(`{"id":987,"account":{"login":"o"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/app/installations/987/access_tokens":
+			if r.Header.Get("Authorization") == "" {
+				t.Fatal("expected app JWT authorization for installation token")
+			}
+			w.Write([]byte(`{"token":"installation-token","expires_at":"2099-01-01T00:00:00Z"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/installation/repositories":
+			if r.Header.Get("Authorization") != "token installation-token" {
+				t.Fatalf("expected installation token authorization, got %q", r.Header.Get("Authorization"))
+			}
+			w.Write([]byte(`{"repositories":[{"full_name":"o/r"},{"full_name":"o/another"}]}`))
+		default:
+			t.Fatalf("unexpected github app request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	srv := newTestServer(t, store, ghServer.URL, &fakeSandbox{})
+	srv.cfg.GitHubAppSlug = "runnerd-test"
+	appClient, err := github.NewAppClient(ghServer.URL, github.AppAuth{
+		AppID:          123,
+		PrivateKeyFile: testServerPrivateKeyFile(t),
+	}, ghServer.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.gh = appClient
+	if _, _, err := store.CreateRequest(state.RunnerRequest{
+		ID:                   "visible",
+		Source:               "test",
+		GitHubInstallationID: 987,
+		RepositoryFullName:   "o/r",
+		Labels:               []string{"self-hosted"},
+		RunnerName:           "e2b-visible",
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.CreateRequest(state.RunnerRequest{
+		ID:                   "hidden",
+		Source:               "test",
+		GitHubInstallationID: 456,
+		RepositoryFullName:   "other/r",
+		Labels:               []string{"self-hosted"},
+		RunnerName:           "e2b-hidden",
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/user/github-app", nil)
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected app status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var appConfig struct {
+		InstallURL string `json:"install_url"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &appConfig); err != nil {
+		t.Fatal(err)
+	}
+	if appConfig.InstallURL != "https://github.com/apps/runnerd-test/installations/new" {
+		t.Fatalf("unexpected install url: %q", appConfig.InstallURL)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/github-app/setup?installation_id=987&setup_action=install", nil)
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("unexpected setup status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Location") != "/accounts?installation_id=987&setup_action=install" {
+		t.Fatalf("unexpected setup redirect: %q", rec.Header().Get("Location"))
+	}
+	req = httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=oauth-code&installation_id=987&setup_action=install", nil)
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("unexpected callback setup status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Location") != "/accounts?installation_id=987&setup_action=install" {
+		t.Fatalf("unexpected callback setup redirect: %q", rec.Header().Get("Location"))
+	}
+	req = httptest.NewRequest(http.MethodGet, "/auth/github/callback?installation_id=987&setup_action=install&state=github-app-state", nil)
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("unexpected callback setup status with state: %d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Location") != "/accounts?installation_id=987&setup_action=install" {
+		t.Fatalf("unexpected callback setup redirect with state: %q", rec.Header().Get("Location"))
+	}
+	req = httptest.NewRequest(http.MethodGet, "/auth/github/callback?installation_id=987&state=github-app-state", nil)
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("unexpected callback setup status without setup_action: %d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Location") != "/accounts?installation_id=987" {
+		t.Fatalf("unexpected callback setup redirect without setup_action: %q", rec.Header().Get("Location"))
+	}
+	account, _, err := store.GetAccountByOAuthIdentity("github", "hubot-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	installations, err := store.ListGitHubInstallations(account.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installations) != 1 {
+		t.Fatalf("expected one installation, got %#v", installations)
+	}
+	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/user/github-app/installations/%d/repositories", installations[0].ID), nil)
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected installation repositories status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var installationRepositories struct {
+		Repositories []string `json:"repositories"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &installationRepositories); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(installationRepositories.Repositories, []string{"o/r", "o/another"}) {
+		t.Fatalf("unexpected installation repositories: %#v", installationRepositories.Repositories)
+	}
+	req = httptest.NewRequest(http.MethodGet, "/user/runner_requests", nil)
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected runner list status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var runners []state.RunnerState
+	if err := json.Unmarshal(rec.Body.Bytes(), &runners); err != nil {
+		t.Fatal(err)
+	}
+	if len(runners) != 1 || runners[0].ID != "visible" {
+		t.Fatalf("unexpected user runners: %#v", runners)
+	}
+}
+
 func TestGitHubOAuthLoginCreatesAdminSession(t *testing.T) {
 	var gotTokenAuth string
 	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -325,6 +489,9 @@ func TestGitHubOAuthLoginCreatesAdminSession(t *testing.T) {
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusFound {
 		t.Fatalf("expected callback redirect, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/" {
+		t.Fatalf("expected admin callback to redirect to /, got %q", loc)
 	}
 	if gotTokenAuth != "Bearer user-token" {
 		t.Fatalf("expected user fetch bearer token, got %q", gotTokenAuth)
@@ -417,6 +584,9 @@ func TestGitHubOAuthLoginCreatesNonAdminAccount(t *testing.T) {
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusFound {
 		t.Fatalf("expected callback redirect, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/" {
+		t.Fatalf("expected user callback to redirect to /, got %q", loc)
 	}
 	var sessionCookie *http.Cookie
 	for _, cookie := range rec.Result().Cookies() {
@@ -556,7 +726,7 @@ func TestAdminUIIsServedWithoutAPIAccess(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected admin ui, got %d", rec.Code)
 	}
-	if !strings.Contains(rec.Body.String(), `<div id="root">`) || !strings.Contains(rec.Body.String(), `/admin/assets/`) {
+	if !strings.Contains(rec.Body.String(), `<div id="root">`) || !strings.Contains(rec.Body.String(), `/assets/`) {
 		t.Fatalf("admin ui did not contain expected vite shell")
 	}
 
@@ -568,6 +738,28 @@ func TestAdminUIIsServedWithoutAPIAccess(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `<div id="root">`) {
 		t.Fatalf("admin route fallback did not serve vite shell")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected root user ui, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `<div id="root">`) {
+		t.Fatalf("root user ui did not serve vite shell")
+	}
+
+	for _, path := range []string{"/repositories", "/accounts"} {
+		req = httptest.NewRequest(http.MethodGet, path, nil)
+		rec = httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected user route fallback for %s, got %d", path, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), `<div id="root">`) {
+			t.Fatalf("user route fallback for %s did not serve vite shell", path)
+		}
 	}
 }
 
@@ -1989,6 +2181,23 @@ func testSessionCookie(subject, login, role string) *http.Cookie {
 		Value: payloadValue + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil)),
 		Path:  "/",
 	}
+}
+
+func testServerPrivateKeyFile(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	path := filepath.Join(t.TempDir(), "github-app.pem")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func waitForState(t *testing.T, store state.Store, id, want string) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -330,49 +331,69 @@ func TestUserGitHubAppConfigurationAndRunnerList(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &appConfig); err != nil {
 		t.Fatal(err)
 	}
-	if appConfig.InstallURL != "https://github.com/apps/runnerd-test/installations/new" {
+	if appConfig.InstallURL != "/github-app/install" {
 		t.Fatalf("unexpected install url: %q", appConfig.InstallURL)
 	}
 
-	req = httptest.NewRequest(http.MethodGet, "/github-app/setup?installation_id=987&setup_action=install", nil)
+	req = httptest.NewRequest(http.MethodGet, "/github-app/install", nil)
 	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("unexpected install redirect status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	installLocation := rec.Header().Get("Location")
+	if !strings.HasPrefix(installLocation, "https://github.com/apps/runnerd-test/installations/new?") {
+		t.Fatalf("unexpected github app install redirect: %q", installLocation)
+	}
+	parsedInstallLocation, err := url.Parse(installLocation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setupState := parsedInstallLocation.Query().Get("state")
+	if setupState == "" {
+		t.Fatalf("expected github app install state in %q", installLocation)
+	}
+	var setupStateCookie *http.Cookie
+	for _, cookie := range rec.Result().Cookies() {
+		if cookie.Name == githubAppSetupStateCookieName {
+			setupStateCookie = cookie
+		}
+	}
+	if setupStateCookie == nil || setupStateCookie.Value != setupState {
+		t.Fatalf("expected github app setup state cookie, got %#v state=%q", setupStateCookie, setupState)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/github-app/setup?installation_id=987&setup_action=install&state="+url.QueryEscape(setupState), nil)
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	req.AddCookie(setupStateCookie)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusFound {
 		t.Fatalf("unexpected setup status: %d body=%s", rec.Code, rec.Body.String())
 	}
-	if rec.Header().Get("Location") != "/account/repositories?installation_id=987&setup_action=install" {
+	if rec.Header().Get("Location") != "/account/repositories?installation_id=987&setup_action=install&state="+url.QueryEscape(setupState) {
 		t.Fatalf("unexpected setup redirect: %q", rec.Header().Get("Location"))
 	}
-	req = httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=oauth-code&installation_id=987&setup_action=install", nil)
+
+	req = httptest.NewRequest(http.MethodPost, "/user/github-app/installations", strings.NewReader(fmt.Sprintf(`{"installation_id":987,"setup_state":%q}`, setupState)))
+	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	req.AddCookie(setupStateCookie)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
-	if rec.Code != http.StatusFound {
-		t.Fatalf("unexpected callback setup status: %d body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected installation save status: %d body=%s", rec.Code, rec.Body.String())
 	}
-	if rec.Header().Get("Location") != "/account/repositories?installation_id=987&setup_action=install" {
-		t.Fatalf("unexpected callback setup redirect: %q", rec.Header().Get("Location"))
-	}
-	req = httptest.NewRequest(http.MethodGet, "/auth/github/callback?installation_id=987&setup_action=install&state=github-app-state", nil)
+
+	req = httptest.NewRequest(http.MethodPost, "/user/github-app/installations", strings.NewReader(`{"installation_id":987,"setup_state":"wrong"}`))
+	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	req.AddCookie(setupStateCookie)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
-	if rec.Code != http.StatusFound {
-		t.Fatalf("unexpected callback setup status with state: %d body=%s", rec.Code, rec.Body.String())
-	}
-	if rec.Header().Get("Location") != "/account/repositories?installation_id=987&setup_action=install" {
-		t.Fatalf("unexpected callback setup redirect with state: %q", rec.Header().Get("Location"))
-	}
-	req = httptest.NewRequest(http.MethodGet, "/auth/github/callback?installation_id=987&state=github-app-state", nil)
-	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
-	rec = httptest.NewRecorder()
-	srv.ServeHTTP(rec, req)
-	if rec.Code != http.StatusFound {
-		t.Fatalf("unexpected callback setup status without setup_action: %d body=%s", rec.Code, rec.Body.String())
-	}
-	if rec.Header().Get("Location") != "/account/repositories?installation_id=987" {
-		t.Fatalf("unexpected callback setup redirect without setup_action: %q", rec.Header().Get("Location"))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected invalid setup state to be rejected, got %d body=%s", rec.Code, rec.Body.String())
 	}
 	account, _, err := store.GetAccountByOAuthIdentity("github", "hubot-id")
 	if err != nil {

--- a/internal/server/server_user_handlers.go
+++ b/internal/server/server_user_handlers.go
@@ -40,7 +40,7 @@ func (s *Server) handleGitHubAppSetupRedirect(w http.ResponseWriter, r *http.Req
 			})
 		}
 	}
-	target := "/accounts"
+	target := "/account/repositories"
 	if encoded := values.Encode(); encoded != "" {
 		target += "?" + encoded
 	}
@@ -190,6 +190,8 @@ func (s *Server) syncGitHubInstallation(ctx context.Context, accountID, installa
 		AccountID:      accountID,
 		InstallationID: installation.ID,
 		AccountLogin:   installation.AccountLogin,
+		AccountName:    installation.AccountName,
+		AccountAvatar:  installation.AccountAvatar,
 	})
 }
 

--- a/internal/server/server_user_handlers.go
+++ b/internal/server/server_user_handlers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"io"
@@ -9,35 +10,51 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/qiniu/ci-runner/internal/state"
 )
 
 type upsertGitHubInstallationRequest struct {
-	InstallationID int64 `json:"installation_id"`
+	InstallationID int64  `json:"installation_id"`
+	SetupState     string `json:"setup_state"`
+}
+
+func (s *Server) handleGitHubAppInstallRedirect(w http.ResponseWriter, r *http.Request) {
+	if _, _, ok := s.requireUserSession(w, r); !ok {
+		return
+	}
+	if strings.TrimSpace(s.cfg.GitHubAppSlug) == "" {
+		writeError(w, http.StatusBadRequest, "github app slug is not configured")
+		return
+	}
+	setupState := newID()
+	http.SetCookie(w, &http.Cookie{
+		Name:     githubAppSetupStateCookieName,
+		Value:    setupState,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   requestIsSecure(r),
+		MaxAge:   int((10 * time.Minute).Seconds()),
+	})
+	http.Redirect(w, r, s.githubAppInstallationURL(setupState), http.StatusFound)
 }
 
 func (s *Server) handleGitHubAppSetupRedirect(w http.ResponseWriter, r *http.Request) {
-	session, account, ok := s.requireUserSession(w, r)
-	if !ok {
+	if _, _, ok := s.requireUserSession(w, r); !ok {
 		return
 	}
 	values := url.Values{}
-	for _, key := range []string{"installation_id", "setup_action"} {
+	for _, key := range []string{"installation_id", "setup_action", "state"} {
 		if value := strings.TrimSpace(r.URL.Query().Get(key)); value != "" {
 			values.Set(key, value)
 		}
 	}
 	installationID, err := strconv.ParseInt(strings.TrimSpace(r.URL.Query().Get("installation_id")), 10, 64)
 	if err == nil && installationID > 0 {
-		installation, syncErr := s.syncGitHubInstallation(r.Context(), account.ID, installationID)
-		if syncErr != nil {
-			s.logger.Warn("github app installation sync failed", "installation_id", installationID, "error", syncErr)
-			values.Set("setup_error", "sync_failed")
-		} else {
-			s.recordAudit("github:"+session.Subject, "github_app.configure", "github_installation", strconv.FormatInt(installation.InstallationID, 10), map[string]any{
-				"account_login": installation.AccountLogin,
-			})
+		if !s.validGitHubAppSetupState(r, r.URL.Query().Get("state")) {
+			values.Set("setup_error", "invalid_state")
 		}
 	}
 	target := "/account/repositories"
@@ -79,11 +96,17 @@ func (s *Server) handleUserSaveGitHubInstallation(w http.ResponseWriter, r *http
 		writeError(w, http.StatusBadRequest, "installation_id is required")
 		return
 	}
+	if !s.validGitHubAppSetupState(r, input.SetupState) {
+		clearCookie(w, githubAppSetupStateCookieName, "/", requestIsSecure(r))
+		writeError(w, http.StatusForbidden, "invalid github app setup state")
+		return
+	}
 	installation, err := s.syncGitHubInstallation(r.Context(), account.ID, input.InstallationID)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	clearCookie(w, githubAppSetupStateCookieName, "/", requestIsSecure(r))
 	s.recordAudit("github:"+session.Subject, "github_app.configure", "github_installation", strconv.FormatInt(installation.InstallationID, 10), map[string]any{
 		"account_login": installation.AccountLogin,
 	})
@@ -131,6 +154,10 @@ func (s *Server) handleUserListGitHubInstallationRepositories(w http.ResponseWri
 		writeError(w, http.StatusNotFound, "github installation not found")
 		return
 	}
+	if s.gh == nil {
+		writeError(w, http.StatusInternalServerError, "github client is not configured")
+		return
+	}
 	repositories, err := s.gh.ListInstallationRepositories(r.Context(), installation.InstallationID)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -165,7 +192,20 @@ func (s *Server) githubAppInstallURL() string {
 	if slug == "" {
 		return ""
 	}
-	return "https://github.com/apps/" + url.PathEscape(slug) + "/installations/new"
+	return "/github-app/install"
+}
+
+func (s *Server) githubAppInstallationURL(setupState string) string {
+	slug := strings.TrimSpace(s.cfg.GitHubAppSlug)
+	if slug == "" {
+		return ""
+	}
+	target := "https://github.com/apps/" + url.PathEscape(slug) + "/installations/new"
+	if strings.TrimSpace(setupState) == "" {
+		return target
+	}
+	values := url.Values{"state": {strings.TrimSpace(setupState)}}
+	return target + "?" + values.Encode()
 }
 
 func (s *Server) githubInstallationForAccount(accountID, id int64) (state.GitHubInstallation, bool, error) {
@@ -182,6 +222,9 @@ func (s *Server) githubInstallationForAccount(accountID, id int64) (state.GitHub
 }
 
 func (s *Server) syncGitHubInstallation(ctx context.Context, accountID, installationID int64) (state.GitHubInstallation, error) {
+	if s.gh == nil {
+		return state.GitHubInstallation{}, errors.New("github client is not configured")
+	}
 	installation, err := s.gh.GetInstallation(ctx, installationID)
 	if err != nil {
 		return state.GitHubInstallation{}, err
@@ -193,6 +236,15 @@ func (s *Server) syncGitHubInstallation(ctx context.Context, accountID, installa
 		AccountName:    installation.AccountName,
 		AccountAvatar:  installation.AccountAvatar,
 	})
+}
+
+func (s *Server) validGitHubAppSetupState(r *http.Request, setupState string) bool {
+	setupState = strings.TrimSpace(setupState)
+	cookie, err := r.Cookie(githubAppSetupStateCookieName)
+	if err != nil || setupState == "" || strings.TrimSpace(cookie.Value) == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(setupState), []byte(cookie.Value)) == 1
 }
 
 func installationIDsForUserInstallations(installations []state.GitHubInstallation) []int64 {

--- a/internal/server/server_user_handlers.go
+++ b/internal/server/server_user_handlers.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/qiniu/ci-runner/internal/state"
+)
+
+type upsertGitHubInstallationRequest struct {
+	InstallationID int64 `json:"installation_id"`
+}
+
+func (s *Server) handleGitHubAppSetupRedirect(w http.ResponseWriter, r *http.Request) {
+	session, account, ok := s.requireUserSession(w, r)
+	if !ok {
+		return
+	}
+	values := url.Values{}
+	for _, key := range []string{"installation_id", "setup_action"} {
+		if value := strings.TrimSpace(r.URL.Query().Get(key)); value != "" {
+			values.Set(key, value)
+		}
+	}
+	installationID, err := strconv.ParseInt(strings.TrimSpace(r.URL.Query().Get("installation_id")), 10, 64)
+	if err == nil && installationID > 0 {
+		installation, syncErr := s.syncGitHubInstallation(r.Context(), account.ID, installationID)
+		if syncErr != nil {
+			s.logger.Warn("github app installation sync failed", "installation_id", installationID, "error", syncErr)
+			values.Set("setup_error", "sync_failed")
+		} else {
+			s.recordAudit("github:"+session.Subject, "github_app.configure", "github_installation", strconv.FormatInt(installation.InstallationID, 10), map[string]any{
+				"account_login": installation.AccountLogin,
+			})
+		}
+	}
+	target := "/accounts"
+	if encoded := values.Encode(); encoded != "" {
+		target += "?" + encoded
+	}
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+func (s *Server) handleUserGitHubApp(w http.ResponseWriter, r *http.Request) {
+	_, account, ok := s.requireUserSession(w, r)
+	if !ok {
+		return
+	}
+	installations, err := s.store.ListGitHubInstallations(account.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"app_slug":      strings.TrimSpace(s.cfg.GitHubAppSlug),
+		"install_url":   s.githubAppInstallURL(),
+		"setup_url":     "/github-app/setup",
+		"installations": installations,
+	})
+}
+
+func (s *Server) handleUserSaveGitHubInstallation(w http.ResponseWriter, r *http.Request) {
+	session, account, ok := s.requireUserSession(w, r)
+	if !ok {
+		return
+	}
+	var input upsertGitHubInstallationRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&input); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid github installation payload")
+		return
+	}
+	if input.InstallationID <= 0 {
+		writeError(w, http.StatusBadRequest, "installation_id is required")
+		return
+	}
+	installation, err := s.syncGitHubInstallation(r.Context(), account.ID, input.InstallationID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.recordAudit("github:"+session.Subject, "github_app.configure", "github_installation", strconv.FormatInt(installation.InstallationID, 10), map[string]any{
+		"account_login": installation.AccountLogin,
+	})
+	writeJSON(w, http.StatusOK, installation)
+}
+
+func (s *Server) handleUserDeleteGitHubInstallation(w http.ResponseWriter, r *http.Request) {
+	session, account, ok := s.requireUserSession(w, r)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || id <= 0 {
+		writeError(w, http.StatusBadRequest, "invalid github installation id")
+		return
+	}
+	if err := s.store.DeleteGitHubInstallation(account.ID, id); err != nil {
+		if errors.Is(err, state.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "github installation not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.recordAudit("github:"+session.Subject, "github_app.delete", "github_installation", strconv.FormatInt(id, 10), nil)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleUserListGitHubInstallationRepositories(w http.ResponseWriter, r *http.Request) {
+	_, account, ok := s.requireUserSession(w, r)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || id <= 0 {
+		writeError(w, http.StatusBadRequest, "invalid github installation id")
+		return
+	}
+	installation, ok, err := s.githubInstallationForAccount(account.ID, id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !ok {
+		writeError(w, http.StatusNotFound, "github installation not found")
+		return
+	}
+	repositories, err := s.gh.ListInstallationRepositories(r.Context(), installation.InstallationID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"installation_id": installation.InstallationID,
+		"repositories":    repositories,
+	})
+}
+
+func (s *Server) handleUserListRunners(w http.ResponseWriter, r *http.Request) {
+	_, account, ok := s.requireUserSession(w, r)
+	if !ok {
+		return
+	}
+	installations, err := s.store.ListGitHubInstallations(account.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	states, err := s.store.ListStatesForGitHubInstallations(installationIDsForUserInstallations(installations), 500)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, states)
+}
+
+func (s *Server) githubAppInstallURL() string {
+	slug := strings.TrimSpace(s.cfg.GitHubAppSlug)
+	if slug == "" {
+		return ""
+	}
+	return "https://github.com/apps/" + url.PathEscape(slug) + "/installations/new"
+}
+
+func (s *Server) githubInstallationForAccount(accountID, id int64) (state.GitHubInstallation, bool, error) {
+	installations, err := s.store.ListGitHubInstallations(accountID)
+	if err != nil {
+		return state.GitHubInstallation{}, false, err
+	}
+	for _, installation := range installations {
+		if installation.ID == id {
+			return installation, true, nil
+		}
+	}
+	return state.GitHubInstallation{}, false, nil
+}
+
+func (s *Server) syncGitHubInstallation(ctx context.Context, accountID, installationID int64) (state.GitHubInstallation, error) {
+	installation, err := s.gh.GetInstallation(ctx, installationID)
+	if err != nil {
+		return state.GitHubInstallation{}, err
+	}
+	return s.store.UpsertGitHubInstallation(state.GitHubInstallation{
+		AccountID:      accountID,
+		InstallationID: installation.ID,
+		AccountLogin:   installation.AccountLogin,
+	})
+}
+
+func installationIDsForUserInstallations(installations []state.GitHubInstallation) []int64 {
+	var ids []int64
+	for _, installation := range installations {
+		ids = append(ids, installation.InstallationID)
+	}
+	return uniquePositiveInt64s(ids)
+}
+
+func uniquePositiveInt64s(values []int64) []int64 {
+	seen := map[int64]bool{}
+	out := make([]int64, 0, len(values))
+	for _, value := range values {
+		if value <= 0 || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/server/server_webhooks.go
+++ b/internal/server/server_webhooks.go
@@ -49,13 +49,14 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 	switch event.Action {
 	case "queued":
 		req := state.RunnerRequest{
-			ID:                 id,
-			Source:             "github_webhook",
-			JobID:              event.WorkflowJob.ID,
-			RepositoryFullName: event.Repository.FullName,
-			RequestedLabels:    append([]string(nil), event.WorkflowJob.Labels...),
-			Labels:             []string(event.WorkflowJob.Labels),
-			RunnerName:         "e2b-" + id,
+			ID:                   id,
+			Source:               "github_webhook",
+			JobID:                event.WorkflowJob.ID,
+			GitHubInstallationID: event.Installation.ID,
+			RepositoryFullName:   event.Repository.FullName,
+			RequestedLabels:      append([]string(nil), event.WorkflowJob.Labels...),
+			Labels:               []string(event.WorkflowJob.Labels),
+			RunnerName:           "e2b-" + id,
 		}
 		if !s.cfg.RepositoryAllowed(event.Repository.FullName) {
 			s.logger.Info("workflow_job repository rejected by allowlist", "job_id", id, "repository", event.Repository.FullName)
@@ -253,7 +254,7 @@ func (s *Server) handleWorkflowRunWebhook(w http.ResponseWriter, r *http.Request
 			skipped++
 			continue
 		}
-		st, wasCreated, err := s.enqueueWorkflowJob(event.Repository.FullName, event.WorkflowRun.Name, job, body)
+		st, wasCreated, err := s.enqueueWorkflowJob(event.Repository.FullName, event.Installation.ID, event.WorkflowRun.Name, job, body)
 		if err != nil {
 			s.logger.Error("enqueue workflow_run job", "run_id", event.WorkflowRun.ID, "job_id", job.ID, "error", err)
 			failed++

--- a/internal/state/conversions.go
+++ b/internal/state/conversions.go
@@ -23,16 +23,17 @@ func recordToRequest(record runnerRequestRecord) (RunnerRequest, error) {
 		}
 	}
 	return RunnerRequest{
-		ID:                 record.ID,
-		Source:             record.Source,
-		JobID:              pointerToInt64(record.WorkflowJobID),
-		RepositoryFullName: record.RepositoryFullName,
-		RequestedLabels:    requestedLabels,
-		Labels:             labels,
-		ProfileName:        record.ProfileName,
-		RunnerGroup:        record.RunnerGroup,
-		RunnerName:         record.RunnerName,
-		CreatedAt:          record.QueuedAt,
+		ID:                   record.ID,
+		Source:               record.Source,
+		JobID:                pointerToInt64(record.WorkflowJobID),
+		GitHubInstallationID: record.GitHubInstallationID,
+		RepositoryFullName:   record.RepositoryFullName,
+		RequestedLabels:      requestedLabels,
+		Labels:               labels,
+		ProfileName:          record.ProfileName,
+		RunnerGroup:          record.RunnerGroup,
+		RunnerName:           record.RunnerName,
+		CreatedAt:            record.QueuedAt,
 	}, nil
 }
 
@@ -40,40 +41,41 @@ func recordToState(record runnerRequestRecord) RunnerState {
 	requestedLabels, _ := labelsFromJSON(record.RequestedLabelsJSON)
 	githubLinks := githubLinksFromPayload(record)
 	return RunnerState{
-		ID:                 record.ID,
-		Status:             record.Status,
-		RepositoryFullName: record.RepositoryFullName,
-		RequestedLabels:    requestedLabels,
-		ProfileName:        record.ProfileName,
-		RunnerGroup:        record.RunnerGroup,
-		RunnerName:         record.RunnerName,
-		SandboxID:          record.SandboxID,
-		ProcessPID:         record.ProcessPID,
-		WorkflowJobID:      pointerToInt64(record.WorkflowJobID),
-		WorkflowRunID:      githubLinks.workflowRunID,
-		GitHubJobURL:       githubLinks.jobURL,
-		PullRequestNumber:  githubLinks.pullRequestNumber,
-		AssignedJobID:      record.AssignedJobID,
-		AssignedJobName:    record.AssignedJobName,
-		Error:              record.Error,
-		FailureStage:       record.FailureStage,
-		FailureReason:      record.FailureReason,
-		LastErrorCode:      record.LastErrorCode,
-		LastErrorMessage:   record.LastErrorMessage,
-		LastErrorRetryable: record.LastErrorRetryable,
-		RetryCount:         record.RetryCount,
-		UpdatedAt:          record.UpdatedAt,
-		CreatedAt:          record.QueuedAt,
-		LastAttemptAt:      pointerToTime(record.LastAttemptAt),
-		NextRetryAt:        pointerToTime(record.NextRetryAt),
-		CreatingAt:         pointerToTime(record.CreatingAt),
-		RunningAt:          pointerToTime(record.RunningAt),
-		StoppingAt:         pointerToTime(record.StoppingAt),
-		CompletedAt:        pointerToTime(record.CompletedAt),
-		FailedAt:           pointerToTime(record.FailedAt),
-		LeaseOwner:         record.LeaseOwner,
-		LeaseExpiresAt:     pointerToTime(record.LeaseExpiresAt),
-		Version:            record.Version,
+		ID:                   record.ID,
+		Status:               record.Status,
+		GitHubInstallationID: record.GitHubInstallationID,
+		RepositoryFullName:   record.RepositoryFullName,
+		RequestedLabels:      requestedLabels,
+		ProfileName:          record.ProfileName,
+		RunnerGroup:          record.RunnerGroup,
+		RunnerName:           record.RunnerName,
+		SandboxID:            record.SandboxID,
+		ProcessPID:           record.ProcessPID,
+		WorkflowJobID:        pointerToInt64(record.WorkflowJobID),
+		WorkflowRunID:        githubLinks.workflowRunID,
+		GitHubJobURL:         githubLinks.jobURL,
+		PullRequestNumber:    githubLinks.pullRequestNumber,
+		AssignedJobID:        record.AssignedJobID,
+		AssignedJobName:      record.AssignedJobName,
+		Error:                record.Error,
+		FailureStage:         record.FailureStage,
+		FailureReason:        record.FailureReason,
+		LastErrorCode:        record.LastErrorCode,
+		LastErrorMessage:     record.LastErrorMessage,
+		LastErrorRetryable:   record.LastErrorRetryable,
+		RetryCount:           record.RetryCount,
+		UpdatedAt:            record.UpdatedAt,
+		CreatedAt:            record.QueuedAt,
+		LastAttemptAt:        pointerToTime(record.LastAttemptAt),
+		NextRetryAt:          pointerToTime(record.NextRetryAt),
+		CreatingAt:           pointerToTime(record.CreatingAt),
+		RunningAt:            pointerToTime(record.RunningAt),
+		StoppingAt:           pointerToTime(record.StoppingAt),
+		CompletedAt:          pointerToTime(record.CompletedAt),
+		FailedAt:             pointerToTime(record.FailedAt),
+		LeaseOwner:           record.LeaseOwner,
+		LeaseExpiresAt:       pointerToTime(record.LeaseExpiresAt),
+		Version:              record.Version,
 	}
 }
 
@@ -218,6 +220,19 @@ func uniqueTrimmed(values []string) []string {
 	for _, value := range values {
 		value = strings.TrimSpace(value)
 		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func uniquePositiveInt64s(values []int64) []int64 {
+	seen := map[int64]bool{}
+	out := make([]int64, 0, len(values))
+	for _, value := range values {
+		if value <= 0 || seen[value] {
 			continue
 		}
 		seen[value] = true

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -151,7 +151,7 @@ func (s *DBStore) migrate(db *gorm.DB) error {
 	if err := migrateLegacySchemaColumns(db); err != nil {
 		return err
 	}
-	return db.AutoMigrate(
+	if err := db.AutoMigrate(
 		&runnerRequestRecord{},
 		&runnerEventRecord{},
 		&runnerProfileRecord{},
@@ -161,7 +161,11 @@ func (s *DBStore) migrate(db *gorm.DB) error {
 		&auditEventRecord{},
 		&accountRecord{},
 		&oauthIdentityRecord{},
-	)
+		&githubInstallationRecord{},
+	); err != nil {
+		return err
+	}
+	return nil
 }
 
 func migrateLegacySchemaColumns(db *gorm.DB) error {

--- a/internal/state/github_installations.go
+++ b/internal/state/github_installations.go
@@ -51,12 +51,14 @@ func (s *DBStore) UpsertGitHubInstallation(installation GitHubInstallation) (Git
 		AccountID:      installation.AccountID,
 		InstallationID: installation.InstallationID,
 		AccountLogin:   strings.TrimSpace(installation.AccountLogin),
+		AccountName:    strings.TrimSpace(installation.AccountName),
+		AccountAvatar:  strings.TrimSpace(installation.AccountAvatar),
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}
 	if err := db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "account_id"}, {Name: "installation_id"}},
-		DoUpdates: clause.AssignmentColumns([]string{"account_login", "updated_at"}),
+		DoUpdates: clause.AssignmentColumns([]string{"account_login", "account_name", "account_avatar", "updated_at"}),
 	}).Create(&record).Error; err != nil {
 		return GitHubInstallation{}, err
 	}
@@ -122,6 +124,8 @@ func recordToGitHubInstallation(record githubInstallationRecord, repositories []
 		AccountID:      record.AccountID,
 		InstallationID: record.InstallationID,
 		AccountLogin:   record.AccountLogin,
+		AccountName:    record.AccountName,
+		AccountAvatar:  record.AccountAvatar,
 		Repositories:   normalizeRepositories(repositories),
 		CreatedAt:      record.CreatedAt,
 		UpdatedAt:      record.UpdatedAt,

--- a/internal/state/github_installations.go
+++ b/internal/state/github_installations.go
@@ -1,0 +1,143 @@
+package state
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func (s *DBStore) ListGitHubInstallations(accountID int64) ([]GitHubInstallation, error) {
+	db, err := s.dbOrEnsure()
+	if err != nil {
+		return nil, err
+	}
+	if accountID <= 0 {
+		return nil, ErrNotFound
+	}
+	var records []githubInstallationRecord
+	if err := db.
+		Where("account_id = ?", accountID).
+		Order("account_login ASC, installation_id ASC").
+		Find(&records).Error; err != nil {
+		return nil, err
+	}
+	repositories, err := repositoriesForGitHubInstallations(db, records)
+	if err != nil {
+		return nil, err
+	}
+	installations := make([]GitHubInstallation, 0, len(records))
+	for _, record := range records {
+		installations = append(installations, recordToGitHubInstallation(record, repositories[record.ID]))
+	}
+	return installations, nil
+}
+
+func (s *DBStore) UpsertGitHubInstallation(installation GitHubInstallation) (GitHubInstallation, error) {
+	db, err := s.dbOrEnsure()
+	if err != nil {
+		return GitHubInstallation{}, err
+	}
+	if installation.AccountID <= 0 {
+		return GitHubInstallation{}, fmt.Errorf("account_id is required")
+	}
+	if installation.InstallationID <= 0 {
+		return GitHubInstallation{}, fmt.Errorf("installation_id is required")
+	}
+	now := time.Now().UTC()
+	record := githubInstallationRecord{
+		AccountID:      installation.AccountID,
+		InstallationID: installation.InstallationID,
+		AccountLogin:   strings.TrimSpace(installation.AccountLogin),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "account_id"}, {Name: "installation_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"account_login", "updated_at"}),
+	}).Create(&record).Error; err != nil {
+		return GitHubInstallation{}, err
+	}
+	if err := db.First(&record, "account_id = ? AND installation_id = ?", installation.AccountID, installation.InstallationID).Error; err != nil {
+		return GitHubInstallation{}, err
+	}
+	return recordToGitHubInstallation(record, nil), nil
+}
+
+func (s *DBStore) DeleteGitHubInstallation(accountID, id int64) error {
+	db, err := s.dbOrEnsure()
+	if err != nil {
+		return err
+	}
+	if accountID <= 0 || id <= 0 {
+		return ErrNotFound
+	}
+	result := db.Where("account_id = ? AND id = ?", accountID, id).Delete(&githubInstallationRecord{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func repositoriesForGitHubInstallations(db *gorm.DB, records []githubInstallationRecord) (map[int64][]string, error) {
+	out := make(map[int64][]string, len(records))
+	if len(records) == 0 {
+		return out, nil
+	}
+	installationIDs := make([]int64, 0, len(records))
+	localIDsByInstallationID := map[int64][]int64{}
+	for _, record := range records {
+		installationIDs = append(installationIDs, record.InstallationID)
+		localIDsByInstallationID[record.InstallationID] = append(localIDsByInstallationID[record.InstallationID], record.ID)
+	}
+	var rows []struct {
+		GitHubInstallationID int64  `gorm:"column:github_installation_id"`
+		RepositoryFullName   string `gorm:"column:repository_full_name"`
+	}
+	if err := db.Model(&runnerRequestRecord{}).
+		Select("github_installation_id, repository_full_name").
+		Where("github_installation_id IN ?", uniquePositiveInt64s(installationIDs)).
+		Where("repository_full_name != ''").
+		Group("github_installation_id, repository_full_name").
+		Order("repository_full_name ASC").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		for _, localID := range localIDsByInstallationID[row.GitHubInstallationID] {
+			out[localID] = append(out[localID], row.RepositoryFullName)
+		}
+	}
+	return out, nil
+}
+
+func recordToGitHubInstallation(record githubInstallationRecord, repositories []string) GitHubInstallation {
+	return GitHubInstallation{
+		ID:             record.ID,
+		AccountID:      record.AccountID,
+		InstallationID: record.InstallationID,
+		AccountLogin:   record.AccountLogin,
+		Repositories:   normalizeRepositories(repositories),
+		CreatedAt:      record.CreatedAt,
+		UpdatedAt:      record.UpdatedAt,
+	}
+}
+
+func normalizeRepositories(repositories []string) []string {
+	out := make([]string, 0, len(repositories))
+	seen := map[string]bool{}
+	for _, repository := range repositories {
+		repository = strings.TrimSpace(repository)
+		if repository == "" || strings.Contains(repository, "*") || !strings.Contains(repository, "/") || seen[repository] {
+			continue
+		}
+		seen[repository] = true
+		out = append(out, repository)
+	}
+	return out
+}

--- a/internal/state/records.go
+++ b/internal/state/records.go
@@ -151,6 +151,8 @@ type githubInstallationRecord struct {
 	Account        accountRecord `gorm:"foreignKey:AccountID"`
 	InstallationID int64         `gorm:"column:installation_id;not null;uniqueIndex:idx_github_installations_account_installation"`
 	AccountLogin   string        `gorm:"column:account_login;not null"`
+	AccountName    string        `gorm:"column:account_name"`
+	AccountAvatar  string        `gorm:"column:account_avatar"`
 	CreatedAt      time.Time     `gorm:"column:created_at;not null"`
 	UpdatedAt      time.Time     `gorm:"column:updated_at;not null"`
 }

--- a/internal/state/records.go
+++ b/internal/state/records.go
@@ -3,40 +3,41 @@ package state
 import "time"
 
 type runnerRequestRecord struct {
-	ID                  string     `gorm:"column:id;primaryKey"`
-	Source              string     `gorm:"column:source;not null"`
-	WorkflowJobID       *int64     `gorm:"column:workflow_job_id;uniqueIndex:idx_runner_requests_workflow_job_id"`
-	RepositoryFullName  string     `gorm:"column:repository_full_name"`
-	RequestedLabelsJSON string     `gorm:"column:requested_labels_json"`
-	LabelsJSON          string     `gorm:"column:labels_json;not null"`
-	ProfileName         string     `gorm:"column:profile_name"`
-	RunnerGroup         string     `gorm:"column:runner_group"`
-	RunnerName          string     `gorm:"column:runner_name;not null"`
-	Status              string     `gorm:"column:status;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_status_retry_queue;index:idx_runner_requests_lease_expiry"`
-	FailureStage        string     `gorm:"column:failure_stage"`
-	FailureReason       string     `gorm:"column:failure_reason"`
-	LastErrorCode       string     `gorm:"column:last_error_code"`
-	LastErrorMessage    string     `gorm:"column:last_error_message"`
-	LastErrorRetryable  bool       `gorm:"column:last_error_retryable;not null;default:false"`
-	RetryCount          int        `gorm:"column:retry_count;not null;default:0"`
-	SandboxID           string     `gorm:"column:sandbox_id"`
-	ProcessPID          uint32     `gorm:"column:process_pid"`
-	AssignedJobID       int64      `gorm:"column:assigned_job_id"`
-	AssignedJobName     string     `gorm:"column:assigned_job_name"`
-	Error               string     `gorm:"column:error"`
-	GitHubPayloadJSON   string     `gorm:"column:github_payload_json;type:text"`
-	QueuedAt            time.Time  `gorm:"column:queued_at;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_status_retry_queue"`
-	LastAttemptAt       *time.Time `gorm:"column:last_attempt_at"`
-	NextRetryAt         *time.Time `gorm:"column:next_retry_at;index:idx_runner_requests_status_retry_queue"`
-	CreatingAt          *time.Time `gorm:"column:creating_at"`
-	RunningAt           *time.Time `gorm:"column:running_at"`
-	StoppingAt          *time.Time `gorm:"column:stopping_at"`
-	CompletedAt         *time.Time `gorm:"column:completed_at"`
-	FailedAt            *time.Time `gorm:"column:failed_at"`
-	LeaseOwner          string     `gorm:"column:lease_owner"`
-	LeaseExpiresAt      *time.Time `gorm:"column:lease_expires_at;index:idx_runner_requests_lease_expiry"`
-	UpdatedAt           time.Time  `gorm:"column:updated_at;not null;index:idx_runner_requests_status_updated"`
-	Version             int64      `gorm:"column:version;not null;default:0"`
+	ID                   string     `gorm:"column:id;primaryKey"`
+	Source               string     `gorm:"column:source;not null"`
+	WorkflowJobID        *int64     `gorm:"column:workflow_job_id;uniqueIndex:idx_runner_requests_workflow_job_id"`
+	GitHubInstallationID int64      `gorm:"column:github_installation_id;index:idx_runner_requests_github_installation_updated"`
+	RepositoryFullName   string     `gorm:"column:repository_full_name"`
+	RequestedLabelsJSON  string     `gorm:"column:requested_labels_json"`
+	LabelsJSON           string     `gorm:"column:labels_json;not null"`
+	ProfileName          string     `gorm:"column:profile_name"`
+	RunnerGroup          string     `gorm:"column:runner_group"`
+	RunnerName           string     `gorm:"column:runner_name;not null"`
+	Status               string     `gorm:"column:status;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_status_retry_queue;index:idx_runner_requests_lease_expiry"`
+	FailureStage         string     `gorm:"column:failure_stage"`
+	FailureReason        string     `gorm:"column:failure_reason"`
+	LastErrorCode        string     `gorm:"column:last_error_code"`
+	LastErrorMessage     string     `gorm:"column:last_error_message"`
+	LastErrorRetryable   bool       `gorm:"column:last_error_retryable;not null;default:false"`
+	RetryCount           int        `gorm:"column:retry_count;not null;default:0"`
+	SandboxID            string     `gorm:"column:sandbox_id"`
+	ProcessPID           uint32     `gorm:"column:process_pid"`
+	AssignedJobID        int64      `gorm:"column:assigned_job_id"`
+	AssignedJobName      string     `gorm:"column:assigned_job_name"`
+	Error                string     `gorm:"column:error"`
+	GitHubPayloadJSON    string     `gorm:"column:github_payload_json;type:text"`
+	QueuedAt             time.Time  `gorm:"column:queued_at;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_status_retry_queue"`
+	LastAttemptAt        *time.Time `gorm:"column:last_attempt_at"`
+	NextRetryAt          *time.Time `gorm:"column:next_retry_at;index:idx_runner_requests_status_retry_queue"`
+	CreatingAt           *time.Time `gorm:"column:creating_at"`
+	RunningAt            *time.Time `gorm:"column:running_at"`
+	StoppingAt           *time.Time `gorm:"column:stopping_at"`
+	CompletedAt          *time.Time `gorm:"column:completed_at"`
+	FailedAt             *time.Time `gorm:"column:failed_at"`
+	LeaseOwner           string     `gorm:"column:lease_owner"`
+	LeaseExpiresAt       *time.Time `gorm:"column:lease_expires_at;index:idx_runner_requests_lease_expiry"`
+	UpdatedAt            time.Time  `gorm:"column:updated_at;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_github_installation_updated"`
+	Version              int64      `gorm:"column:version;not null;default:0"`
 }
 
 func (runnerRequestRecord) TableName() string { return "runner_requests" }
@@ -143,3 +144,15 @@ type oauthIdentityRecord struct {
 }
 
 func (oauthIdentityRecord) TableName() string { return "oauth_identities" }
+
+type githubInstallationRecord struct {
+	ID             int64         `gorm:"column:id;primaryKey;autoIncrement"`
+	AccountID      int64         `gorm:"column:account_id;not null;uniqueIndex:idx_github_installations_account_installation;index:idx_github_installations_account"`
+	Account        accountRecord `gorm:"foreignKey:AccountID"`
+	InstallationID int64         `gorm:"column:installation_id;not null;uniqueIndex:idx_github_installations_account_installation"`
+	AccountLogin   string        `gorm:"column:account_login;not null"`
+	CreatedAt      time.Time     `gorm:"column:created_at;not null"`
+	UpdatedAt      time.Time     `gorm:"column:updated_at;not null"`
+}
+
+func (githubInstallationRecord) TableName() string { return "github_installations" }

--- a/internal/state/runner_requests.go
+++ b/internal/state/runner_requests.go
@@ -45,19 +45,20 @@ func (s *DBStore) CreateRequest(req RunnerRequest, payload []byte) (bool, Runner
 		return false, RunnerState{}, err
 	}
 	record := runnerRequestRecord{
-		ID:                  req.ID,
-		Source:              req.Source,
-		RepositoryFullName:  req.RepositoryFullName,
-		RequestedLabelsJSON: string(requestedLabelsJSON),
-		LabelsJSON:          string(labelsJSON),
-		ProfileName:         req.ProfileName,
-		RunnerGroup:         req.RunnerGroup,
-		RunnerName:          req.RunnerName,
-		Status:              StatusQueued,
-		GitHubPayloadJSON:   string(payload),
-		QueuedAt:            req.CreatedAt,
-		UpdatedAt:           now,
-		Version:             0,
+		ID:                   req.ID,
+		Source:               req.Source,
+		GitHubInstallationID: req.GitHubInstallationID,
+		RepositoryFullName:   req.RepositoryFullName,
+		RequestedLabelsJSON:  string(requestedLabelsJSON),
+		LabelsJSON:           string(labelsJSON),
+		ProfileName:          req.ProfileName,
+		RunnerGroup:          req.RunnerGroup,
+		RunnerName:           req.RunnerName,
+		Status:               StatusQueued,
+		GitHubPayloadJSON:    string(payload),
+		QueuedAt:             req.CreatedAt,
+		UpdatedAt:            now,
+		Version:              0,
 	}
 	if req.JobID != 0 {
 		record.WorkflowJobID = &req.JobID
@@ -262,6 +263,60 @@ func (s *DBStore) ListStatesPage(limit, offset int) ([]RunnerState, int64, error
 		states = append(states, recordToState(record))
 	}
 	return states, total, nil
+}
+
+func (s *DBStore) ListStatesForRepositories(repositories []string, limit int) ([]RunnerState, error) {
+	db, err := s.dbOrEnsure()
+	if err != nil {
+		return nil, err
+	}
+	repositories = uniqueTrimmed(repositories)
+	if len(repositories) == 0 {
+		return []RunnerState{}, nil
+	}
+	if limit <= 0 || limit > 500 {
+		limit = 500
+	}
+	var records []runnerRequestRecord
+	if err := db.
+		Where("repository_full_name IN ?", repositories).
+		Order("queued_at DESC").
+		Limit(limit).
+		Find(&records).Error; err != nil {
+		return nil, err
+	}
+	states := make([]RunnerState, 0, len(records))
+	for _, record := range records {
+		states = append(states, recordToState(record))
+	}
+	return states, nil
+}
+
+func (s *DBStore) ListStatesForGitHubInstallations(installationIDs []int64, limit int) ([]RunnerState, error) {
+	db, err := s.dbOrEnsure()
+	if err != nil {
+		return nil, err
+	}
+	installationIDs = uniquePositiveInt64s(installationIDs)
+	if len(installationIDs) == 0 {
+		return []RunnerState{}, nil
+	}
+	if limit <= 0 || limit > 500 {
+		limit = 500
+	}
+	var records []runnerRequestRecord
+	if err := db.
+		Where("github_installation_id IN ?", installationIDs).
+		Order("queued_at DESC").
+		Limit(limit).
+		Find(&records).Error; err != nil {
+		return nil, err
+	}
+	states := make([]RunnerState, 0, len(records))
+	for _, record := range records {
+		states = append(states, recordToState(record))
+	}
+	return states, nil
 }
 
 func activeStatuses() []string {

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -27,53 +27,55 @@ var (
 )
 
 type RunnerRequest struct {
-	ID                 string    `json:"id"`
-	Source             string    `json:"source"`
-	JobID              int64     `json:"job_id,omitempty"`
-	RepositoryFullName string    `json:"repository_full_name,omitempty"`
-	RequestedLabels    []string  `json:"requested_labels,omitempty"`
-	Labels             []string  `json:"labels"`
-	ProfileName        string    `json:"runner_spec_name,omitempty"`
-	RunnerGroup        string    `json:"runner_group,omitempty"`
-	RunnerName         string    `json:"runner_name"`
-	CreatedAt          time.Time `json:"created_at"`
+	ID                   string    `json:"id"`
+	Source               string    `json:"source"`
+	JobID                int64     `json:"job_id,omitempty"`
+	GitHubInstallationID int64     `json:"github_installation_id,omitempty"`
+	RepositoryFullName   string    `json:"repository_full_name,omitempty"`
+	RequestedLabels      []string  `json:"requested_labels,omitempty"`
+	Labels               []string  `json:"labels"`
+	ProfileName          string    `json:"runner_spec_name,omitempty"`
+	RunnerGroup          string    `json:"runner_group,omitempty"`
+	RunnerName           string    `json:"runner_name"`
+	CreatedAt            time.Time `json:"created_at"`
 }
 
 type RunnerState struct {
-	ID                 string    `json:"id"`
-	Status             string    `json:"status"`
-	RepositoryFullName string    `json:"repository_full_name,omitempty"`
-	RequestedLabels    []string  `json:"requested_labels,omitempty"`
-	ProfileName        string    `json:"runner_spec_name,omitempty"`
-	RunnerGroup        string    `json:"runner_group,omitempty"`
-	RunnerName         string    `json:"runner_name"`
-	SandboxID          string    `json:"sandbox_id,omitempty"`
-	ProcessPID         uint32    `json:"process_pid,omitempty"`
-	WorkflowJobID      int64     `json:"workflow_job_id,omitempty"`
-	WorkflowRunID      int64     `json:"workflow_run_id,omitempty"`
-	GitHubJobURL       string    `json:"github_job_url,omitempty"`
-	PullRequestNumber  int64     `json:"pull_request_number,omitempty"`
-	AssignedJobID      int64     `json:"assigned_job_id,omitempty"`
-	AssignedJobName    string    `json:"assigned_job_name,omitempty"`
-	Error              string    `json:"error,omitempty"`
-	FailureStage       string    `json:"failure_stage,omitempty"`
-	FailureReason      string    `json:"failure_reason,omitempty"`
-	LastErrorCode      string    `json:"last_error_code,omitempty"`
-	LastErrorMessage   string    `json:"last_error_message,omitempty"`
-	LastErrorRetryable bool      `json:"last_error_retryable,omitempty"`
-	RetryCount         int       `json:"retry_count,omitempty"`
-	UpdatedAt          time.Time `json:"updated_at"`
-	CreatedAt          time.Time `json:"created_at"`
-	LastAttemptAt      time.Time `json:"last_attempt_at,omitempty"`
-	NextRetryAt        time.Time `json:"next_retry_at,omitempty"`
-	CreatingAt         time.Time `json:"creating_at,omitempty"`
-	RunningAt          time.Time `json:"running_at,omitempty"`
-	StoppingAt         time.Time `json:"stopping_at,omitempty"`
-	CompletedAt        time.Time `json:"completed_at,omitempty"`
-	FailedAt           time.Time `json:"failed_at,omitempty"`
-	LeaseOwner         string    `json:"lease_owner,omitempty"`
-	LeaseExpiresAt     time.Time `json:"lease_expires_at,omitempty"`
-	Version            int64     `json:"version"`
+	ID                   string    `json:"id"`
+	Status               string    `json:"status"`
+	GitHubInstallationID int64     `json:"github_installation_id,omitempty"`
+	RepositoryFullName   string    `json:"repository_full_name,omitempty"`
+	RequestedLabels      []string  `json:"requested_labels,omitempty"`
+	ProfileName          string    `json:"runner_spec_name,omitempty"`
+	RunnerGroup          string    `json:"runner_group,omitempty"`
+	RunnerName           string    `json:"runner_name"`
+	SandboxID            string    `json:"sandbox_id,omitempty"`
+	ProcessPID           uint32    `json:"process_pid,omitempty"`
+	WorkflowJobID        int64     `json:"workflow_job_id,omitempty"`
+	WorkflowRunID        int64     `json:"workflow_run_id,omitempty"`
+	GitHubJobURL         string    `json:"github_job_url,omitempty"`
+	PullRequestNumber    int64     `json:"pull_request_number,omitempty"`
+	AssignedJobID        int64     `json:"assigned_job_id,omitempty"`
+	AssignedJobName      string    `json:"assigned_job_name,omitempty"`
+	Error                string    `json:"error,omitempty"`
+	FailureStage         string    `json:"failure_stage,omitempty"`
+	FailureReason        string    `json:"failure_reason,omitempty"`
+	LastErrorCode        string    `json:"last_error_code,omitempty"`
+	LastErrorMessage     string    `json:"last_error_message,omitempty"`
+	LastErrorRetryable   bool      `json:"last_error_retryable,omitempty"`
+	RetryCount           int       `json:"retry_count,omitempty"`
+	UpdatedAt            time.Time `json:"updated_at"`
+	CreatedAt            time.Time `json:"created_at"`
+	LastAttemptAt        time.Time `json:"last_attempt_at,omitempty"`
+	NextRetryAt          time.Time `json:"next_retry_at,omitempty"`
+	CreatingAt           time.Time `json:"creating_at,omitempty"`
+	RunningAt            time.Time `json:"running_at,omitempty"`
+	StoppingAt           time.Time `json:"stopping_at,omitempty"`
+	CompletedAt          time.Time `json:"completed_at,omitempty"`
+	FailedAt             time.Time `json:"failed_at,omitempty"`
+	LeaseOwner           string    `json:"lease_owner,omitempty"`
+	LeaseExpiresAt       time.Time `json:"lease_expires_at,omitempty"`
+	Version              int64     `json:"version"`
 }
 
 type RunnerProfile struct {
@@ -144,6 +146,19 @@ type OAuthIdentity struct {
 	UpdatedAt     time.Time `json:"updated_at"`
 }
 
+// GitHubInstallation is a per-account GitHub App installation link.
+// Repositories contains repositories observed by runnerd for that installation,
+// not the full GitHub App authorization scope.
+type GitHubInstallation struct {
+	ID             int64     `json:"id"`
+	AccountID      int64     `json:"account_id"`
+	InstallationID int64     `json:"installation_id"`
+	AccountLogin   string    `json:"account_login,omitempty"`
+	Repositories   []string  `json:"repositories"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
 type RunnerRequestStore interface {
 	Ensure() error
 	CreateRequest(req RunnerRequest, payload []byte) (bool, RunnerState, error)
@@ -155,6 +170,8 @@ type RunnerRequestStore interface {
 	ListMismatchedCompletedStates(limit int) ([]RunnerState, error)
 	ListFailedWorkflowJobStates(limit int) ([]RunnerState, error)
 	ListStatesPage(limit, offset int) ([]RunnerState, int64, error)
+	ListStatesForRepositories(repositories []string, limit int) ([]RunnerState, error)
+	ListStatesForGitHubInstallations(installationIDs []int64, limit int) ([]RunnerState, error)
 	ActiveCount() (int, error)
 	InFlightCount() (int, error)
 	ActiveCountForProfile(name string) (int, error)
@@ -189,6 +206,12 @@ type IdentityStore interface {
 	LinkOAuthIdentityToAccount(accountID int64, identity OAuthIdentity) (Account, OAuthIdentity, error)
 }
 
+type GitHubInstallationStore interface {
+	ListGitHubInstallations(accountID int64) ([]GitHubInstallation, error)
+	UpsertGitHubInstallation(installation GitHubInstallation) (GitHubInstallation, error)
+	DeleteGitHubInstallation(accountID, id int64) error
+}
+
 type AuditStore interface {
 	AppendAuditEvent(event AuditEvent) (AuditEvent, error)
 	ListAuditEvents(limit int) ([]AuditEvent, error)
@@ -198,6 +221,7 @@ type Store interface {
 	RunnerRequestStore
 	RunnerCatalogStore
 	IdentityStore
+	GitHubInstallationStore
 	AuditStore
 }
 

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -154,6 +154,8 @@ type GitHubInstallation struct {
 	AccountID      int64     `json:"account_id"`
 	InstallationID int64     `json:"installation_id"`
 	AccountLogin   string    `json:"account_login,omitempty"`
+	AccountName    string    `json:"account_name,omitempty"`
+	AccountAvatar  string    `json:"account_avatar,omitempty"`
 	Repositories   []string  `json:"repositories"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -869,6 +870,135 @@ func TestListStatesPage(t *testing.T) {
 	}
 	if paged[0].ID != "runner-3" || paged[1].ID != "runner-2" {
 		t.Fatalf("unexpected page order: %#v", []string{paged[0].ID, paged[1].ID})
+	}
+}
+
+func TestGitHubInstallationsAndRepositoryRunnerList(t *testing.T) {
+	store := New(t.TempDir())
+	account, _, err := store.EnsureAccountForOAuthIdentity(OAuthIdentity{OAuthProvider: "github", OAuthSubject: "12345", OAuthLogin: "octocat"}, "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation, err := store.UpsertGitHubInstallation(GitHubInstallation{
+		AccountID:      account.ID,
+		InstallationID: 987,
+		AccountLogin:   "o",
+		Repositories:   []string{"o/r", "o/another", "bad*", "missing-slash"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installation.Repositories) != 0 {
+		t.Fatalf("upsert should not persist the full installation repository scope, got %#v", installation.Repositories)
+	}
+	if _, err := store.UpsertGitHubInstallation(GitHubInstallation{
+		AccountID:      account.ID,
+		InstallationID: 987,
+		AccountLogin:   "renamed",
+		Repositories:   []string{"o/r"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.CreateRequest(RunnerRequest{
+		ID:                   "visible",
+		Source:               "test",
+		GitHubInstallationID: 987,
+		RepositoryFullName:   "o/r",
+		Labels:               []string{"self-hosted"},
+		RunnerName:           "e2b-visible",
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.CreateRequest(RunnerRequest{
+		ID:                   "hidden",
+		Source:               "test",
+		GitHubInstallationID: 456,
+		RepositoryFullName:   "other/r",
+		Labels:               []string{"self-hosted"},
+		RunnerName:           "e2b-hidden",
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+	states, err := store.ListStatesForRepositories([]string{"o/r"}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].ID != "visible" {
+		t.Fatalf("unexpected filtered states: %#v", states)
+	}
+	states, err = store.ListStatesForGitHubInstallations([]int64{987}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 || states[0].ID != "visible" {
+		t.Fatalf("unexpected installation-filtered states: %#v", states)
+	}
+	installations, err := store.ListGitHubInstallations(account.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installations) != 1 || installations[0].AccountLogin != "renamed" || !reflect.DeepEqual(installations[0].Repositories, []string{"o/r"}) {
+		t.Fatalf("unexpected installations: %#v", installations)
+	}
+	if err := store.DeleteGitHubInstallation(account.ID, installations[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	installations, err = store.ListGitHubInstallations(account.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installations) != 0 {
+		t.Fatalf("expected installation to be deleted, got %#v", installations)
+	}
+}
+
+func TestGitHubInstallationsAllowSharedOrgInstallationAcrossAccounts(t *testing.T) {
+	store := New(t.TempDir())
+	first, _, err := store.EnsureAccountForOAuthIdentity(OAuthIdentity{OAuthProvider: "github", OAuthSubject: "100", OAuthLogin: "alice"}, "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := store.EnsureAccountForOAuthIdentity(OAuthIdentity{OAuthProvider: "github", OAuthSubject: "200", OAuthLogin: "bob"}, "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, account := range []Account{first, second} {
+		if _, err := store.UpsertGitHubInstallation(GitHubInstallation{
+			AccountID:      account.ID,
+			InstallationID: 987,
+			AccountLogin:   "shared-org",
+			Repositories:   []string{"shared-org/repo"},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	firstInstallations, err := store.ListGitHubInstallations(first.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondInstallations, err := store.ListGitHubInstallations(second.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(firstInstallations) != 1 || len(secondInstallations) != 1 {
+		t.Fatalf("expected both users to keep their own installation link, first=%#v second=%#v", firstInstallations, secondInstallations)
+	}
+	if firstInstallations[0].ID == secondInstallations[0].ID {
+		t.Fatalf("expected separate local installation rows for shared GitHub installation, got %#v", firstInstallations[0])
+	}
+	if err := store.DeleteGitHubInstallation(first.ID, firstInstallations[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	firstInstallations, err = store.ListGitHubInstallations(first.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondInstallations, err = store.ListGitHubInstallations(second.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(firstInstallations) != 0 || len(secondInstallations) != 1 {
+		t.Fatalf("expected deleting one user's link to preserve collaborator link, first=%#v second=%#v", firstInstallations, secondInstallations)
 	}
 }
 

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -883,6 +883,8 @@ func TestGitHubInstallationsAndRepositoryRunnerList(t *testing.T) {
 		AccountID:      account.ID,
 		InstallationID: 987,
 		AccountLogin:   "o",
+		AccountName:    "Octo Org",
+		AccountAvatar:  "https://avatars.example/o.png",
 		Repositories:   []string{"o/r", "o/another", "bad*", "missing-slash"},
 	})
 	if err != nil {
@@ -895,6 +897,8 @@ func TestGitHubInstallationsAndRepositoryRunnerList(t *testing.T) {
 		AccountID:      account.ID,
 		InstallationID: 987,
 		AccountLogin:   "renamed",
+		AccountName:    "Renamed Org",
+		AccountAvatar:  "https://avatars.example/renamed.png",
 		Repositories:   []string{"o/r"},
 	}); err != nil {
 		t.Fatal(err)
@@ -937,7 +941,11 @@ func TestGitHubInstallationsAndRepositoryRunnerList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(installations) != 1 || installations[0].AccountLogin != "renamed" || !reflect.DeepEqual(installations[0].Repositories, []string{"o/r"}) {
+	if len(installations) != 1 ||
+		installations[0].AccountLogin != "renamed" ||
+		installations[0].AccountName != "Renamed Org" ||
+		installations[0].AccountAvatar != "https://avatars.example/renamed.png" ||
+		!reflect.DeepEqual(installations[0].Repositories, []string{"o/r"}) {
 		t.Fatalf("unexpected installations: %#v", installations)
 	}
 	if err := store.DeleteGitHubInstallation(account.ID, installations[0].ID); err != nil {

--- a/runnerd.yaml.example
+++ b/runnerd.yaml.example
@@ -33,6 +33,10 @@ github:
   # Webhook requests use repository.full_name from GitHub and are admitted by runner_policies.
   app:
     id: 123456
+    # Optional. Enables the ordinary-user UI to link to the GitHub App installation flow.
+    # Configure the GitHub App Setup URL as:
+    #   http://127.0.0.1:25500/github-app/setup
+    slug: your-github-app-slug
     # Optional. Leave empty to resolve the GitHub App installation dynamically per repository.
     # installation_id: 12345678
     # Relative paths are resolved from the directory containing runnerd.yaml.

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>E2B Runner Console</title>
+    <title>Qiniu Runner</title>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -273,12 +273,13 @@ function App() {
     const params = new URLSearchParams(window.location.search)
     const installationID = Number(params.get("installation_id") || "")
     if (!Number.isSafeInteger(installationID) || installationID <= 0) return
+    const setupState = params.get("state") || ""
     setLoading(true)
     try {
       const installation = (await request("/user/github-app/installations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ installation_id: installationID }),
+        body: JSON.stringify({ installation_id: installationID, setup_state: setupState }),
       })) as GitHubInstallation
       toast.success("GitHub App account connected")
       const nextPath = accountSettingsPathForInstallation(installation, authSession.login, "repositories")

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -30,6 +30,7 @@ import {
   type AuthorizedRepositories,
   type DiagnosticsSummary,
   type GitHubAppConfig,
+  type GitHubInstallation,
   type Metric,
   type RunnerGroup,
   type RunnerPolicy,
@@ -39,6 +40,12 @@ import {
   type RunnerStatus,
 } from "@/admin-types"
 import { useRunnerCatalog } from "@/hooks/use-runner-catalog"
+
+type AccountSettingsTab = "repositories" | "preferences"
+type AccountSettingsRoute = {
+  accountLogin?: string
+  tab: AccountSettingsTab
+}
 
 function App() {
   const [authSession, setAuthSession] = useState<AuthSession>({ authenticated: false, oauth_enabled: false })
@@ -83,13 +90,24 @@ function App() {
     }
   }, [])
 
-  const setUserPage = useCallback((next: "home" | "repositories" | "accounts") => {
-    const nextPath = next === "accounts" ? "/accounts" : next === "repositories" ? "/repositories" : "/"
+  const setUserPage = useCallback((next: "home" | "repositories" | "settings") => {
+    const nextPath = next === "settings" ? "/account/repositories" : next === "repositories" ? "/repositories" : "/"
     if (window.location.pathname !== nextPath) {
       window.history.pushState(null, "", nextPath)
     }
     setLocationPath(nextPath)
   }, [])
+
+  const setAccountSettingsRoute = useCallback(
+    (accountLogin: string | undefined, tab: AccountSettingsTab) => {
+      const nextPath = accountSettingsPath(accountLogin, authSession.login, tab)
+      if (window.location.pathname !== nextPath) {
+        window.history.pushState(null, "", nextPath)
+      }
+      setLocationPath(nextPath)
+    },
+    [authSession.login]
+  )
 
   const selected = useMemo(
     () => runners.find((runner) => runner.id === selectedID),
@@ -128,7 +146,8 @@ function App() {
 
   const hasAccess = authSession.authenticated && authSession.role === "admin"
   const isAdminRoute = locationPath === "/admin" || locationPath.startsWith("/admin/")
-  const userPage = locationPath === "/accounts" ? "accounts" : locationPath === "/repositories" ? "repositories" : "home"
+  const accountSettingsRoute = parseAccountSettingsRoute(locationPath, authSession.login)
+  const userPage = accountSettingsRoute ? "settings" : locationPath === "/repositories" ? "repositories" : "home"
 
   const metrics = useMemo<Metric[]>(() => {
     const count = (status: RunnerStatus) => runners.filter((runner) => runner.status === status).length
@@ -250,27 +269,28 @@ function App() {
   }, [authSession.authenticated, hasAccess, isAdminRoute, request])
 
   const syncGitHubAppSetupFromURL = useCallback(async () => {
-    if (!authSession.authenticated || (hasAccess && isAdminRoute) || locationPath !== "/accounts") return
+    if (!authSession.authenticated || (hasAccess && isAdminRoute) || !isAccountSettingsPath(locationPath)) return
     const params = new URLSearchParams(window.location.search)
     const installationID = Number(params.get("installation_id") || "")
     if (!Number.isSafeInteger(installationID) || installationID <= 0) return
     setLoading(true)
     try {
-      await request("/user/github-app/installations", {
+      const installation = (await request("/user/github-app/installations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ installation_id: installationID }),
-      })
+      })) as GitHubInstallation
       toast.success("GitHub App account connected")
-      window.history.replaceState(null, "", "/accounts")
-      setLocationPath("/accounts")
+      const nextPath = accountSettingsPathForInstallation(installation, authSession.login, "repositories")
+      window.history.replaceState(null, "", nextPath)
+      setLocationPath(nextPath)
       await loadUserAll()
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to sync GitHub App repositories")
     } finally {
       setLoading(false)
     }
-  }, [authSession.authenticated, hasAccess, isAdminRoute, loadUserAll, locationPath, request])
+  }, [authSession.authenticated, authSession.login, hasAccess, isAdminRoute, loadUserAll, locationPath, request])
 
   const loadAuthorizedRepositories = useCallback(async (id: number) => {
     setLoadingRepositoriesFor(id)
@@ -345,6 +365,13 @@ function App() {
     window.addEventListener("popstate", handlePopState)
     return () => window.removeEventListener("popstate", handlePopState)
   }, [])
+
+  useEffect(() => {
+    if (locationPath !== "/accounts" && locationPath !== "/settings") return
+    const nextPath = `/account/repositories${window.location.search}`
+    window.history.replaceState(null, "", nextPath)
+    setLocationPath("/account/repositories")
+  }, [locationPath])
 
   useEffect(() => {
     void loadAll()
@@ -488,21 +515,6 @@ function App() {
     }
   }
 
-  const deleteGitHubInstallation = async (id: number) => {
-    try {
-      await request(`/user/github-app/installations/${encodeURIComponent(String(id))}`, { method: "DELETE" })
-      toast.success("GitHub App installation removed")
-      setAuthorizedRepositories((current) => {
-        const next = { ...current }
-        delete next[id]
-        return next
-      })
-      await loadUserAll()
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to remove GitHub App installation")
-    }
-  }
-
   const copySelectedID = async () => {
     if (!selected) return
     await navigator.clipboard.writeText(selected.id)
@@ -532,11 +544,12 @@ function App() {
           runners={userRunners}
           selectedKey={userSelectedKey}
           page={userPage}
+          accountSettingsRoute={accountSettingsRoute || defaultAccountSettingsRoute(authSession.login)}
           authorizedRepositories={authorizedRepositories}
           loadingRepositoriesFor={loadingRepositoriesFor}
-          onDeleteInstallation={(id) => void deleteGitHubInstallation(id)}
           onLoadAuthorizedRepositories={(id) => void loadAuthorizedRepositories(id)}
           onNavigate={setUserPage}
+          onNavigateAccountSettings={setAccountSettingsRoute}
           onSelectKey={setUserSelectedKey}
           onSignOut={signOut}
         />
@@ -696,6 +709,63 @@ function App() {
       <Toaster richColors />
     </SidebarProvider>
   )
+}
+
+function defaultAccountSettingsRoute(currentLogin?: string): AccountSettingsRoute {
+  return { accountLogin: currentLogin, tab: "repositories" }
+}
+
+function isAccountSettingsPath(path: string): boolean {
+  return (
+    path === "/settings" ||
+    path === "/accounts" ||
+    path === "/account/repositories" ||
+    path === "/account/preferences" ||
+    /^\/organizations\/[^/]+\/(repositories|preferences)$/.test(path)
+  )
+}
+
+function parseAccountSettingsRoute(path: string, currentLogin?: string): AccountSettingsRoute | null {
+  if (path === "/settings" || path === "/accounts") return defaultAccountSettingsRoute(currentLogin)
+  if (path === "/account/repositories") return { accountLogin: currentLogin, tab: "repositories" }
+  if (path === "/account/preferences") return { accountLogin: currentLogin, tab: "preferences" }
+
+  const organizationMatch = path.match(/^\/organizations\/([^/]+)\/(repositories|preferences)$/)
+  if (!organizationMatch) return null
+  const accountLogin = safeDecodePathSegment(organizationMatch[1])
+  if (!accountLogin) return null
+
+  return {
+    accountLogin,
+    tab: organizationMatch[2] as AccountSettingsTab,
+  }
+}
+
+function safeDecodePathSegment(value: string): string | null {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return null
+  }
+}
+
+function accountSettingsPathForInstallation(
+  installation: Pick<GitHubInstallation, "account_login">,
+  currentLogin: string | undefined,
+  tab: AccountSettingsTab
+): string {
+  return accountSettingsPath(installation.account_login, currentLogin, tab)
+}
+
+function accountSettingsPath(
+  accountLogin: string | undefined,
+  currentLogin: string | undefined,
+  tab: AccountSettingsTab
+): string {
+  const segment = tab === "preferences" ? "preferences" : "repositories"
+  const login = accountLogin?.trim()
+  if (!login || login === currentLogin) return `/account/${segment}`
+  return `/organizations/${encodeURIComponent(login)}/${segment}`
 }
 
 export default App

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,6 +9,7 @@ import { RunnerPoliciesSection } from "@/components/runner-policies-section"
 import { RunnerRequestsSection } from "@/components/runner-requests-section"
 import { RunnerSpecsSection } from "@/components/runner-specs-section"
 import { SiteHeader } from "@/components/site-header"
+import { UserDashboard } from "@/components/user-dashboard"
 import {
   Card,
   CardContent,
@@ -26,7 +27,9 @@ import {
   type AdminSection,
   type AuditEvent,
   type AuthSession,
+  type AuthorizedRepositories,
   type DiagnosticsSummary,
+  type GitHubAppConfig,
   type Metric,
   type RunnerGroup,
   type RunnerPolicy,
@@ -39,6 +42,7 @@ import { useRunnerCatalog } from "@/hooks/use-runner-catalog"
 
 function App() {
   const [authSession, setAuthSession] = useState<AuthSession>({ authenticated: false, oauth_enabled: false })
+  const [locationPath, setLocationPath] = useState(() => window.location.pathname)
   const [section, setSectionState] = useState<AdminSection>(() => sectionFromPath())
   const [runners, setRunners] = useState<RunnerState[]>([])
   const [runnerSpecs, setRunnerSpecs] = useState<RunnerSpec[]>([])
@@ -63,6 +67,11 @@ function App() {
   const [diagnostics, setDiagnostics] = useState<DiagnosticsSummary | null>(null)
   const [diagnosticsVars, setDiagnosticsVars] = useState("")
   const [auditEvents, setAuditEvents] = useState<AuditEvent[]>([])
+  const [userRunners, setUserRunners] = useState<RunnerState[]>([])
+  const [githubApp, setGitHubApp] = useState<GitHubAppConfig | null>(null)
+  const [authorizedRepositories, setAuthorizedRepositories] = useState<Record<number, string[]>>({})
+  const [loadingRepositoriesFor, setLoadingRepositoriesFor] = useState<number | null>(null)
+  const [userSelectedKey, setUserSelectedKey] = useState("")
 
   const setSection = useCallback((next: string) => {
     const section = adminSections.includes(next as AdminSection) ? (next as AdminSection) : "overview"
@@ -70,7 +79,16 @@ function App() {
     const nextPath = section === "overview" ? "/admin/" : `/admin/${section}`
     if (window.location.pathname !== nextPath) {
       window.history.pushState(null, "", nextPath)
+      setLocationPath(nextPath)
     }
+  }, [])
+
+  const setUserPage = useCallback((next: "home" | "repositories" | "accounts") => {
+    const nextPath = next === "accounts" ? "/accounts" : next === "repositories" ? "/repositories" : "/"
+    if (window.location.pathname !== nextPath) {
+      window.history.pushState(null, "", nextPath)
+    }
+    setLocationPath(nextPath)
   }, [])
 
   const selected = useMemo(
@@ -109,6 +127,8 @@ function App() {
   )
 
   const hasAccess = authSession.authenticated && authSession.role === "admin"
+  const isAdminRoute = locationPath === "/admin" || locationPath.startsWith("/admin/")
+  const userPage = locationPath === "/accounts" ? "accounts" : locationPath === "/repositories" ? "repositories" : "home"
 
   const metrics = useMemo<Metric[]>(() => {
     const count = (status: RunnerStatus) => runners.filter((runner) => runner.status === status).length
@@ -138,7 +158,7 @@ function App() {
           setAuthSession((current) => ({ ...current, authenticated: false, login: undefined, role: undefined, avatar_url: undefined, expires_at: undefined }))
         }
         setConnected(false)
-        throw new Error("You do not have admin access")
+        throw new Error("Session expired or access is not allowed")
       }
       if (!response.ok) {
         const text = await response.text()
@@ -209,6 +229,63 @@ function App() {
     }
   }, [hasAccess, request, selectedID])
 
+  const loadUserAll = useCallback(async () => {
+    if (!authSession.authenticated || (hasAccess && isAdminRoute)) return
+    setLoading(true)
+    try {
+      const [appData, runnerData] = await Promise.all([
+        request("/user/github-app"),
+        request("/user/runner_requests"),
+      ])
+      const nextApp = appData as GitHubAppConfig
+      const nextRunners = Array.isArray(runnerData) ? (runnerData as RunnerState[]) : []
+      setGitHubApp(nextApp)
+      setUserRunners(nextRunners)
+      if (nextRunners.length === 0) setUserSelectedKey("")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to load workspace data")
+    } finally {
+      setLoading(false)
+    }
+  }, [authSession.authenticated, hasAccess, isAdminRoute, request])
+
+  const syncGitHubAppSetupFromURL = useCallback(async () => {
+    if (!authSession.authenticated || (hasAccess && isAdminRoute) || locationPath !== "/accounts") return
+    const params = new URLSearchParams(window.location.search)
+    const installationID = Number(params.get("installation_id") || "")
+    if (!Number.isSafeInteger(installationID) || installationID <= 0) return
+    setLoading(true)
+    try {
+      await request("/user/github-app/installations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ installation_id: installationID }),
+      })
+      toast.success("GitHub App account connected")
+      window.history.replaceState(null, "", "/accounts")
+      setLocationPath("/accounts")
+      await loadUserAll()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to sync GitHub App repositories")
+    } finally {
+      setLoading(false)
+    }
+  }, [authSession.authenticated, hasAccess, isAdminRoute, loadUserAll, locationPath, request])
+
+  const loadAuthorizedRepositories = useCallback(async (id: number) => {
+    setLoadingRepositoriesFor(id)
+    try {
+      const data = (await request(
+        `/user/github-app/installations/${encodeURIComponent(String(id))}/repositories`
+      )) as AuthorizedRepositories
+      setAuthorizedRepositories((current) => ({ ...current, [id]: data.repositories || [] }))
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to load GitHub repositories")
+    } finally {
+      setLoadingRepositoriesFor(null)
+    }
+  }, [request])
+
   const {
     runnerSpecOpen,
     runnerGroupOpen,
@@ -261,7 +338,10 @@ function App() {
   }, [])
 
   useEffect(() => {
-    const handlePopState = () => setSectionState(sectionFromPath())
+    const handlePopState = () => {
+      setLocationPath(window.location.pathname)
+      setSectionState(sectionFromPath())
+    }
     window.addEventListener("popstate", handlePopState)
     return () => window.removeEventListener("popstate", handlePopState)
   }, [])
@@ -271,6 +351,16 @@ function App() {
     const timer = window.setInterval(() => void loadAll(), 5000)
     return () => window.clearInterval(timer)
   }, [loadAll])
+
+  useEffect(() => {
+    void loadUserAll()
+    const timer = window.setInterval(() => void loadUserAll(), 5000)
+    return () => window.clearInterval(timer)
+  }, [loadUserAll])
+
+  useEffect(() => {
+    void syncGitHubAppSetupFromURL()
+  }, [syncGitHubAppSetupFromURL])
 
   useEffect(() => {
     if (selectedID) void loadLog(selectedID, selectedLog)
@@ -301,6 +391,11 @@ function App() {
     setRunnerGroups([])
     setRunnerPolicies([])
     setAuditEvents([])
+    setUserRunners([])
+    setGitHubApp(null)
+    setAuthorizedRepositories({})
+    setLoadingRepositoriesFor(null)
+    setUserSelectedKey("")
     setSelectedID("")
     setLogText("No runner selected")
   }
@@ -393,19 +488,56 @@ function App() {
     }
   }
 
+  const deleteGitHubInstallation = async (id: number) => {
+    try {
+      await request(`/user/github-app/installations/${encodeURIComponent(String(id))}`, { method: "DELETE" })
+      toast.success("GitHub App installation removed")
+      setAuthorizedRepositories((current) => {
+        const next = { ...current }
+        delete next[id]
+        return next
+      })
+      await loadUserAll()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to remove GitHub App installation")
+    }
+  }
+
   const copySelectedID = async () => {
     if (!selected) return
     await navigator.clipboard.writeText(selected.id)
     toast.success("Runner ID copied")
   }
 
-  if (!hasAccess) {
+  if (!authSession.authenticated || !authSession.oauth_enabled) {
     return (
       <>
         <LoginPage
           oauthEnabled={authSession.oauth_enabled}
           currentLogin={authSession.login}
           currentRole={authSession.role}
+          onSignOut={signOut}
+        />
+        <Toaster richColors />
+      </>
+    )
+  }
+
+  if (!hasAccess || !isAdminRoute) {
+    return (
+      <>
+        <UserDashboard
+          authSession={authSession}
+          githubApp={githubApp}
+          runners={userRunners}
+          selectedKey={userSelectedKey}
+          page={userPage}
+          authorizedRepositories={authorizedRepositories}
+          loadingRepositoriesFor={loadingRepositoriesFor}
+          onDeleteInstallation={(id) => void deleteGitHubInstallation(id)}
+          onLoadAuthorizedRepositories={(id) => void loadAuthorizedRepositories(id)}
+          onNavigate={setUserPage}
+          onSelectKey={setUserSelectedKey}
           onSignOut={signOut}
         />
         <Toaster richColors />

--- a/ui/src/admin-types.ts
+++ b/ui/src/admin-types.ts
@@ -100,6 +100,8 @@ export type GitHubInstallation = {
   account_id: number
   installation_id: number
   account_login?: string
+  account_name?: string
+  account_avatar?: string
   repositories: string[]
   created_at: string
   updated_at: string

--- a/ui/src/admin-types.ts
+++ b/ui/src/admin-types.ts
@@ -95,6 +95,28 @@ export type AuthSession = {
   expires_at?: string
 }
 
+export type GitHubInstallation = {
+  id: number
+  account_id: number
+  installation_id: number
+  account_login?: string
+  repositories: string[]
+  created_at: string
+  updated_at: string
+}
+
+export type GitHubAppConfig = {
+  app_slug?: string
+  install_url?: string
+  setup_url: string
+  installations: GitHubInstallation[]
+}
+
+export type AuthorizedRepositories = {
+  installation_id: number
+  repositories: string[]
+}
+
 export type Metric = {
   label: string
   value: number

--- a/ui/src/components/app-sidebar.tsx
+++ b/ui/src/components/app-sidebar.tsx
@@ -46,20 +46,20 @@ export function AppSidebar({
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton className="data-[slot=sidebar-menu-button]:!p-1.5">
-              <div className="flex items-center gap-2">
+            <SidebarMenuButton asChild className="data-[slot=sidebar-menu-button]:!p-1.5">
+              <a href="/" aria-label="Qiniu Runner home">
                 <div className="rounded-lg bg-sidebar-primary p-1.5 shadow-sm">
                   <Terminal className="h-4 w-4 text-sidebar-primary-foreground" />
                 </div>
                 <div className="flex flex-col">
                   <span className="bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-base font-semibold text-transparent">
-                    E2B
+                    Qiniu
                   </span>
                   <span className="text-[10px] font-medium leading-none text-muted-foreground">
                     Runner
                   </span>
                 </div>
-              </div>
+              </a>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/ui/src/components/login-page.tsx
+++ b/ui/src/components/login-page.tsx
@@ -36,7 +36,7 @@ export function LoginPage({
               <Play className="h-5 w-5" />
             </div>
             <div>
-              <div className="text-sm font-semibold tracking-wide">E2B Runner Console</div>
+              <div className="text-sm font-semibold tracking-wide">Qiniu Runner</div>
               <div className="text-xs text-muted-foreground">Ephemeral Actions control plane</div>
             </div>
           </div>
@@ -54,7 +54,7 @@ export function LoginPage({
                 {currentLogin ? (
                   <div className="space-y-3">
                     <div className="rounded-lg border bg-muted/50 p-3 text-sm text-muted-foreground">
-                      @{currentLogin} is signed in as {currentRole || "user"} and does not have admin access.
+                      {currentLogin} is signed in as {currentRole || "user"} and does not have admin access.
                     </div>
                     <Button
                       type="button"

--- a/ui/src/components/site-header.tsx
+++ b/ui/src/components/site-header.tsx
@@ -11,7 +11,7 @@ export function SiteHeader() {
           orientation="vertical"
           className="mx-2 data-[orientation=vertical]:h-4"
         />
-        <span className="text-sm font-semibold text-foreground">E2B Runner Console</span>
+        <span className="text-sm font-semibold text-foreground">Qiniu Runner</span>
         <div className="ml-auto flex items-center gap-2">
           <ModeToggle />
         </div>

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -1,0 +1,582 @@
+import { Github, GitPullRequest, ListTree, LogOut, Trash2, UserRound } from "lucide-react"
+import { type MouseEvent, useEffect, useMemo, useState } from "react"
+
+import type { AuthSession, GitHubAppConfig, RunnerState } from "@/admin-types"
+import { formatTime } from "@/admin-format"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { cn } from "@/lib/utils"
+
+type PRGroup = {
+  key: string
+  repository: string
+  prLabel: string
+  updatedAt: string
+  jobs: RunnerState[]
+}
+
+type UserPage = "home" | "repositories" | "accounts"
+
+export function UserDashboard({
+  authSession,
+  githubApp,
+  runners,
+  selectedKey,
+  page,
+  authorizedRepositories,
+  loadingRepositoriesFor,
+  onDeleteInstallation,
+  onLoadAuthorizedRepositories,
+  onNavigate,
+  onSelectKey,
+  onSignOut,
+}: {
+  authSession: AuthSession
+  githubApp: GitHubAppConfig | null
+  runners: RunnerState[]
+  selectedKey: string
+  page: UserPage
+  authorizedRepositories: Record<number, string[]>
+  loadingRepositoriesFor: number | null
+  onDeleteInstallation: (id: number) => void
+  onLoadAuthorizedRepositories: (id: number) => void
+  onNavigate: (page: UserPage) => void
+  onSelectKey: (key: string) => void
+  onSignOut: () => void
+}) {
+  const groups = useMemo(() => groupRunnersByPR(runners), [runners])
+  const selected = groups.find((group) => group.key === selectedKey) || groups[0]
+  const installations = githubApp?.installations ?? []
+  const hasInstallations = installations.length > 0
+  const repositoryCount = useMemo(
+    () => new Set(installations.flatMap((installation) => installation.repositories)).size,
+    [installations]
+  )
+  const navItemClass = (active: boolean) =>
+    cn(
+      "inline-flex h-9 items-center gap-2 rounded-md px-3 text-sm font-medium transition-colors",
+      active ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+    )
+  const goToPage = (event: MouseEvent<HTMLAnchorElement>, next: UserPage) => {
+    event.preventDefault()
+    onNavigate(next)
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col bg-background text-foreground">
+      <header className="flex h-14 shrink-0 items-center gap-3 border-b px-4 lg:px-6">
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-foreground text-background">
+          <Github className="h-4 w-4" />
+        </div>
+        <div>
+          <div className="text-sm font-semibold">E2B Runner Console</div>
+          <div className="text-xs text-muted-foreground">@{authSession.login} workspace</div>
+        </div>
+        <nav className="ml-3 hidden items-center gap-1 md:flex" aria-label="Workspace">
+          <a href="/" className={navItemClass(page === "home")} onClick={(event) => goToPage(event, "home")}>
+            <GitPullRequest className="h-4 w-4" />
+            Pull Requests
+          </a>
+          <a
+            href="/repositories"
+            className={navItemClass(page === "repositories")}
+            onClick={(event) => goToPage(event, "repositories")}
+          >
+            <ListTree className="h-4 w-4" />
+            Activity
+          </a>
+          <a href="/accounts" className={navItemClass(page === "accounts")} onClick={(event) => goToPage(event, "accounts")}>
+            <UserRound className="h-4 w-4" />
+            Accounts
+          </a>
+        </nav>
+        <div className="ml-auto flex items-center gap-2">
+          <Button type="button" variant="ghost" size="icon" onClick={onSignOut} aria-label="Sign out">
+            <LogOut className="h-4 w-4" />
+          </Button>
+        </div>
+      </header>
+
+      <nav className="flex items-center gap-1 border-b px-4 py-2 md:hidden" aria-label="Workspace">
+        <a href="/" className={navItemClass(page === "home")} onClick={(event) => goToPage(event, "home")}>
+          <GitPullRequest className="h-4 w-4" />
+          Pull Requests
+        </a>
+        <a
+          href="/repositories"
+          className={navItemClass(page === "repositories")}
+          onClick={(event) => goToPage(event, "repositories")}
+        >
+          <ListTree className="h-4 w-4" />
+          Activity
+        </a>
+        <a href="/accounts" className={navItemClass(page === "accounts")} onClick={(event) => goToPage(event, "accounts")}>
+          <UserRound className="h-4 w-4" />
+          Accounts
+        </a>
+      </nav>
+
+      {page === "repositories" ? (
+        <ActivityRepositoriesPage
+          installations={installations}
+          repositoryCount={repositoryCount}
+          onNavigate={onNavigate}
+        />
+      ) : page === "accounts" ? (
+        <AccountsPage
+          githubApp={githubApp}
+          installations={installations}
+          authorizedRepositories={authorizedRepositories}
+          loadingRepositoriesFor={loadingRepositoriesFor}
+          onDeleteInstallation={onDeleteInstallation}
+          onLoadAuthorizedRepositories={onLoadAuthorizedRepositories}
+        />
+      ) : (
+        <PullRequestsPage
+          groups={groups}
+          hasInstallations={hasInstallations}
+          selected={selected}
+          onSelectKey={onSelectKey}
+          onNavigate={onNavigate}
+        />
+      )}
+    </main>
+  )
+}
+
+function ActivityRepositoriesPage({
+  installations,
+  repositoryCount,
+  onNavigate,
+}: {
+  installations: NonNullable<GitHubAppConfig["installations"]>
+  repositoryCount: number
+  onNavigate: (page: UserPage) => void
+}) {
+  return (
+    <>
+      <section className="border-b bg-muted/35 px-4 py-4 lg:px-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold">Activity repositories</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Local repositories appear here after runnerd observes jobs from them.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">{installations.length} installations</Badge>
+            <Badge variant="secondary">{repositoryCount} active repositories</Badge>
+            <Button type="button" variant="outline" size="sm" onClick={() => onNavigate("accounts")}>
+              <UserRound className="h-4 w-4" />
+              Accounts
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 lg:p-6">
+        {installations.length ? (
+          <div className="grid gap-4">
+            {installations.map((installation) => (
+              <Card key={installation.id} className="rounded-lg">
+                <CardHeader className="gap-3 pb-3">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <CardTitle className="text-base">{installation.account_login || "GitHub App"}</CardTitle>
+                    </div>
+                    <Badge variant="secondary">{installation.repositories.length} active repositories</Badge>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  {installation.repositories.length ? (
+                    <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+                      {installation.repositories.map((repository) => (
+                        <div key={repository} className="rounded-md border bg-muted/25 px-3 py-2">
+                          <div className="truncate text-sm font-medium">{repository}</div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="rounded-md border bg-muted/25 px-3 py-2 text-sm text-muted-foreground">
+                      No repositories have runner jobs for this installation yet.
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
+            <button type="button" className="text-left text-primary hover:underline" onClick={() => onNavigate("accounts")}>
+              Connect a GitHub App account, then trigger a PR workflow to show active repositories here.
+            </button>
+          </div>
+        )}
+      </section>
+    </>
+  )
+}
+
+function AccountsPage({
+  githubApp,
+  installations,
+  authorizedRepositories,
+  loadingRepositoriesFor,
+  onDeleteInstallation,
+  onLoadAuthorizedRepositories,
+}: {
+  githubApp: GitHubAppConfig | null
+  installations: NonNullable<GitHubAppConfig["installations"]>
+  authorizedRepositories: Record<number, string[]>
+  loadingRepositoriesFor: number | null
+  onDeleteInstallation: (id: number) => void
+  onLoadAuthorizedRepositories: (id: number) => void
+}) {
+  const [selectedID, setSelectedID] = useState<number | null>(null)
+  const [filter, setFilter] = useState("")
+  const selected = installations.find((installation) => installation.id === selectedID) || installations[0]
+  const authorized = selected ? authorizedRepositories[selected.id] : undefined
+  const filteredRepositories = useMemo(() => {
+    const query = filter.trim().toLowerCase()
+    const repositories = authorized || []
+    if (!query) return repositories
+    return repositories.filter((repository) => repository.toLowerCase().includes(query))
+  }, [authorized, filter])
+
+  useEffect(() => {
+    if (!selected) {
+      setSelectedID(null)
+      return
+    }
+    if (selectedID !== selected.id) {
+      setSelectedID(selected.id)
+    }
+    if (!authorizedRepositories[selected.id]) {
+      onLoadAuthorizedRepositories(selected.id)
+    }
+  }, [authorizedRepositories, onLoadAuthorizedRepositories, selected, selectedID])
+
+  return (
+    <>
+      <section className="border-b bg-muted/35 px-4 py-4 lg:px-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold">Accounts</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Manage GitHub App accounts and inspect repositories currently authorized on GitHub.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {githubApp?.install_url ? (
+              <Button type="button" asChild>
+                <a href={githubApp.install_url}>
+                  <Github className="h-4 w-4" />
+                  Install GitHub App
+                </a>
+              </Button>
+            ) : (
+              <Badge variant="outline">Set github.app.slug to enable the install link</Badge>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <div className="grid min-h-0 flex-1 lg:grid-cols-[320px_minmax(0,1fr)]">
+        <aside className="min-h-0 border-r bg-muted/20">
+          <div className="flex h-full flex-col">
+            <div className="flex h-12 items-center justify-between border-b px-4">
+              <span className="text-sm font-semibold">GitHub accounts</span>
+              <Badge variant="outline">{installations.length}</Badge>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {installations.length ? (
+                installations.map((installation) => (
+                  <button
+                    key={installation.id}
+                    type="button"
+                    className={cn(
+                      "flex h-14 w-full items-center gap-3 border-b px-4 text-left transition-colors hover:bg-accent",
+                      selected?.id === installation.id ? "bg-accent" : ""
+                    )}
+                    onClick={() => {
+                      setSelectedID(installation.id)
+                      setFilter("")
+                      if (!authorizedRepositories[installation.id]) onLoadAuthorizedRepositories(installation.id)
+                    }}
+                  >
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-foreground text-xs font-semibold text-background">
+                      {(installation.account_login || "GH").slice(0, 2).toUpperCase()}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-semibold">{installation.account_login || "GitHub App"}</div>
+                    </div>
+                  </button>
+                ))
+              ) : (
+                <div className="p-4 text-sm text-muted-foreground">
+                  Install the GitHub App to connect a user or organization account.
+                </div>
+              )}
+            </div>
+          </div>
+        </aside>
+
+        <section className="min-h-0 overflow-y-auto p-4 lg:p-6">
+          {selected ? (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-2xl font-semibold">{selected.account_login || "GitHub App"}</h2>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button type="button" variant="outline" size="sm" asChild>
+                    <a href={`https://github.com/settings/installations/${selected.installation_id}`}>
+                      <Github className="h-4 w-4" />
+                      Manage on GitHub
+                    </a>
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => onDeleteInstallation(selected.id)}
+                    aria-label="Delete installation"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <Card className="rounded-lg">
+                <CardHeader className="gap-3 pb-3">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <CardTitle className="text-base">Authorized repositories</CardTitle>
+                      <CardDescription>Loaded from GitHub App authorization for this account.</CardDescription>
+                    </div>
+                    <Badge variant="secondary">
+                      {authorized ? `${authorized.length} repositories` : "Not loaded"}
+                    </Badge>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <input
+                    className="h-9 w-full rounded-md border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    placeholder="Filter GitHub repositories"
+                    value={filter}
+                    onChange={(event) => setFilter(event.target.value)}
+                  />
+                  {loadingRepositoriesFor === selected.id ? (
+                    <div className="rounded-md border bg-muted/25 px-3 py-2 text-sm text-muted-foreground">
+                      Loading repositories from GitHub...
+                    </div>
+                  ) : filteredRepositories.length ? (
+                    <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+                      {filteredRepositories.map((repository) => (
+                        <div key={repository} className="rounded-md border bg-muted/25 px-3 py-2">
+                          <div className="truncate text-sm font-medium">{repository}</div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="rounded-md border bg-muted/25 px-3 py-2 text-sm text-muted-foreground">
+                      {authorized ? "No repositories match the current filter." : "Select this account to load repositories."}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          ) : (
+            <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
+              Install the GitHub App to connect a user or organization account.
+            </div>
+          )}
+        </section>
+      </div>
+    </>
+  )
+}
+
+function PullRequestsPage({
+  groups,
+  hasInstallations,
+  selected,
+  onSelectKey,
+  onNavigate,
+}: {
+  groups: PRGroup[]
+  hasInstallations: boolean
+  selected: PRGroup | undefined
+  onSelectKey: (key: string) => void
+  onNavigate: (page: UserPage) => void
+}) {
+  return (
+    <>
+      <section className="border-b bg-muted/35 px-4 py-4 lg:px-6">
+        <div className="space-y-3">
+          <div>
+            <h1 className="text-xl font-semibold">Pull requests</h1>
+            <p className="text-sm text-muted-foreground">
+              Review pull requests and the runner jobs currently attached to them.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid min-h-0 flex-1 xl:grid-cols-[360px_minmax(0,1fr)]">
+        <aside className="min-h-0 border-r bg-muted/20">
+          <div className="flex h-full flex-col">
+            <div className="flex h-12 items-center justify-between border-b px-4">
+              <span className="text-sm font-semibold">Repo + PR</span>
+              <Badge variant="outline">{groups.length}</Badge>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {groups.length ? (
+                groups.map((group) => (
+                  <button
+                    key={group.key}
+                    type="button"
+                    onClick={() => onSelectKey(group.key)}
+                    className={cn(
+                      "flex w-full flex-col gap-2 border-b px-4 py-3 text-left transition-colors hover:bg-accent",
+                      selected?.key === group.key ? "bg-accent" : ""
+                    )}
+                  >
+                    <div className="flex items-center gap-2">
+                      <GitPullRequest className="h-4 w-4 text-primary" />
+                      <span className="truncate text-sm font-semibold">{group.prLabel}</span>
+                    </div>
+                    <div className="truncate text-xs text-muted-foreground">{group.repository}</div>
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary">{group.jobs.length} jobs</Badge>
+                      <span className="text-xs text-muted-foreground">{formatTime(group.updatedAt)}</span>
+                    </div>
+                  </button>
+                ))
+              ) : (
+                <div className="p-4 text-sm text-muted-foreground">
+                  {hasInstallations ? (
+                    "No PR jobs yet. Trigger a workflow in an installed repository, then refresh."
+                  ) : (
+                    <button
+                      type="button"
+                      className="text-left text-primary hover:underline"
+                      onClick={() => onNavigate("accounts")}
+                    >
+                      Connect a GitHub App account to start tracking PR jobs.
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </aside>
+
+        <section className="min-h-0 overflow-y-auto p-4 lg:p-6">
+          {selected ? (
+            <div className="space-y-4">
+              <div>
+                <div className="text-sm text-muted-foreground">{selected.repository}</div>
+                <h2 className="text-2xl font-semibold">{selected.prLabel}</h2>
+              </div>
+              <div className="grid gap-3">
+                {selected.jobs.map((job) => (
+                  <Card key={job.id} className="rounded-lg">
+                    <CardHeader className="gap-3 pb-3">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <CardTitle className="text-base">{job.assigned_job_name || job.runner_name}</CardTitle>
+                          <CardDescription>{job.id}</CardDescription>
+                        </div>
+                        <Badge className={userStatusClass(job.status)}>{job.status}</Badge>
+                      </div>
+                    </CardHeader>
+                    <CardContent className="grid gap-3 text-sm md:grid-cols-3">
+                      <JobField label="Runner spec" value={job.runner_spec_name || "matched by labels"} />
+                      <JobField label="Workflow run" value={job.workflow_run_id ? String(job.workflow_run_id) : "unknown"} />
+                      <JobField label="Updated" value={formatTime(job.updated_at)} />
+                      {job.github_job_url ? (
+                        <>
+                          <Separator className="md:col-span-3" />
+                          <a className="text-sm font-medium text-primary hover:underline md:col-span-3" href={job.github_job_url}>
+                            Open GitHub Actions job
+                          </a>
+                        </>
+                      ) : null}
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
+              {hasInstallations ? (
+                "No runner jobs are available yet. Trigger a PR workflow in an installed repository to see jobs here."
+              ) : (
+                <button
+                  type="button"
+                  className="text-left text-primary hover:underline"
+                  onClick={() => onNavigate("accounts")}
+                >
+                  Connect a GitHub App account to start tracking PR jobs.
+                </button>
+              )}
+            </div>
+          )}
+        </section>
+      </div>
+    </>
+  )
+}
+
+function JobField({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="mt-1 break-words font-medium">{value}</div>
+    </div>
+  )
+}
+
+function groupRunnersByPR(runners: RunnerState[]): PRGroup[] {
+  const groups = new Map<string, PRGroup>()
+  for (const runner of runners) {
+    const repository = runner.repository_full_name || "unknown/repository"
+    const pr = runner.pull_request_number ? `PR #${runner.pull_request_number}` : "Manual or workflow job"
+    const key = `${repository}:${runner.pull_request_number || runner.workflow_run_id || runner.id}`
+    const current = groups.get(key)
+    if (current) {
+      current.jobs.push(runner)
+      if (runner.updated_at > current.updatedAt) current.updatedAt = runner.updated_at
+      continue
+    }
+    groups.set(key, {
+      key,
+      repository,
+      prLabel: pr,
+      updatedAt: runner.updated_at,
+      jobs: [runner],
+    })
+  }
+  return Array.from(groups.values()).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+}
+
+function userStatusClass(status: RunnerState["status"]) {
+  switch (status) {
+    case "running":
+      return "bg-emerald-500 text-white"
+    case "queued":
+    case "creating":
+    case "stopping":
+      return "bg-blue-500 text-white"
+    case "completed":
+      return "bg-muted text-foreground"
+    case "failed":
+      return "bg-destructive text-destructive-foreground"
+    default:
+      return ""
+  }
+}

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -1,4 +1,4 @@
-import { Github, GitPullRequest, ListTree, LogOut, Trash2, UserRound } from "lucide-react"
+import { Github, ListTree, LogOut, Trash2, UserRound, Workflow } from "lucide-react"
 import { type MouseEvent, useEffect, useMemo, useState } from "react"
 
 import type { AuthSession, GitHubAppConfig, RunnerState } from "@/admin-types"
@@ -50,10 +50,6 @@ export function UserDashboard({
   const selected = groups.find((group) => group.key === selectedKey) || groups[0]
   const installations = githubApp?.installations ?? []
   const hasInstallations = installations.length > 0
-  const repositoryCount = useMemo(
-    () => new Set(installations.flatMap((installation) => installation.repositories)).size,
-    [installations]
-  )
   const navItemClass = (active: boolean) =>
     cn(
       "inline-flex h-9 items-center gap-2 rounded-md px-3 text-sm font-medium transition-colors",
@@ -76,8 +72,8 @@ export function UserDashboard({
         </div>
         <nav className="ml-3 hidden items-center gap-1 md:flex" aria-label="Workspace">
           <a href="/" className={navItemClass(page === "home")} onClick={(event) => goToPage(event, "home")}>
-            <GitPullRequest className="h-4 w-4" />
-            Pull Requests
+            <Workflow className="h-4 w-4" />
+            Jobs
           </a>
           <a
             href="/repositories"
@@ -85,7 +81,7 @@ export function UserDashboard({
             onClick={(event) => goToPage(event, "repositories")}
           >
             <ListTree className="h-4 w-4" />
-            Activity
+            Repositories
           </a>
           <a href="/accounts" className={navItemClass(page === "accounts")} onClick={(event) => goToPage(event, "accounts")}>
             <UserRound className="h-4 w-4" />
@@ -101,8 +97,8 @@ export function UserDashboard({
 
       <nav className="flex items-center gap-1 border-b px-4 py-2 md:hidden" aria-label="Workspace">
         <a href="/" className={navItemClass(page === "home")} onClick={(event) => goToPage(event, "home")}>
-          <GitPullRequest className="h-4 w-4" />
-          Pull Requests
+          <Workflow className="h-4 w-4" />
+          Jobs
         </a>
         <a
           href="/repositories"
@@ -110,7 +106,7 @@ export function UserDashboard({
           onClick={(event) => goToPage(event, "repositories")}
         >
           <ListTree className="h-4 w-4" />
-          Activity
+          Repositories
         </a>
         <a href="/accounts" className={navItemClass(page === "accounts")} onClick={(event) => goToPage(event, "accounts")}>
           <UserRound className="h-4 w-4" />
@@ -121,8 +117,6 @@ export function UserDashboard({
       {page === "repositories" ? (
         <ActivityRepositoriesPage
           installations={installations}
-          repositoryCount={repositoryCount}
-          onNavigate={onNavigate}
         />
       ) : page === "accounts" ? (
         <AccountsPage
@@ -148,51 +142,86 @@ export function UserDashboard({
 
 function ActivityRepositoriesPage({
   installations,
-  repositoryCount,
-  onNavigate,
 }: {
   installations: NonNullable<GitHubAppConfig["installations"]>
-  repositoryCount: number
-  onNavigate: (page: UserPage) => void
 }) {
+  const [selectedID, setSelectedID] = useState<number | null>(null)
+  const selected = installations.find((installation) => installation.id === selectedID) || installations[0]
+
+  useEffect(() => {
+    if (!selected) {
+      setSelectedID(null)
+      return
+    }
+    if (selectedID !== selected.id) {
+      setSelectedID(selected.id)
+    }
+  }, [selected, selectedID])
+
   return (
     <>
       <section className="border-b bg-muted/35 px-4 py-4 lg:px-6">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <h1 className="text-xl font-semibold">Activity repositories</h1>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Local repositories appear here after runnerd observes jobs from them.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="secondary">{installations.length} installations</Badge>
-            <Badge variant="secondary">{repositoryCount} active repositories</Badge>
-            <Button type="button" variant="outline" size="sm" onClick={() => onNavigate("accounts")}>
-              <UserRound className="h-4 w-4" />
-              Accounts
-            </Button>
-          </div>
+        <div>
+          <h1 className="text-xl font-semibold">Repositories</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Local repositories appear here after runnerd observes jobs from them.
+          </p>
         </div>
       </section>
 
-      <section className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 lg:p-6">
-        {installations.length ? (
-          <div className="grid gap-4">
-            {installations.map((installation) => (
-              <Card key={installation.id} className="rounded-lg">
-                <CardHeader className="gap-3 pb-3">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <CardTitle className="text-base">{installation.account_login || "GitHub App"}</CardTitle>
+      <div className="grid min-h-0 flex-1 lg:grid-cols-[320px_minmax(0,1fr)]">
+        <aside className="min-h-0 border-r bg-muted/20">
+          <div className="flex h-full flex-col">
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {installations.length ? (
+                installations.map((installation) => (
+                  <button
+                    key={installation.id}
+                    type="button"
+                    className={cn(
+                      "flex h-14 w-full items-center gap-3 border-b px-4 text-left transition-colors hover:bg-accent",
+                      selected?.id === installation.id ? "bg-accent" : ""
+                    )}
+                    onClick={() => setSelectedID(installation.id)}
+                  >
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-foreground text-xs font-semibold text-background">
+                      {(installation.account_login || "GH").slice(0, 2).toUpperCase()}
                     </div>
-                    <Badge variant="secondary">{installation.repositories.length} active repositories</Badge>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-semibold">{installation.account_login || "GitHub App"}</div>
+                    </div>
+                  </button>
+                ))
+              ) : (
+                <div className="p-4 text-sm text-muted-foreground">
+                  Connect a GitHub App account, then trigger a workflow job to show active repositories here.
+                </div>
+              )}
+            </div>
+          </div>
+        </aside>
+
+        <section className="min-h-0 overflow-y-auto p-4 lg:p-6">
+          {selected ? (
+            <div className="space-y-4">
+              <div>
+                <h2 className="text-2xl font-semibold">{selected.account_login || "GitHub App"}</h2>
+              </div>
+
+              <Card className="rounded-lg">
+                <CardHeader className="gap-3 pb-3">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <CardTitle className="text-base">Active repositories</CardTitle>
+                      <CardDescription>Local repositories with observed runner jobs.</CardDescription>
+                    </div>
+                    <Badge variant="secondary">{selected.repositories.length} repositories</Badge>
                   </div>
                 </CardHeader>
                 <CardContent>
-                  {installation.repositories.length ? (
+                  {selected.repositories.length ? (
                     <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
-                      {installation.repositories.map((repository) => (
+                      {selected.repositories.map((repository) => (
                         <div key={repository} className="rounded-md border bg-muted/25 px-3 py-2">
                           <div className="truncate text-sm font-medium">{repository}</div>
                         </div>
@@ -200,21 +229,19 @@ function ActivityRepositoriesPage({
                     </div>
                   ) : (
                     <div className="rounded-md border bg-muted/25 px-3 py-2 text-sm text-muted-foreground">
-                      No repositories have runner jobs for this installation yet.
+                      No repositories have runner jobs for this account yet.
                     </div>
                   )}
                 </CardContent>
               </Card>
-            ))}
-          </div>
-        ) : (
-          <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
-            <button type="button" className="text-left text-primary hover:underline" onClick={() => onNavigate("accounts")}>
-              Connect a GitHub App account, then trigger a PR workflow to show active repositories here.
-            </button>
-          </div>
-        )}
-      </section>
+            </div>
+          ) : (
+            <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
+              Connect a GitHub App account, then trigger a workflow job to show active repositories here.
+            </div>
+          )}
+        </section>
+      </div>
     </>
   )
 }
@@ -286,10 +313,6 @@ function AccountsPage({
       <div className="grid min-h-0 flex-1 lg:grid-cols-[320px_minmax(0,1fr)]">
         <aside className="min-h-0 border-r bg-muted/20">
           <div className="flex h-full flex-col">
-            <div className="flex h-12 items-center justify-between border-b px-4">
-              <span className="text-sm font-semibold">GitHub accounts</span>
-              <Badge variant="outline">{installations.length}</Badge>
-            </div>
             <div className="min-h-0 flex-1 overflow-y-auto">
               {installations.length ? (
                 installations.map((installation) => (
@@ -416,23 +439,17 @@ function PullRequestsPage({
   return (
     <>
       <section className="border-b bg-muted/35 px-4 py-4 lg:px-6">
-        <div className="space-y-3">
-          <div>
-            <h1 className="text-xl font-semibold">Pull requests</h1>
-            <p className="text-sm text-muted-foreground">
-              Review pull requests and the runner jobs currently attached to them.
-            </p>
-          </div>
+        <div>
+          <h1 className="text-xl font-semibold">Jobs</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Review runner jobs grouped by repository, pull request, or workflow run.
+          </p>
         </div>
       </section>
 
       <div className="grid min-h-0 flex-1 xl:grid-cols-[360px_minmax(0,1fr)]">
         <aside className="min-h-0 border-r bg-muted/20">
           <div className="flex h-full flex-col">
-            <div className="flex h-12 items-center justify-between border-b px-4">
-              <span className="text-sm font-semibold">Repo + PR</span>
-              <Badge variant="outline">{groups.length}</Badge>
-            </div>
             <div className="min-h-0 flex-1 overflow-y-auto">
               {groups.length ? (
                 groups.map((group) => (
@@ -446,7 +463,7 @@ function PullRequestsPage({
                     )}
                   >
                     <div className="flex items-center gap-2">
-                      <GitPullRequest className="h-4 w-4 text-primary" />
+                      <Workflow className="h-4 w-4 text-primary" />
                       <span className="truncate text-sm font-semibold">{group.prLabel}</span>
                     </div>
                     <div className="truncate text-xs text-muted-foreground">{group.repository}</div>
@@ -459,14 +476,14 @@ function PullRequestsPage({
               ) : (
                 <div className="p-4 text-sm text-muted-foreground">
                   {hasInstallations ? (
-                    "No PR jobs yet. Trigger a workflow in an installed repository, then refresh."
+                    "No jobs yet. Trigger a workflow in an installed repository, then refresh."
                   ) : (
                     <button
                       type="button"
                       className="text-left text-primary hover:underline"
                       onClick={() => onNavigate("accounts")}
                     >
-                      Connect a GitHub App account to start tracking PR jobs.
+                      Connect a GitHub App account to start tracking jobs.
                     </button>
                   )}
                 </div>
@@ -514,14 +531,14 @@ function PullRequestsPage({
           ) : (
             <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
               {hasInstallations ? (
-                "No runner jobs are available yet. Trigger a PR workflow in an installed repository to see jobs here."
+                "No runner jobs are available yet. Trigger a workflow in an installed repository to see jobs here."
               ) : (
                 <button
                   type="button"
                   className="text-left text-primary hover:underline"
                   onClick={() => onNavigate("accounts")}
                 >
-                  Connect a GitHub App account to start tracking PR jobs.
+                  Connect a GitHub App account to start tracking jobs.
                 </button>
               )}
             </div>

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -1,4 +1,5 @@
-import { Github, ListTree, LogOut, Trash2, UserRound, Workflow } from "lucide-react"
+import { BookOpen, Github, LogOut, Monitor, Moon, Settings, ShieldCheck, Sun, Workflow } from "lucide-react"
+import { useTheme } from "next-themes"
 import { type MouseEvent, useEffect, useMemo, useState } from "react"
 
 import type { AuthSession, GitHubAppConfig, RunnerState } from "@/admin-types"
@@ -6,7 +7,18 @@ import { formatTime } from "@/admin-format"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Separator } from "@/components/ui/separator"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { cn } from "@/lib/utils"
 
 type PRGroup = {
@@ -17,7 +29,12 @@ type PRGroup = {
   jobs: RunnerState[]
 }
 
-type UserPage = "home" | "repositories" | "accounts"
+type UserPage = "home" | "repositories" | "settings"
+type AccountSettingsTab = "repositories" | "preferences"
+type AccountSettingsRoute = {
+  accountLogin?: string
+  tab: AccountSettingsTab
+}
 
 export function UserDashboard({
   authSession,
@@ -25,11 +42,12 @@ export function UserDashboard({
   runners,
   selectedKey,
   page,
+  accountSettingsRoute,
   authorizedRepositories,
   loadingRepositoriesFor,
-  onDeleteInstallation,
   onLoadAuthorizedRepositories,
   onNavigate,
+  onNavigateAccountSettings,
   onSelectKey,
   onSignOut,
 }: {
@@ -38,17 +56,21 @@ export function UserDashboard({
   runners: RunnerState[]
   selectedKey: string
   page: UserPage
+  accountSettingsRoute: AccountSettingsRoute
   authorizedRepositories: Record<number, string[]>
   loadingRepositoriesFor: number | null
-  onDeleteInstallation: (id: number) => void
   onLoadAuthorizedRepositories: (id: number) => void
   onNavigate: (page: UserPage) => void
+  onNavigateAccountSettings: (accountLogin: string | undefined, tab: AccountSettingsTab) => void
   onSelectKey: (key: string) => void
   onSignOut: () => void
 }) {
   const groups = useMemo(() => groupRunnersByPR(runners), [runners])
   const selected = groups.find((group) => group.key === selectedKey) || groups[0]
-  const installations = githubApp?.installations ?? []
+  const installations = useMemo(
+    () => orderInstallationsByCurrentAccount(githubApp?.installations ?? [], authSession.login),
+    [authSession.login, githubApp?.installations]
+  )
   const hasInstallations = installations.length > 0
   const navItemClass = (active: boolean) =>
     cn(
@@ -67,8 +89,7 @@ export function UserDashboard({
           <Github className="h-4 w-4" />
         </div>
         <div>
-          <div className="text-sm font-semibold">E2B Runner Console</div>
-          <div className="text-xs text-muted-foreground">@{authSession.login} workspace</div>
+          <div className="text-sm font-semibold">Qiniu Runner</div>
         </div>
         <nav className="ml-3 hidden items-center gap-1 md:flex" aria-label="Workspace">
           <a href="/" className={navItemClass(page === "home")} onClick={(event) => goToPage(event, "home")}>
@@ -80,18 +101,16 @@ export function UserDashboard({
             className={navItemClass(page === "repositories")}
             onClick={(event) => goToPage(event, "repositories")}
           >
-            <ListTree className="h-4 w-4" />
+            <BookOpen className="h-4 w-4" />
             Repositories
           </a>
-          <a href="/accounts" className={navItemClass(page === "accounts")} onClick={(event) => goToPage(event, "accounts")}>
-            <UserRound className="h-4 w-4" />
-            Accounts
+          <a href="/account/repositories" className={navItemClass(page === "settings")} onClick={(event) => goToPage(event, "settings")}>
+            <Settings className="h-4 w-4" />
+            Settings
           </a>
         </nav>
         <div className="ml-auto flex items-center gap-2">
-          <Button type="button" variant="ghost" size="icon" onClick={onSignOut} aria-label="Sign out">
-            <LogOut className="h-4 w-4" />
-          </Button>
+          <UserMenu authSession={authSession} onSignOut={onSignOut} />
         </div>
       </header>
 
@@ -105,12 +124,12 @@ export function UserDashboard({
           className={navItemClass(page === "repositories")}
           onClick={(event) => goToPage(event, "repositories")}
         >
-          <ListTree className="h-4 w-4" />
+          <BookOpen className="h-4 w-4" />
           Repositories
         </a>
-        <a href="/accounts" className={navItemClass(page === "accounts")} onClick={(event) => goToPage(event, "accounts")}>
-          <UserRound className="h-4 w-4" />
-          Accounts
+        <a href="/account/repositories" className={navItemClass(page === "settings")} onClick={(event) => goToPage(event, "settings")}>
+          <Settings className="h-4 w-4" />
+          Settings
         </a>
       </nav>
 
@@ -118,14 +137,15 @@ export function UserDashboard({
         <ActivityRepositoriesPage
           installations={installations}
         />
-      ) : page === "accounts" ? (
+      ) : page === "settings" ? (
         <AccountsPage
           githubApp={githubApp}
           installations={installations}
           authorizedRepositories={authorizedRepositories}
           loadingRepositoriesFor={loadingRepositoriesFor}
-          onDeleteInstallation={onDeleteInstallation}
+          route={accountSettingsRoute}
           onLoadAuthorizedRepositories={onLoadAuthorizedRepositories}
+          onNavigateAccountSettings={onNavigateAccountSettings}
         />
       ) : (
         <PullRequestsPage
@@ -184,9 +204,7 @@ function ActivityRepositoriesPage({
                     )}
                     onClick={() => setSelectedID(installation.id)}
                   >
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-foreground text-xs font-semibold text-background">
-                      {(installation.account_login || "GH").slice(0, 2).toUpperCase()}
-                    </div>
+                    <AccountAvatar installation={installation} size="sm" />
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-sm font-semibold">{installation.account_login || "GitHub App"}</div>
                     </div>
@@ -204,8 +222,12 @@ function ActivityRepositoriesPage({
         <section className="min-h-0 overflow-y-auto p-4 lg:p-6">
           {selected ? (
             <div className="space-y-4">
-              <div>
-                <h2 className="text-2xl font-semibold">{selected.account_login || "GitHub App"}</h2>
+              <div className="flex items-center gap-3">
+                <AccountAvatar installation={selected} size="lg" />
+                <div className="min-w-0">
+                  <h2 className="truncate text-2xl font-semibold">{accountDisplayName(selected)}</h2>
+                  <div className="truncate text-sm text-muted-foreground">{selected.account_login || "GitHub"}</div>
+                </div>
               </div>
 
               <Card className="rounded-lg">
@@ -251,19 +273,21 @@ function AccountsPage({
   installations,
   authorizedRepositories,
   loadingRepositoriesFor,
-  onDeleteInstallation,
+  route,
   onLoadAuthorizedRepositories,
+  onNavigateAccountSettings,
 }: {
   githubApp: GitHubAppConfig | null
   installations: NonNullable<GitHubAppConfig["installations"]>
   authorizedRepositories: Record<number, string[]>
   loadingRepositoriesFor: number | null
-  onDeleteInstallation: (id: number) => void
+  route: AccountSettingsRoute
   onLoadAuthorizedRepositories: (id: number) => void
+  onNavigateAccountSettings: (accountLogin: string | undefined, tab: AccountSettingsTab) => void
 }) {
-  const [selectedID, setSelectedID] = useState<number | null>(null)
   const [filter, setFilter] = useState("")
-  const selected = installations.find((installation) => installation.id === selectedID) || installations[0]
+  const selected =
+    installations.find((installation) => installation.account_login === route.accountLogin) || installations[0]
   const authorized = selected ? authorizedRepositories[selected.id] : undefined
   const filteredRepositories = useMemo(() => {
     const query = filter.trim().toLowerCase()
@@ -273,26 +297,20 @@ function AccountsPage({
   }, [authorized, filter])
 
   useEffect(() => {
-    if (!selected) {
-      setSelectedID(null)
-      return
-    }
-    if (selectedID !== selected.id) {
-      setSelectedID(selected.id)
-    }
+    if (!selected) return
     if (!authorizedRepositories[selected.id]) {
       onLoadAuthorizedRepositories(selected.id)
     }
-  }, [authorizedRepositories, onLoadAuthorizedRepositories, selected, selectedID])
+  }, [authorizedRepositories, onLoadAuthorizedRepositories, selected])
 
   return (
     <>
       <section className="border-b bg-muted/35 px-4 py-4 lg:px-6">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
-            <h1 className="text-xl font-semibold">Accounts</h1>
+            <h1 className="text-xl font-semibold">Settings</h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              Manage GitHub App accounts and inspect repositories currently authorized on GitHub.
+              Configure repository access and runner preferences for GitHub users and organizations.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -324,14 +342,12 @@ function AccountsPage({
                       selected?.id === installation.id ? "bg-accent" : ""
                     )}
                     onClick={() => {
-                      setSelectedID(installation.id)
+                      onNavigateAccountSettings(installation.account_login, route.tab)
                       setFilter("")
                       if (!authorizedRepositories[installation.id]) onLoadAuthorizedRepositories(installation.id)
                     }}
                   >
-                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-foreground text-xs font-semibold text-background">
-                      {(installation.account_login || "GH").slice(0, 2).toUpperCase()}
-                    </div>
+                    <AccountAvatar installation={installation} size="sm" />
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-sm font-semibold">{installation.account_login || "GitHub App"}</div>
                     </div>
@@ -339,7 +355,7 @@ function AccountsPage({
                 ))
               ) : (
                 <div className="p-4 text-sm text-muted-foreground">
-                  Install the GitHub App to connect a user or organization account.
+                  Install the GitHub App to connect a user or organization.
                 </div>
               )}
             </div>
@@ -349,72 +365,101 @@ function AccountsPage({
         <section className="min-h-0 overflow-y-auto p-4 lg:p-6">
           {selected ? (
             <div className="space-y-4">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <h2 className="text-2xl font-semibold">{selected.account_login || "GitHub App"}</h2>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button type="button" variant="outline" size="sm" asChild>
-                    <a href={`https://github.com/settings/installations/${selected.installation_id}`}>
-                      <Github className="h-4 w-4" />
-                      Manage on GitHub
-                    </a>
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8"
-                    onClick={() => onDeleteInstallation(selected.id)}
-                    aria-label="Delete installation"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+              <div className="flex items-center gap-3">
+                <AccountAvatar installation={selected} size="lg" />
+                <div className="min-w-0">
+                  <h2 className="truncate text-2xl font-semibold">{accountDisplayName(selected)}</h2>
+                  <div className="truncate text-sm text-muted-foreground">{selected.account_login || "GitHub"}</div>
                 </div>
               </div>
 
-              <Card className="rounded-lg">
-                <CardHeader className="gap-3 pb-3">
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                      <CardTitle className="text-base">Authorized repositories</CardTitle>
-                      <CardDescription>Loaded from GitHub App authorization for this account.</CardDescription>
-                    </div>
-                    <Badge variant="secondary">
-                      {authorized ? `${authorized.length} repositories` : "Not loaded"}
-                    </Badge>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  <input
-                    className="h-9 w-full rounded-md border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    placeholder="Filter GitHub repositories"
-                    value={filter}
-                    onChange={(event) => setFilter(event.target.value)}
-                  />
-                  {loadingRepositoriesFor === selected.id ? (
-                    <div className="rounded-md border bg-muted/25 px-3 py-2 text-sm text-muted-foreground">
-                      Loading repositories from GitHub...
-                    </div>
-                  ) : filteredRepositories.length ? (
-                    <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
-                      {filteredRepositories.map((repository) => (
-                        <div key={repository} className="rounded-md border bg-muted/25 px-3 py-2">
-                          <div className="truncate text-sm font-medium">{repository}</div>
+              <Tabs
+                value={route.tab}
+                onValueChange={(value) => onNavigateAccountSettings(selected.account_login, value as AccountSettingsTab)}
+                className="gap-4"
+              >
+                <TabsList className="h-auto w-full justify-start rounded-none border-b bg-transparent p-0">
+                  <TabsTrigger
+                    value="repositories"
+                    className="mr-8 h-10 flex-none rounded-none border-0 border-b-2 border-transparent bg-transparent px-0 py-2 shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
+                  >
+                    Repositories
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="preferences"
+                    className="h-10 flex-none rounded-none border-0 border-b-2 border-transparent bg-transparent px-0 py-2 shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
+                  >
+                    Preferences
+                  </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="repositories">
+                  <Card className="rounded-lg">
+                    <CardHeader className="gap-3 pb-3">
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                          <CardTitle className="text-base">Authorized repositories</CardTitle>
+                          <CardDescription>Repositories currently authorized for this GitHub App installation.</CardDescription>
                         </div>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="rounded-md border bg-muted/25 px-3 py-2 text-sm text-muted-foreground">
-                      {authorized ? "No repositories match the current filter." : "Select this account to load repositories."}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge variant="secondary">
+                            {authorized ? `${authorized.length} repositories` : "Not loaded"}
+                          </Badge>
+                          <Button type="button" variant="outline" size="sm" asChild>
+                            <a href={`https://github.com/settings/installations/${selected.installation_id}`}>
+                              <Github className="h-4 w-4" />
+                              Manage on GitHub
+                            </a>
+                          </Button>
+                        </div>
+                      </div>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                      <input
+                        className="h-9 w-full rounded-md border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        placeholder="Filter GitHub repositories"
+                        value={filter}
+                        onChange={(event) => setFilter(event.target.value)}
+                      />
+                      {loadingRepositoriesFor === selected.id ? (
+                        <div className="rounded-md border bg-muted/25 px-3 py-2 text-sm text-muted-foreground">
+                          Loading repositories from GitHub...
+                        </div>
+                      ) : filteredRepositories.length ? (
+                        <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+                          {filteredRepositories.map((repository) => (
+                            <div key={repository} className="rounded-md border bg-muted/25 px-3 py-2">
+                              <div className="truncate text-sm font-medium">{repository}</div>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="rounded-md border bg-muted/25 px-3 py-2 text-sm text-muted-foreground">
+                          {authorized ? "No repositories match the current filter." : "Select this account to load repositories."}
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+
+                <TabsContent value="preferences">
+                  <Card className="rounded-lg">
+                    <CardHeader>
+                      <CardTitle className="text-base">Runner preferences</CardTitle>
+                      <CardDescription>Runner platform preferences for this account.</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="rounded-md border bg-muted/25 px-3 py-2 text-sm text-muted-foreground">
+                        No runner platform settings are configured for this account yet.
+                      </div>
+                    </CardContent>
+                  </Card>
+                </TabsContent>
+              </Tabs>
             </div>
           ) : (
             <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
-              Install the GitHub App to connect a user or organization account.
+              Install the GitHub App to connect a user or organization.
             </div>
           )}
         </section>
@@ -481,7 +526,7 @@ function PullRequestsPage({
                     <button
                       type="button"
                       className="text-left text-primary hover:underline"
-                      onClick={() => onNavigate("accounts")}
+                      onClick={() => onNavigate("settings")}
                     >
                       Connect a GitHub App account to start tracking jobs.
                     </button>
@@ -536,7 +581,7 @@ function PullRequestsPage({
                 <button
                   type="button"
                   className="text-left text-primary hover:underline"
-                  onClick={() => onNavigate("accounts")}
+                  onClick={() => onNavigate("settings")}
                 >
                   Connect a GitHub App account to start tracking jobs.
                 </button>
@@ -546,6 +591,68 @@ function PullRequestsPage({
         </section>
       </div>
     </>
+  )
+}
+
+function UserMenu({ authSession, onSignOut }: { authSession: AuthSession; onSignOut: () => void }) {
+  const { setTheme, theme } = useTheme()
+  const avatarURL = userAvatarURL(authSession)
+  const login = authSession.login || "github"
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="ghost" size="icon" className="rounded-full" aria-label="Account menu">
+          {avatarURL ? (
+            <img
+              src={avatarURL}
+              alt=""
+              className="h-8 w-8 rounded-full border bg-muted object-cover"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <span className="flex h-8 w-8 items-center justify-center rounded-full border bg-muted text-xs font-semibold">
+              {userInitials(login)}
+            </span>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel className="truncate">{login}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">Theme</DropdownMenuLabel>
+        <DropdownMenuRadioGroup value={theme || "system"} onValueChange={setTheme}>
+          <DropdownMenuRadioItem value="light">
+            <Sun className="h-4 w-4" />
+            Light
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="dark">
+            <Moon className="h-4 w-4" />
+            Dark
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="system">
+            <Monitor className="h-4 w-4" />
+            System
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        {authSession.role === "admin" ? (
+          <>
+            <DropdownMenuItem asChild>
+              <a href="/admin/">
+                <ShieldCheck className="h-4 w-4" />
+                Admin
+              </a>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        ) : null}
+        <DropdownMenuItem onClick={onSignOut}>
+          <LogOut className="h-4 w-4" />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 
@@ -579,6 +686,77 @@ function groupRunnersByPR(runners: RunnerState[]): PRGroup[] {
     })
   }
   return Array.from(groups.values()).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+}
+
+function orderInstallationsByCurrentAccount(
+  installations: NonNullable<GitHubAppConfig["installations"]>,
+  currentLogin?: string
+) {
+  const login = (currentLogin || "").toLowerCase()
+  return [...installations].sort((a, b) => {
+    const aLogin = a.account_login || ""
+    const bLogin = b.account_login || ""
+    const aIsCurrent = aLogin.toLowerCase() === login
+    const bIsCurrent = bLogin.toLowerCase() === login
+    if (aIsCurrent !== bIsCurrent) return aIsCurrent ? -1 : 1
+    return aLogin.localeCompare(bLogin)
+  })
+}
+
+function AccountAvatar({
+  installation,
+  size,
+}: {
+  installation: NonNullable<GitHubAppConfig["installations"]>[number]
+  size: "sm" | "lg"
+}) {
+  const className =
+    size === "lg"
+      ? "flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-md bg-foreground text-sm font-semibold text-background"
+      : "flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-md bg-foreground text-xs font-semibold text-background"
+  const label = accountInitials(installation)
+  const avatarURL = accountAvatarURL(installation)
+  if (avatarURL) {
+    return (
+      <img
+        className={className}
+        src={avatarURL}
+        alt={`${installation.account_login || "GitHub"} avatar`}
+      />
+    )
+  }
+  return <div className={className}>{label}</div>
+}
+
+function accountDisplayName(installation: NonNullable<GitHubAppConfig["installations"]>[number]) {
+  return installation.account_name || installation.account_login || "GitHub App"
+}
+
+function accountInitials(installation: NonNullable<GitHubAppConfig["installations"]>[number]) {
+  return accountDisplayName(installation).slice(0, 2).toUpperCase()
+}
+
+function accountAvatarURL(installation: NonNullable<GitHubAppConfig["installations"]>[number]) {
+  if (installation.account_avatar) return installation.account_avatar
+  if (!installation.account_login) return ""
+  return `https://github.com/${encodeURIComponent(installation.account_login)}.png?size=96`
+}
+
+function userAvatarURL(authSession: AuthSession) {
+  if (authSession.avatar_url) return authSession.avatar_url
+  if (!authSession.login) return ""
+  return `https://github.com/${encodeURIComponent(authSession.login)}.png?size=96`
+}
+
+function userInitials(login: string) {
+  return (
+    login
+      .split(/[-_\s]+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase())
+      .join("") || "GH"
+  )
 }
 
 function userStatusClass(status: RunnerState["status"]) {

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -104,10 +104,6 @@ export function UserDashboard({
             <BookOpen className="h-4 w-4" />
             Repositories
           </a>
-          <a href="/account/repositories" className={navItemClass(page === "settings")} onClick={(event) => goToPage(event, "settings")}>
-            <Settings className="h-4 w-4" />
-            Settings
-          </a>
         </nav>
         <div className="ml-auto flex items-center gap-2">
           <UserMenu authSession={authSession} onSignOut={onSignOut} />
@@ -126,10 +122,6 @@ export function UserDashboard({
         >
           <BookOpen className="h-4 w-4" />
           Repositories
-        </a>
-        <a href="/account/repositories" className={navItemClass(page === "settings")} onClick={(event) => goToPage(event, "settings")}>
-          <Settings className="h-4 w-4" />
-          Settings
         </a>
       </nav>
 
@@ -619,6 +611,13 @@ function UserMenu({ authSession, onSignOut }: { authSession: AuthSession; onSign
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuLabel className="truncate">{login}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <a href="/account/repositories">
+            <Settings className="h-4 w-4" />
+            Settings
+          </a>
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">Theme</DropdownMenuLabel>
         <DropdownMenuRadioGroup value={theme || "system"} onValueChange={setTheme}>

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vite"
 import tailwindcss from "@tailwindcss/vite"
 
 export default defineConfig({
-  base: "/admin/",
+  base: "/",
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {
@@ -15,6 +15,8 @@ export default defineConfig({
       "/audit-events": "http://127.0.0.1:25500",
       "/diagnostics": "http://127.0.0.1:25500",
       "/auth": "http://127.0.0.1:25500",
+      "/user/github-app": "http://127.0.0.1:25500",
+      "/user/runner_requests": "http://127.0.0.1:25500",
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
- implement ordinary-user GitHub App installation and setup sync after GitHub OAuth / App install callbacks
- add user-facing Jobs, Repositories, and account/organization settings flows for GitHub App installations
- track GitHub installation accounts and account metadata in state, with repository/job activity derived from runner records
- polish the dashboard navigation, account menu, avatars, branding, and admin entry points

## Commit breakdown
- `feat(github): add user GitHub App setup UI`
  - Adds GitHub App install/configure support for ordinary users, user APIs, state records, and dashboard views.
- `refactor(ui): simplify user dashboard navigation`
  - Simplifies ordinary-user navigation around Jobs, activity repositories, and account settings.
- `refactor(ui): refine user settings navigation`
  - Routes settings by current account or organization and improves GitHub account display metadata.
- `refactor(ui): move settings into user menu`
  - Moves Settings into the avatar menu so primary navigation stays focused on Jobs and Repositories.

## Validation
- `go test ./internal/state ./internal/server -count=1`
- `bun run tsc -b`
- `git diff --check`

Closes #10
Closes #12
