### PR TITLE
feat(runner): group jobs by build context

### DIFF
--- a/internal/state/conversions.go
+++ b/internal/state/conversions.go
@@ -39,7 +39,7 @@ func recordToRequest(record runnerRequestRecord) (RunnerRequest, error) {
 
 func recordToState(record runnerRequestRecord) RunnerState {
 	requestedLabels, _ := labelsFromJSON(record.RequestedLabelsJSON)
-	githubLinks := githubLinksFromPayload(record)
+	githubLinks := githubLinksFromRecord(record)
 	return RunnerState{
 		ID:                   record.ID,
 		Status:               record.Status,
@@ -53,6 +53,10 @@ func recordToState(record runnerRequestRecord) RunnerState {
 		ProcessPID:           record.ProcessPID,
 		WorkflowJobID:        pointerToInt64(record.WorkflowJobID),
 		WorkflowRunID:        githubLinks.workflowRunID,
+		WorkflowName:         githubLinks.workflowName,
+		WorkflowRunAttempt:   githubLinks.workflowRunAttempt,
+		HeadBranch:           githubLinks.headBranch,
+		HeadSHA:              githubLinks.headSHA,
 		GitHubJobURL:         githubLinks.jobURL,
 		PullRequestNumber:    githubLinks.pullRequestNumber,
 		AssignedJobID:        record.AssignedJobID,
@@ -79,10 +83,65 @@ func recordToState(record runnerRequestRecord) RunnerState {
 	}
 }
 
+func githubLinksFromRecord(record runnerRequestRecord) githubPayloadLinks {
+	links := githubPayloadLinks{
+		workflowRunID:      record.WorkflowRunID,
+		workflowName:       record.WorkflowName,
+		workflowRunAttempt: record.WorkflowRunAttempt,
+		headBranch:         record.HeadBranch,
+		headSHA:            record.HeadSHA,
+		jobURL:             record.GitHubJobURL,
+		pullRequestNumber:  record.PullRequestNumber,
+	}
+	if !record.GitHubContextBackfilled {
+		links = mergeGitHubPayloadLinks(links, githubLinksFromPayload(record))
+	}
+	if links.jobURL == "" && record.RepositoryFullName != "" && links.workflowRunID > 0 {
+		jobID := record.AssignedJobID
+		if jobID == 0 {
+			jobID = pointerToInt64(record.WorkflowJobID)
+		}
+		if jobID > 0 {
+			links.jobURL = fmt.Sprintf("https://github.com/%s/actions/runs/%d/job/%d", record.RepositoryFullName, links.workflowRunID, jobID)
+		}
+	}
+	links.jobURL = appendPullRequestQuery(links.jobURL, links.pullRequestNumber)
+	return links
+}
+
+func mergeGitHubPayloadLinks(links githubPayloadLinks, fallback githubPayloadLinks) githubPayloadLinks {
+	if links.workflowRunID == 0 {
+		links.workflowRunID = fallback.workflowRunID
+	}
+	if links.workflowName == "" {
+		links.workflowName = fallback.workflowName
+	}
+	if links.workflowRunAttempt == 0 {
+		links.workflowRunAttempt = fallback.workflowRunAttempt
+	}
+	if links.headBranch == "" {
+		links.headBranch = fallback.headBranch
+	}
+	if links.headSHA == "" {
+		links.headSHA = fallback.headSHA
+	}
+	if links.jobURL == "" {
+		links.jobURL = fallback.jobURL
+	}
+	if links.pullRequestNumber == 0 {
+		links.pullRequestNumber = fallback.pullRequestNumber
+	}
+	return links
+}
+
 type githubPayloadLinks struct {
-	workflowRunID     int64
-	jobURL            string
-	pullRequestNumber int64
+	workflowRunID      int64
+	workflowName       string
+	workflowRunAttempt int64
+	headBranch         string
+	headSHA            string
+	jobURL             string
+	pullRequestNumber  int64
 }
 
 type githubPayloadPullRequest struct {
@@ -93,6 +152,10 @@ func githubLinksFromPayload(record runnerRequestRecord) githubPayloadLinks {
 	var payload struct {
 		WorkflowJob struct {
 			RunID        int64                      `json:"run_id"`
+			WorkflowName string                     `json:"workflow_name"`
+			RunAttempt   int64                      `json:"run_attempt"`
+			HeadBranch   string                     `json:"head_branch"`
+			HeadSHA      string                     `json:"head_sha"`
 			HTMLURL      string                     `json:"html_url"`
 			PullRequests []githubPayloadPullRequest `json:"pull_requests"`
 			WorkflowRun  struct {
@@ -101,6 +164,10 @@ func githubLinksFromPayload(record runnerRequestRecord) githubPayloadLinks {
 		} `json:"workflow_job"`
 		WorkflowRun struct {
 			ID           int64                      `json:"id"`
+			Name         string                     `json:"name"`
+			RunAttempt   int64                      `json:"run_attempt"`
+			HeadBranch   string                     `json:"head_branch"`
+			HeadSHA      string                     `json:"head_sha"`
 			HTMLURL      string                     `json:"html_url"`
 			PullRequests []githubPayloadPullRequest `json:"pull_requests"`
 		} `json:"workflow_run"`
@@ -119,6 +186,13 @@ func githubLinksFromPayload(record runnerRequestRecord) githubPayloadLinks {
 	if runID == 0 {
 		runID = payload.WorkflowRun.ID
 	}
+	workflowName := firstNonEmpty(payload.WorkflowJob.WorkflowName, payload.WorkflowRun.Name)
+	runAttempt := payload.WorkflowJob.RunAttempt
+	if runAttempt == 0 {
+		runAttempt = payload.WorkflowRun.RunAttempt
+	}
+	headBranch := firstNonEmpty(payload.WorkflowJob.HeadBranch, payload.WorkflowRun.HeadBranch)
+	headSHA := firstNonEmpty(payload.WorkflowJob.HeadSHA, payload.WorkflowRun.HeadSHA)
 
 	prNumber := firstPullRequestNumber(payload.WorkflowJob.PullRequests)
 	if prNumber == 0 {
@@ -139,10 +213,24 @@ func githubLinksFromPayload(record runnerRequestRecord) githubPayloadLinks {
 	jobURL = appendPullRequestQuery(jobURL, prNumber)
 
 	return githubPayloadLinks{
-		workflowRunID:     runID,
-		jobURL:            jobURL,
-		pullRequestNumber: prNumber,
+		workflowRunID:      runID,
+		workflowName:       workflowName,
+		workflowRunAttempt: runAttempt,
+		headBranch:         headBranch,
+		headSHA:            headSHA,
+		jobURL:             jobURL,
+		pullRequestNumber:  prNumber,
 	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func firstPullRequestNumber(pulls []githubPayloadPullRequest) int64 {

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -15,6 +15,8 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 )
 
+const runnerRequestGitHubContextBackfillBatchSize = 200
+
 type DBStore struct {
 	opts     Options
 	mu       sync.Mutex
@@ -165,6 +167,9 @@ func (s *DBStore) migrate(db *gorm.DB) error {
 	); err != nil {
 		return err
 	}
+	if err := backfillRunnerRequestGitHubContext(db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -190,4 +195,49 @@ func migrateLegacySchemaColumns(db *gorm.DB) error {
 		}
 	}
 	return nil
+}
+
+func backfillRunnerRequestGitHubContext(db *gorm.DB) error {
+	var records []runnerRequestRecord
+	return db.
+		Where("github_payload_json <> ''").
+		Where("github_context_backfilled IS NULL OR github_context_backfilled = ?", false).
+		FindInBatches(&records, runnerRequestGitHubContextBackfillBatchSize, func(tx *gorm.DB, _ int) error {
+			for _, record := range records {
+				updates := runnerRequestGitHubContextBackfill(record)
+				if err := tx.Model(&runnerRequestRecord{}).Where("id = ?", record.ID).Updates(updates).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		}).Error
+}
+
+func runnerRequestGitHubContextBackfill(record runnerRequestRecord) map[string]any {
+	links := githubLinksFromPayload(record)
+	updates := map[string]any{
+		"github_context_backfilled": true,
+	}
+	if record.WorkflowRunID == 0 && links.workflowRunID != 0 {
+		updates["workflow_run_id"] = links.workflowRunID
+	}
+	if record.WorkflowName == "" && links.workflowName != "" {
+		updates["workflow_name"] = links.workflowName
+	}
+	if record.WorkflowRunAttempt == 0 && links.workflowRunAttempt != 0 {
+		updates["workflow_run_attempt"] = links.workflowRunAttempt
+	}
+	if record.HeadBranch == "" && links.headBranch != "" {
+		updates["head_branch"] = links.headBranch
+	}
+	if record.HeadSHA == "" && links.headSHA != "" {
+		updates["head_sha"] = links.headSHA
+	}
+	if record.GitHubJobURL == "" && links.jobURL != "" {
+		updates["github_job_url"] = links.jobURL
+	}
+	if record.PullRequestNumber == 0 && links.pullRequestNumber != 0 {
+		updates["pull_request_number"] = links.pullRequestNumber
+	}
+	return updates
 }

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -203,13 +203,15 @@ func backfillRunnerRequestGitHubContext(db *gorm.DB) error {
 		Where("github_payload_json <> ''").
 		Where("github_context_backfilled IS NULL OR github_context_backfilled = ?", false).
 		FindInBatches(&records, runnerRequestGitHubContextBackfillBatchSize, func(tx *gorm.DB, _ int) error {
-			for _, record := range records {
-				updates := runnerRequestGitHubContextBackfill(record)
-				if err := tx.Model(&runnerRequestRecord{}).Where("id = ?", record.ID).Updates(updates).Error; err != nil {
-					return err
+			return tx.Transaction(func(batchTx *gorm.DB) error {
+				for _, record := range records {
+					updates := runnerRequestGitHubContextBackfill(record)
+					if err := batchTx.Model(&runnerRequestRecord{}).Where("id = ?", record.ID).Updates(updates).Error; err != nil {
+						return err
+					}
 				}
-			}
-			return nil
+				return nil
+			})
 		}).Error
 }
 

--- a/internal/state/records.go
+++ b/internal/state/records.go
@@ -3,41 +3,49 @@ package state
 import "time"
 
 type runnerRequestRecord struct {
-	ID                   string     `gorm:"column:id;primaryKey"`
-	Source               string     `gorm:"column:source;not null"`
-	WorkflowJobID        *int64     `gorm:"column:workflow_job_id;uniqueIndex:idx_runner_requests_workflow_job_id"`
-	GitHubInstallationID int64      `gorm:"column:github_installation_id;index:idx_runner_requests_github_installation_updated"`
-	RepositoryFullName   string     `gorm:"column:repository_full_name"`
-	RequestedLabelsJSON  string     `gorm:"column:requested_labels_json"`
-	LabelsJSON           string     `gorm:"column:labels_json;not null"`
-	ProfileName          string     `gorm:"column:profile_name"`
-	RunnerGroup          string     `gorm:"column:runner_group"`
-	RunnerName           string     `gorm:"column:runner_name;not null"`
-	Status               string     `gorm:"column:status;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_status_retry_queue;index:idx_runner_requests_lease_expiry"`
-	FailureStage         string     `gorm:"column:failure_stage"`
-	FailureReason        string     `gorm:"column:failure_reason"`
-	LastErrorCode        string     `gorm:"column:last_error_code"`
-	LastErrorMessage     string     `gorm:"column:last_error_message"`
-	LastErrorRetryable   bool       `gorm:"column:last_error_retryable;not null;default:false"`
-	RetryCount           int        `gorm:"column:retry_count;not null;default:0"`
-	SandboxID            string     `gorm:"column:sandbox_id"`
-	ProcessPID           uint32     `gorm:"column:process_pid"`
-	AssignedJobID        int64      `gorm:"column:assigned_job_id"`
-	AssignedJobName      string     `gorm:"column:assigned_job_name"`
-	Error                string     `gorm:"column:error"`
-	GitHubPayloadJSON    string     `gorm:"column:github_payload_json;type:text"`
-	QueuedAt             time.Time  `gorm:"column:queued_at;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_status_retry_queue"`
-	LastAttemptAt        *time.Time `gorm:"column:last_attempt_at"`
-	NextRetryAt          *time.Time `gorm:"column:next_retry_at;index:idx_runner_requests_status_retry_queue"`
-	CreatingAt           *time.Time `gorm:"column:creating_at"`
-	RunningAt            *time.Time `gorm:"column:running_at"`
-	StoppingAt           *time.Time `gorm:"column:stopping_at"`
-	CompletedAt          *time.Time `gorm:"column:completed_at"`
-	FailedAt             *time.Time `gorm:"column:failed_at"`
-	LeaseOwner           string     `gorm:"column:lease_owner"`
-	LeaseExpiresAt       *time.Time `gorm:"column:lease_expires_at;index:idx_runner_requests_lease_expiry"`
-	UpdatedAt            time.Time  `gorm:"column:updated_at;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_github_installation_updated"`
-	Version              int64      `gorm:"column:version;not null;default:0"`
+	ID                      string     `gorm:"column:id;primaryKey"`
+	Source                  string     `gorm:"column:source;not null"`
+	WorkflowJobID           *int64     `gorm:"column:workflow_job_id;uniqueIndex:idx_runner_requests_workflow_job_id"`
+	GitHubInstallationID    int64      `gorm:"column:github_installation_id;index:idx_runner_requests_github_installation_updated;index:idx_runner_requests_github_installation_queued,priority:1"`
+	WorkflowRunID           int64      `gorm:"column:workflow_run_id;index:idx_runner_requests_workflow_run"`
+	WorkflowName            string     `gorm:"column:workflow_name"`
+	WorkflowRunAttempt      int64      `gorm:"column:workflow_run_attempt"`
+	HeadBranch              string     `gorm:"column:head_branch"`
+	HeadSHA                 string     `gorm:"column:head_sha;index:idx_runner_requests_repository_head,priority:2"`
+	GitHubJobURL            string     `gorm:"column:github_job_url"`
+	PullRequestNumber       int64      `gorm:"column:pull_request_number;index:idx_runner_requests_repository_pr,priority:2"`
+	GitHubContextBackfilled bool       `gorm:"column:github_context_backfilled;not null;default:false;index:idx_runner_requests_github_context_backfill"`
+	RepositoryFullName      string     `gorm:"column:repository_full_name;index:idx_runner_requests_repository_pr,priority:1;index:idx_runner_requests_repository_head,priority:1"`
+	RequestedLabelsJSON     string     `gorm:"column:requested_labels_json"`
+	LabelsJSON              string     `gorm:"column:labels_json;not null"`
+	ProfileName             string     `gorm:"column:profile_name"`
+	RunnerGroup             string     `gorm:"column:runner_group"`
+	RunnerName              string     `gorm:"column:runner_name;not null"`
+	Status                  string     `gorm:"column:status;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_status_retry_queue;index:idx_runner_requests_lease_expiry"`
+	FailureStage            string     `gorm:"column:failure_stage"`
+	FailureReason           string     `gorm:"column:failure_reason"`
+	LastErrorCode           string     `gorm:"column:last_error_code"`
+	LastErrorMessage        string     `gorm:"column:last_error_message"`
+	LastErrorRetryable      bool       `gorm:"column:last_error_retryable;not null;default:false"`
+	RetryCount              int        `gorm:"column:retry_count;not null;default:0"`
+	SandboxID               string     `gorm:"column:sandbox_id"`
+	ProcessPID              uint32     `gorm:"column:process_pid"`
+	AssignedJobID           int64      `gorm:"column:assigned_job_id"`
+	AssignedJobName         string     `gorm:"column:assigned_job_name"`
+	Error                   string     `gorm:"column:error"`
+	GitHubPayloadJSON       string     `gorm:"column:github_payload_json;type:text"`
+	QueuedAt                time.Time  `gorm:"column:queued_at;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_status_retry_queue;index:idx_runner_requests_github_installation_queued,priority:2"`
+	LastAttemptAt           *time.Time `gorm:"column:last_attempt_at"`
+	NextRetryAt             *time.Time `gorm:"column:next_retry_at;index:idx_runner_requests_status_retry_queue"`
+	CreatingAt              *time.Time `gorm:"column:creating_at"`
+	RunningAt               *time.Time `gorm:"column:running_at"`
+	StoppingAt              *time.Time `gorm:"column:stopping_at"`
+	CompletedAt             *time.Time `gorm:"column:completed_at"`
+	FailedAt                *time.Time `gorm:"column:failed_at"`
+	LeaseOwner              string     `gorm:"column:lease_owner"`
+	LeaseExpiresAt          *time.Time `gorm:"column:lease_expires_at;index:idx_runner_requests_lease_expiry"`
+	UpdatedAt               time.Time  `gorm:"column:updated_at;not null;index:idx_runner_requests_status_updated;index:idx_runner_requests_github_installation_updated"`
+	Version                 int64      `gorm:"column:version;not null;default:0"`
 }
 
 func (runnerRequestRecord) TableName() string { return "runner_requests" }

--- a/internal/state/runner_requests.go
+++ b/internal/state/runner_requests.go
@@ -44,21 +44,34 @@ func (s *DBStore) CreateRequest(req RunnerRequest, payload []byte) (bool, Runner
 	if err != nil {
 		return false, RunnerState{}, err
 	}
+	payloadLinks := githubLinksFromPayload(runnerRequestRecord{
+		WorkflowJobID:      &req.JobID,
+		RepositoryFullName: req.RepositoryFullName,
+		GitHubPayloadJSON:  string(payload),
+	})
 	record := runnerRequestRecord{
-		ID:                   req.ID,
-		Source:               req.Source,
-		GitHubInstallationID: req.GitHubInstallationID,
-		RepositoryFullName:   req.RepositoryFullName,
-		RequestedLabelsJSON:  string(requestedLabelsJSON),
-		LabelsJSON:           string(labelsJSON),
-		ProfileName:          req.ProfileName,
-		RunnerGroup:          req.RunnerGroup,
-		RunnerName:           req.RunnerName,
-		Status:               StatusQueued,
-		GitHubPayloadJSON:    string(payload),
-		QueuedAt:             req.CreatedAt,
-		UpdatedAt:            now,
-		Version:              0,
+		ID:                      req.ID,
+		Source:                  req.Source,
+		GitHubInstallationID:    req.GitHubInstallationID,
+		WorkflowRunID:           payloadLinks.workflowRunID,
+		WorkflowName:            payloadLinks.workflowName,
+		WorkflowRunAttempt:      payloadLinks.workflowRunAttempt,
+		HeadBranch:              payloadLinks.headBranch,
+		HeadSHA:                 payloadLinks.headSHA,
+		GitHubJobURL:            payloadLinks.jobURL,
+		PullRequestNumber:       payloadLinks.pullRequestNumber,
+		GitHubContextBackfilled: true,
+		RepositoryFullName:      req.RepositoryFullName,
+		RequestedLabelsJSON:     string(requestedLabelsJSON),
+		LabelsJSON:              string(labelsJSON),
+		ProfileName:             req.ProfileName,
+		RunnerGroup:             req.RunnerGroup,
+		RunnerName:              req.RunnerName,
+		Status:                  StatusQueued,
+		GitHubPayloadJSON:       string(payload),
+		QueuedAt:                req.CreatedAt,
+		UpdatedAt:               now,
+		Version:                 0,
 	}
 	if req.JobID != 0 {
 		record.WorkflowJobID = &req.JobID

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -53,6 +53,10 @@ type RunnerState struct {
 	ProcessPID           uint32    `json:"process_pid,omitempty"`
 	WorkflowJobID        int64     `json:"workflow_job_id,omitempty"`
 	WorkflowRunID        int64     `json:"workflow_run_id,omitempty"`
+	WorkflowName         string    `json:"workflow_name,omitempty"`
+	WorkflowRunAttempt   int64     `json:"workflow_run_attempt,omitempty"`
+	HeadBranch           string    `json:"head_branch,omitempty"`
+	HeadSHA              string    `json:"head_sha,omitempty"`
 	GitHubJobURL         string    `json:"github_job_url,omitempty"`
 	PullRequestNumber    int64     `json:"pull_request_number,omitempty"`
 	AssignedJobID        int64     `json:"assigned_job_id,omitempty"`

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -1327,11 +1327,15 @@ func TestAuditEventsCanBeListed(t *testing.T) {
 }
 
 func TestRunnerStateDerivesGitHubJobLinkFromWorkflowJobPayload(t *testing.T) {
-	store := New(t.TempDir())
+	store := New(t.TempDir()).(*DBStore)
 	payload := []byte(`{
 		"workflow_job": {
 			"id": 77684492230,
 			"run_id": 26392225417,
+			"workflow_name": "CI",
+			"run_attempt": 2,
+			"head_branch": "feature/group-jobs",
+			"head_sha": "abc123def456",
 			"html_url": "https://github.com/qbox/las/actions/runs/26392225417/job/77684492230",
 			"pull_requests": [{"number": 3335}]
 		}
@@ -1351,9 +1355,33 @@ func TestRunnerStateDerivesGitHubJobLinkFromWorkflowJobPayload(t *testing.T) {
 	if st.WorkflowRunID != 26392225417 || st.WorkflowJobID != 77684492230 || st.PullRequestNumber != 3335 {
 		t.Fatalf("unexpected github metadata: %#v", st)
 	}
+	if st.WorkflowName != "CI" || st.WorkflowRunAttempt != 2 || st.HeadBranch != "feature/group-jobs" || st.HeadSHA != "abc123def456" {
+		t.Fatalf("unexpected github context: %#v", st)
+	}
 	wantURL := "https://github.com/qbox/las/actions/runs/26392225417/job/77684492230?pr=3335"
 	if st.GitHubJobURL != wantURL {
 		t.Fatalf("unexpected github job url: %q", st.GitHubJobURL)
+	}
+
+	db, err := store.dbOrEnsure()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record runnerRequestRecord
+	if err := db.First(&record, "id = ?", "77684492230").Error; err != nil {
+		t.Fatal(err)
+	}
+	if record.WorkflowRunID != 26392225417 || record.WorkflowName != "CI" || record.WorkflowRunAttempt != 2 {
+		t.Fatalf("expected github context to be persisted on runner_requests: %#v", record)
+	}
+	if record.HeadBranch != "feature/group-jobs" || record.HeadSHA != "abc123def456" || record.PullRequestNumber != 3335 {
+		t.Fatalf("expected grouping fields to be persisted on runner_requests: %#v", record)
+	}
+	if record.GitHubJobURL != wantURL {
+		t.Fatalf("expected github job url to be persisted, got %q", record.GitHubJobURL)
+	}
+	if !record.GitHubContextBackfilled {
+		t.Fatalf("expected github context backfill marker to be persisted")
 	}
 }
 
@@ -1380,5 +1408,171 @@ func TestRunnerStateBuildsGitHubJobLinkFromWorkflowRunPayload(t *testing.T) {
 	wantURL := "https://github.com/qbox/las/actions/runs/26392225417/job/77684492230?pr=3335"
 	if st.WorkflowRunID != 26392225417 || st.GitHubJobURL != wantURL {
 		t.Fatalf("unexpected github metadata: %#v", st)
+	}
+}
+
+func TestRunnerStateUsesBackfilledGitHubContextWithoutParsingPayload(t *testing.T) {
+	workflowJobID := int64(77684492230)
+	st := recordToState(runnerRequestRecord{
+		ID:                      "77684492230",
+		Source:                  "github",
+		WorkflowJobID:           &workflowJobID,
+		GitHubInstallationID:    42,
+		WorkflowRunID:           26392225417,
+		WorkflowName:            "CI",
+		WorkflowRunAttempt:      2,
+		HeadBranch:              "feature/group-jobs",
+		HeadSHA:                 "abc123def456",
+		GitHubJobURL:            "https://github.com/qbox/las/actions/runs/26392225417/job/77684492230",
+		PullRequestNumber:       3335,
+		GitHubContextBackfilled: true,
+		RepositoryFullName:      "qbox/las",
+		RequestedLabelsJSON:     `["self-hosted"]`,
+		LabelsJSON:              `["self-hosted"]`,
+		RunnerName:              "e2b-77684492230",
+		Status:                  StatusQueued,
+		GitHubPayloadJSON:       `{"workflow_job":{"run_id":111,"workflow_name":"stale","run_attempt":9,"head_branch":"stale","head_sha":"stale","pull_requests":[{"number":1}]}}`,
+	})
+	if st.WorkflowRunID != 26392225417 || st.WorkflowName != "CI" || st.WorkflowRunAttempt != 2 {
+		t.Fatalf("expected state to use denormalized github context, got %#v", st)
+	}
+	if st.HeadBranch != "feature/group-jobs" || st.HeadSHA != "abc123def456" || st.PullRequestNumber != 3335 {
+		t.Fatalf("expected state to use denormalized grouping fields, got %#v", st)
+	}
+	wantURL := "https://github.com/qbox/las/actions/runs/26392225417/job/77684492230?pr=3335"
+	if st.GitHubJobURL != wantURL {
+		t.Fatalf("expected denormalized github job url, got %q", st.GitHubJobURL)
+	}
+}
+
+func TestMigrateBackfillsLegacyRunnerRequestGitHubContext(t *testing.T) {
+	dir := t.TempDir()
+	databaseURL := dir + "/runnerd.db"
+	store := NewWithOptions(Options{
+		Backend:        BackendSQLite,
+		DatabaseDSN:    databaseURL,
+		MigrateOnStart: false,
+	}).(*DBStore)
+	db, err := store.open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if err := db.Exec(`CREATE TABLE runner_requests (
+		id TEXT PRIMARY KEY,
+		source TEXT NOT NULL,
+		workflow_job_id INTEGER,
+		github_installation_id INTEGER,
+		repository_full_name TEXT,
+		requested_labels_json TEXT,
+		labels_json TEXT NOT NULL,
+		profile_name TEXT,
+		runner_group TEXT,
+		runner_name TEXT NOT NULL,
+		status TEXT NOT NULL,
+		failure_stage TEXT,
+		failure_reason TEXT,
+		last_error_code TEXT,
+		last_error_message TEXT,
+		last_error_retryable BOOLEAN NOT NULL DEFAULT FALSE,
+		retry_count INTEGER NOT NULL DEFAULT 0,
+		sandbox_id TEXT,
+		process_pid INTEGER,
+		assigned_job_id INTEGER,
+		assigned_job_name TEXT,
+		error TEXT,
+		github_payload_json TEXT,
+		queued_at TIMESTAMP NOT NULL,
+		last_attempt_at TIMESTAMP,
+		next_retry_at TIMESTAMP,
+		creating_at TIMESTAMP,
+		running_at TIMESTAMP,
+		stopping_at TIMESTAMP,
+		completed_at TIMESTAMP,
+		failed_at TIMESTAMP,
+		lease_owner TEXT,
+		lease_expires_at TIMESTAMP,
+		updated_at TIMESTAMP NOT NULL,
+		version INTEGER NOT NULL DEFAULT 0
+	);`).Error; err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"workflow_job":{"run_id":26392225417,"workflow_name":"CI","run_attempt":2,"head_branch":"feature/group-jobs","head_sha":"abc123def456","pull_requests":[{"number":3335}]}}`
+	if err := db.Exec(`INSERT INTO runner_requests (
+		id, source, workflow_job_id, github_installation_id, repository_full_name,
+		requested_labels_json, labels_json, runner_name, status, github_payload_json,
+		queued_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"77684492230", "github", 77684492230, 42, "qbox/las",
+		`["self-hosted"]`, `["self-hosted"]`, "e2b-77684492230", StatusQueued, payload,
+		now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	closeTestDB(t, db)
+
+	migrated := NewWithOptions(Options{
+		Backend:        BackendSQLite,
+		DatabaseDSN:    databaseURL,
+		MigrateOnStart: true,
+	}).(*DBStore)
+	states, err := migrated.ListStatesForGitHubInstallations([]int64{42}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("expected one migrated runner request, got %d", len(states))
+	}
+	st := states[0]
+	if st.WorkflowRunID != 26392225417 || st.PullRequestNumber != 3335 {
+		t.Fatalf("expected github context after migration, got %#v", st)
+	}
+	if st.WorkflowName != "CI" || st.WorkflowRunAttempt != 2 || st.HeadBranch != "feature/group-jobs" || st.HeadSHA != "abc123def456" {
+		t.Fatalf("unexpected github context after migration: %#v", st)
+	}
+
+	db, err = migrated.dbOrEnsure()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, column := range []string{
+		"workflow_run_id",
+		"workflow_name",
+		"workflow_run_attempt",
+		"head_branch",
+		"head_sha",
+		"github_job_url",
+		"pull_request_number",
+		"github_context_backfilled",
+	} {
+		if !db.Migrator().HasColumn(&runnerRequestRecord{}, column) {
+			t.Fatalf("expected migrated runner_requests.%s column", column)
+		}
+	}
+	var record runnerRequestRecord
+	if err := db.First(&record, "id = ?", "77684492230").Error; err != nil {
+		t.Fatal(err)
+	}
+	if record.WorkflowRunID != 26392225417 || record.PullRequestNumber != 3335 {
+		t.Fatalf("expected migrated runner request columns to be backfilled: %#v", record)
+	}
+	if record.WorkflowName != "CI" || record.WorkflowRunAttempt != 2 || record.HeadBranch != "feature/group-jobs" || record.HeadSHA != "abc123def456" {
+		t.Fatalf("unexpected backfilled runner request columns: %#v", record)
+	}
+	wantURL := "https://github.com/qbox/las/actions/runs/26392225417/job/77684492230?pr=3335"
+	if record.GitHubJobURL != wantURL {
+		t.Fatalf("expected github job url to be backfilled, got %q", record.GitHubJobURL)
+	}
+	if !record.GitHubContextBackfilled {
+		t.Fatalf("expected github context backfill marker to be set")
+	}
+	var pendingBackfills int64
+	if err := db.Model(&runnerRequestRecord{}).
+		Where("github_payload_json <> ''").
+		Where("github_context_backfilled IS NULL OR github_context_backfilled = ?", false).
+		Count(&pendingBackfills).Error; err != nil {
+		t.Fatal(err)
+	}
+	if pendingBackfills != 0 {
+		t.Fatalf("expected no pending github context backfills, got %d", pendingBackfills)
 	}
 }

--- a/ui/src/admin-types.ts
+++ b/ui/src/admin-types.ts
@@ -12,6 +12,10 @@ export type RunnerState = {
   process_pid?: number
   workflow_job_id?: number
   workflow_run_id?: number
+  workflow_name?: string
+  workflow_run_attempt?: number
+  head_branch?: string
+  head_sha?: string
   github_job_url?: string
   pull_request_number?: number
   assigned_job_id?: number

--- a/ui/src/components/runner-requests-section.tsx
+++ b/ui/src/components/runner-requests-section.tsx
@@ -390,7 +390,11 @@ export function RunnerRequestsSection({
                 }
               />
               <Detail label="Workflow run" value={selected.workflow_run_id || "-"} />
+              <Detail label="Workflow" value={selected.workflow_name || "-"} />
+              <Detail label="Workflow attempt" value={selected.workflow_run_attempt || "-"} />
               <Detail label="Pull request" value={selected.pull_request_number || "-"} />
+              <Detail label="Branch" value={selected.head_branch || "-"} />
+              <Detail label="Commit" value={selected.head_sha || "-"} />
               <Detail label="Created" value={formatTime(selected.created_at)} />
               <Detail label="Updated" value={formatTime(selected.updated_at)} />
               <Detail label="Completed" value={formatTime(selected.completed_at)} />

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -1,12 +1,30 @@
-import { BookOpen, Github, LogOut, Monitor, Moon, Settings, ShieldCheck, Sun, Workflow } from "lucide-react"
+import {
+  AlertCircle,
+  BookOpen,
+  CalendarDays,
+  ChevronDown,
+  Check,
+  ExternalLink,
+  Github,
+  LogOut,
+  Monitor,
+  Moon,
+  Play,
+  Settings,
+  ShieldCheck,
+  Sun,
+  Workflow,
+  X,
+} from "lucide-react"
 import { useTheme } from "next-themes"
-import { type MouseEvent, useEffect, useMemo, useState } from "react"
+import { type MouseEvent, type ReactNode, useEffect, useMemo, useState } from "react"
 
 import type { AuthSession, GitHubAppConfig, RunnerState } from "@/admin-types"
 import { formatTime } from "@/admin-format"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -17,16 +35,24 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { cn } from "@/lib/utils"
 
-type PRGroup = {
+type BuildGroupKind = "pull_request" | "branch" | "workflow_run" | "manual"
+type RunnerStatusSummary = "completed" | "active" | "failed"
+
+type BuildGroup = {
   key: string
+  kind: BuildGroupKind
   repository: string
-  prLabel: string
+  title: string
+  subtitle: string
   updatedAt: string
   jobs: RunnerState[]
+  workflowRunIDs: number[]
+  headSHA?: string
+  headBranch?: string
+  pullRequestNumber?: number
 }
 
 type UserPage = "home" | "repositories" | "settings"
@@ -65,7 +91,7 @@ export function UserDashboard({
   onSelectKey: (key: string) => void
   onSignOut: () => void
 }) {
-  const groups = useMemo(() => groupRunnersByPR(runners), [runners])
+  const groups = useMemo(() => groupRunnersByBuildContext(runners), [runners])
   const selected = groups.find((group) => group.key === selectedKey) || groups[0]
   const installations = useMemo(
     () => orderInstallationsByCurrentAccount(githubApp?.installations ?? [], authSession.login),
@@ -159,16 +185,6 @@ function ActivityRepositoriesPage({
 }) {
   const [selectedID, setSelectedID] = useState<number | null>(null)
   const selected = installations.find((installation) => installation.id === selectedID) || installations[0]
-
-  useEffect(() => {
-    if (!selected) {
-      setSelectedID(null)
-      return
-    }
-    if (selectedID !== selected.id) {
-      setSelectedID(selected.id)
-    }
-  }, [selected, selectedID])
 
   return (
     <>
@@ -467,12 +483,15 @@ function PullRequestsPage({
   onSelectKey,
   onNavigate,
 }: {
-  groups: PRGroup[]
+  groups: BuildGroup[]
   hasInstallations: boolean
-  selected: PRGroup | undefined
+  selected: BuildGroup | undefined
   onSelectKey: (key: string) => void
   onNavigate: (page: UserPage) => void
 }) {
+  const currentJobs = selected ? currentBuildJobs(selected) : []
+  const previousJobs = selected ? previousBuildJobs(selected, currentJobs) : []
+
   return (
     <>
       <section className="border-b bg-muted/35 px-4 py-4 lg:px-6">
@@ -490,25 +509,12 @@ function PullRequestsPage({
             <div className="min-h-0 flex-1 overflow-y-auto">
               {groups.length ? (
                 groups.map((group) => (
-                  <button
+                  <BuildGroupListItem
                     key={group.key}
-                    type="button"
-                    onClick={() => onSelectKey(group.key)}
-                    className={cn(
-                      "flex w-full flex-col gap-2 border-b px-4 py-3 text-left transition-colors hover:bg-accent",
-                      selected?.key === group.key ? "bg-accent" : ""
-                    )}
-                  >
-                    <div className="flex items-center gap-2">
-                      <Workflow className="h-4 w-4 text-primary" />
-                      <span className="truncate text-sm font-semibold">{group.prLabel}</span>
-                    </div>
-                    <div className="truncate text-xs text-muted-foreground">{group.repository}</div>
-                    <div className="flex items-center gap-2">
-                      <Badge variant="secondary">{group.jobs.length} jobs</Badge>
-                      <span className="text-xs text-muted-foreground">{formatTime(group.updatedAt)}</span>
-                    </div>
-                  </button>
+                    group={group}
+                    selected={selected?.key === group.key}
+                    onSelect={() => onSelectKey(group.key)}
+                  />
                 ))
               ) : (
                 <div className="p-4 text-sm text-muted-foreground">
@@ -533,36 +539,39 @@ function PullRequestsPage({
           {selected ? (
             <div className="space-y-4">
               <div>
-                <div className="text-sm text-muted-foreground">{selected.repository}</div>
-                <h2 className="text-2xl font-semibold">{selected.prLabel}</h2>
+                <h2 className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-2xl font-semibold">
+                  <span>{selected.repository}</span>
+                  <span className={userBuildGroupTitleClass(selected)}>{selected.title}</span>
+                </h2>
+                <div className="mt-3 grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4">
+                  <JobField label="Branch" value={selected.headBranch || selected.subtitle || "unknown"} />
+                  <JobField label="Commit" value={shortSHA(selected.headSHA) || "unknown"} />
+                  <JobField label="Workflow runs" value={String(selected.workflowRunIDs.length || 1)} />
+                  <JobField label="Last updated" value={formatTime(selected.updatedAt)} />
+                </div>
               </div>
               <div className="grid gap-3">
-                {selected.jobs.map((job) => (
-                  <Card key={job.id} className="rounded-lg">
-                    <CardHeader className="gap-3 pb-3">
-                      <div className="flex flex-wrap items-start justify-between gap-3">
-                        <div>
-                          <CardTitle className="text-base">{job.assigned_job_name || job.runner_name}</CardTitle>
-                          <CardDescription>{job.id}</CardDescription>
-                        </div>
-                        <Badge className={userStatusClass(job.status)}>{job.status}</Badge>
-                      </div>
-                    </CardHeader>
-                    <CardContent className="grid gap-3 text-sm md:grid-cols-3">
-                      <JobField label="Runner spec" value={job.runner_spec_name || "matched by labels"} />
-                      <JobField label="Workflow run" value={job.workflow_run_id ? String(job.workflow_run_id) : "unknown"} />
-                      <JobField label="Updated" value={formatTime(job.updated_at)} />
-                      {job.github_job_url ? (
-                        <>
-                          <Separator className="md:col-span-3" />
-                          <a className="text-sm font-medium text-primary hover:underline md:col-span-3" href={job.github_job_url}>
-                            Open GitHub Actions job
-                          </a>
-                        </>
-                      ) : null}
-                    </CardContent>
-                  </Card>
+                {currentJobs.map((job) => (
+                  <RunnerJobCard key={job.id} job={job} />
                 ))}
+                {previousJobs.length ? (
+                  <Collapsible>
+                    <CollapsibleTrigger asChild>
+                      <Button type="button" variant="outline" className="w-full justify-between">
+                        Previous jobs
+                        <span className="inline-flex items-center gap-2 text-muted-foreground">
+                          {previousJobs.length} jobs
+                          <ChevronDown className="h-4 w-4" />
+                        </span>
+                      </Button>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="mt-3 grid gap-3">
+                      {previousJobs.map((job) => (
+                        <RunnerJobCard key={job.id} job={job} />
+                      ))}
+                    </CollapsibleContent>
+                  </Collapsible>
+                ) : null}
               </div>
             </div>
           ) : (
@@ -655,7 +664,7 @@ function UserMenu({ authSession, onSignOut }: { authSession: AuthSession; onSign
   )
 }
 
-function JobField({ label, value }: { label: string; value: string }) {
+function JobField({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div>
       <div className="text-xs text-muted-foreground">{label}</div>
@@ -664,27 +673,294 @@ function JobField({ label, value }: { label: string; value: string }) {
   )
 }
 
-function groupRunnersByPR(runners: RunnerState[]): PRGroup[] {
-  const groups = new Map<string, PRGroup>()
+function RunnerJobCard({ job }: { job: RunnerState }) {
+  return (
+    <Card className="rounded-lg">
+      <CardHeader className="gap-1 pb-0">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-base">{runnerJobTitle(job)}</CardTitle>
+          </div>
+          <Badge className={userStatusClass(job.status)}>{job.status}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-3 pt-0 text-sm md:grid-cols-3">
+        <JobField label="Runner spec" value={job.runner_spec_name || "matched by labels"} />
+        <JobField label="Workflow" value={job.workflow_name || "unknown"} />
+        <JobField label="Workflow run" value={workflowRunValue(job)} />
+      </CardContent>
+    </Card>
+  )
+}
+
+function workflowRunValue(job: RunnerState) {
+  const runID = job.workflow_run_id ? String(job.workflow_run_id) : "unknown"
+  const jobID = job.workflow_job_id ? String(job.workflow_job_id) : job.id
+  const runURL = workflowRunURL(job)
+  const runValue = runURL ? (
+    <a className="text-primary hover:underline" href={runURL} target="_blank" rel="noreferrer">
+      {runID}
+    </a>
+  ) : (
+    runID
+  )
+  if (!job.github_job_url || !jobID) return runValue
+  return (
+    <span className="inline-flex items-center gap-1">
+      {runValue}
+      <span className="text-muted-foreground">/</span>
+      <a className="inline-flex items-center gap-1 text-primary hover:underline" href={job.github_job_url} target="_blank" rel="noreferrer">
+        {jobID}
+        <ExternalLink className="h-3.5 w-3.5" />
+      </a>
+    </span>
+  )
+}
+
+function workflowRunURL(job: RunnerState) {
+  if (!job.github_job_url || !job.workflow_run_id) return ""
+  const marker = `/actions/runs/${job.workflow_run_id}`
+  const index = job.github_job_url.indexOf(marker)
+  if (index < 0) return ""
+  return job.github_job_url.slice(0, index + marker.length)
+}
+
+function BuildGroupListItem({
+  group,
+  selected,
+  onSelect,
+}: {
+  group: BuildGroup
+  selected: boolean
+  onSelect: () => void
+}) {
+  const status = buildGroupStatus(group)
+  const statusClasses = buildGroupStatusClasses(status)
+  const reference = buildGroupReference(group)
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "group relative flex w-full gap-2 border-b bg-background/60 py-4 pl-3 pr-4 text-left transition-colors hover:bg-accent/70",
+        selected ? "bg-accent" : ""
+      )}
+    >
+      <span className={cn("absolute inset-y-0 left-0 w-1", statusClasses.bar)} aria-hidden="true" />
+      <span className={cn("mt-1 flex h-5 w-5 shrink-0 items-center justify-center", statusClasses.icon)}>
+        <BuildGroupStatusIcon status={status} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-start justify-between gap-3">
+          <span className="min-w-0 flex-1">
+            <span className={cn("block truncate text-sm font-semibold leading-5", statusClasses.title)}>
+              {group.repository}
+            </span>
+          </span>
+          <span className="flex shrink-0 items-baseline gap-1 font-mono text-sm leading-5">
+            <span className="text-muted-foreground">#</span>
+            <span className={cn("text-sm font-semibold", statusClasses.title)}>{reference}</span>
+          </span>
+        </span>
+        <span className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <Workflow className="h-3.5 w-3.5" />
+            {group.jobs.length} jobs
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <Play className="h-3.5 w-3.5" />
+            {group.workflowRunIDs.length || 1} runs
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <CalendarDays className="h-3.5 w-3.5" />
+            {formatTime(group.updatedAt)}
+          </span>
+        </span>
+      </span>
+    </button>
+  )
+}
+
+function userBuildGroupTitleClass(group: BuildGroup) {
+  return buildGroupStatusClasses(buildGroupStatus(group)).title
+}
+
+function BuildGroupStatusIcon({ status }: { status: RunnerStatusSummary }) {
+  const className = "h-4 w-4"
+  if (status === "failed") return <X className={className} />
+  if (status === "active") return <AlertCircle className={className} />
+  return <Check className={className} />
+}
+
+function buildGroupStatus(group: BuildGroup): RunnerStatusSummary {
+  if (group.jobs.some((job) => job.status === "failed")) return "failed"
+  if (group.jobs.some((job) => job.status === "queued" || job.status === "creating" || job.status === "running" || job.status === "stopping")) {
+    return "active"
+  }
+  return "completed"
+}
+
+function buildGroupStatusClasses(status: RunnerStatusSummary) {
+  switch (status) {
+    case "failed":
+      return {
+        bar: "bg-destructive",
+        icon: "text-destructive",
+        title: "text-destructive",
+      }
+    case "active":
+      return {
+        bar: "bg-blue-500",
+        icon: "text-blue-500",
+        title: "text-blue-500",
+      }
+    default:
+      return {
+        bar: "bg-emerald-500",
+        icon: "text-emerald-500",
+        title: "text-emerald-500",
+      }
+  }
+}
+
+function buildGroupReference(group: BuildGroup) {
+  if (group.pullRequestNumber) return String(group.pullRequestNumber)
+  if (group.headSHA) return shortSHA(group.headSHA)
+  if (group.workflowRunIDs[0]) return String(group.workflowRunIDs[0])
+  return String(group.jobs.length)
+}
+
+function runnerJobTitle(job: RunnerState) {
+  if (job.assigned_job_name && job.assigned_job_name !== "__runner_job_started__") {
+    return job.assigned_job_name
+  }
+  return job.workflow_name || job.runner_name
+}
+
+function groupRunnersByBuildContext(runners: RunnerState[]): BuildGroup[] {
+  const prByRepositoryAndSHA = new Map<string, number>()
+  for (const runner of runners) {
+    if (runner.repository_full_name && runner.head_sha && runner.pull_request_number) {
+      prByRepositoryAndSHA.set(`${runner.repository_full_name}:${runner.head_sha}`, runner.pull_request_number)
+    }
+  }
+
+  const groups = new Map<string, BuildGroup>()
   for (const runner of runners) {
     const repository = runner.repository_full_name || "unknown/repository"
-    const pr = runner.pull_request_number ? `PR #${runner.pull_request_number}` : "Manual or workflow job"
-    const key = `${repository}:${runner.pull_request_number || runner.workflow_run_id || runner.id}`
+    const inferredPR = runner.pull_request_number || (runner.head_sha ? prByRepositoryAndSHA.get(`${repository}:${runner.head_sha}`) : undefined)
+    const group = buildGroupSeed(runner, repository, inferredPR)
+    const key = group.key
     const current = groups.get(key)
     if (current) {
       current.jobs.push(runner)
-      if (runner.updated_at > current.updatedAt) current.updatedAt = runner.updated_at
+      if (runner.updated_at > current.updatedAt) {
+        current.updatedAt = runner.updated_at
+        current.subtitle = group.subtitle
+        current.headSHA = runner.head_sha || current.headSHA
+        current.headBranch = runner.head_branch || current.headBranch
+      }
+      if (runner.head_sha && !current.headSHA) current.headSHA = runner.head_sha
+      if (runner.head_branch && !current.headBranch) current.headBranch = runner.head_branch
+      if (runner.workflow_run_id && !current.workflowRunIDs.includes(runner.workflow_run_id)) {
+        current.workflowRunIDs.push(runner.workflow_run_id)
+        current.workflowRunIDs.sort((a, b) => b - a)
+      }
       continue
     }
-    groups.set(key, {
-      key,
+    groups.set(key, group)
+  }
+  return Array.from(groups.values())
+    .map((group) => ({ ...group, jobs: orderJobs(group.jobs) }))
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+}
+
+function buildGroupSeed(runner: RunnerState, repository: string, pullRequestNumber?: number): BuildGroup {
+  const workflowRunIDs = runner.workflow_run_id ? [runner.workflow_run_id] : []
+  if (pullRequestNumber) {
+    return {
+      key: `pr:${repository}:${pullRequestNumber}`,
+      kind: "pull_request",
       repository,
-      prLabel: pr,
+      title: `PR #${pullRequestNumber}`,
+      subtitle: runner.head_branch || shortSHA(runner.head_sha) || runner.workflow_name || "Pull request checks",
       updatedAt: runner.updated_at,
       jobs: [runner],
-    })
+      workflowRunIDs,
+      headSHA: runner.head_sha,
+      headBranch: runner.head_branch,
+      pullRequestNumber,
+    }
   }
-  return Array.from(groups.values()).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+  if (runner.head_sha) {
+    const branch = runner.head_branch || "detached"
+    return {
+      key: `branch:${repository}:${branch}:${runner.head_sha}`,
+      kind: "branch",
+      repository,
+      title: runner.head_branch || `Commit ${shortSHA(runner.head_sha)}`,
+      subtitle: shortSHA(runner.head_sha) || runner.workflow_name || "Branch checks",
+      updatedAt: runner.updated_at,
+      jobs: [runner],
+      workflowRunIDs,
+      headSHA: runner.head_sha,
+      headBranch: runner.head_branch,
+    }
+  }
+  if (runner.workflow_run_id) {
+    return {
+      key: `run:${repository}:${runner.workflow_run_id}`,
+      kind: "workflow_run",
+      repository,
+      title: runner.workflow_name || "Workflow run",
+      subtitle: `Run ${runner.workflow_run_id}`,
+      updatedAt: runner.updated_at,
+      jobs: [runner],
+      workflowRunIDs,
+    }
+  }
+  return {
+    key: `manual:${repository}:${runner.id}`,
+    kind: "manual",
+    repository,
+    title: "Manual runner",
+    subtitle: runner.runner_spec_name || runner.runner_name || runner.id,
+    updatedAt: runner.updated_at,
+    jobs: [runner],
+    workflowRunIDs,
+  }
+}
+
+function orderJobs(jobs: RunnerState[]) {
+  return [...jobs].sort((a, b) => {
+    const runOrder = (b.workflow_run_id || 0) - (a.workflow_run_id || 0)
+    if (runOrder !== 0) return runOrder
+    return b.updated_at.localeCompare(a.updated_at)
+  })
+}
+
+function currentBuildJobs(group: BuildGroup) {
+  if (group.headSHA) {
+    const current = group.jobs.filter((job) => job.head_sha === group.headSHA)
+    if (current.length > 0) return current
+  }
+  const latestRunID = group.workflowRunIDs[0]
+  if (latestRunID) {
+    const current = group.jobs.filter((job) => job.workflow_run_id === latestRunID)
+    if (current.length > 0) return current
+  }
+  return group.jobs
+}
+
+function previousBuildJobs(group: BuildGroup, currentJobs: RunnerState[]) {
+  const currentIDs = new Set(currentJobs.map((job) => job.id))
+  return group.jobs.filter((job) => !currentIDs.has(job.id))
+}
+
+function shortSHA(value?: string) {
+  if (!value) return ""
+  return value.length > 7 ? value.slice(0, 7) : value
 }
 
 function orderInstallationsByCurrentAccount(
@@ -769,7 +1045,7 @@ function userStatusClass(status: RunnerState["status"]) {
     case "completed":
       return "bg-muted text-foreground"
     case "failed":
-      return "bg-destructive text-destructive-foreground"
+      return "bg-destructive text-white"
     default:
       return ""
   }


### PR DESCRIPTION
## Summary

- group runner jobs by pull request or workflow context in the Jobs dashboard
- denormalize GitHub workflow and PR context on runner_requests for efficient listing
- backfill legacy runner_requests rows once and avoid repeated payload parsing

## Validation

- go test ./internal/state -count=1
- go test ./...
- cd ui && bun run lint && bun run build
- git diff --check
