### PR TITLE
fix(dev): clean task dev children on exit

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -168,13 +168,28 @@ tasks:
 
         ./scripts/smee.sh --check
         (
-          cd ui
+          cd ui || exit
           exec bun run dev --host 127.0.0.1 --port "${RUNNERD_VITE_PORT}" --strictPort
         ) &
         UI_PID="$!"
         ./scripts/smee.sh &
         SMEE_PID="$!"
-        trap 'kill "$UI_PID" "$SMEE_PID" 2>/dev/null || true' EXIT
+        kill_tree() {
+          pid="$1"
+          if command -v pgrep >/dev/null 2>&1; then
+            for child_pid in $(pgrep -P "$pid" 2>/dev/null || true); do
+              kill_tree "$child_pid"
+            done
+          fi
+          kill "$pid" 2>/dev/null || true
+        }
+        cleanup_dev() {
+          trap - EXIT
+          kill_tree "$UI_PID"
+          kill_tree "$SMEE_PID"
+          wait "$UI_PID" "$SMEE_PID" 2>/dev/null || true
+        }
+        trap cleanup_dev EXIT
         UI_READY=0
         for _ in 1 2 3 4 5 6 7 8 9 10; do
           if curl -fsS "${RUNNERD_VITE_DEV_SERVER_URL}" >/dev/null 2>&1; then

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -176,6 +176,7 @@ tasks:
         SMEE_PID="$!"
         kill_tree() {
           pid="$1"
+          [ -z "$pid" ] && return
           if command -v pgrep >/dev/null 2>&1; then
             for child_pid in $(pgrep -P "$pid" 2>/dev/null || true); do
               kill_tree "$child_pid"
@@ -187,7 +188,8 @@ tasks:
           trap - EXIT
           kill_tree "$UI_PID"
           kill_tree "$SMEE_PID"
-          wait "$UI_PID" "$SMEE_PID" 2>/dev/null || true
+          [ -n "$UI_PID" ] && wait "$UI_PID" 2>/dev/null || true
+          [ -n "$SMEE_PID" ] && wait "$SMEE_PID" 2>/dev/null || true
         }
         trap cleanup_dev EXIT
         UI_READY=0


### PR DESCRIPTION
## Summary
- recursively clean the `task dev` Vite and smee process trees on task exit
- make the UI dev server subshell fail fast if `cd ui` fails

## Why
`task dev` could leave smee or Vite child processes behind after Ctrl+C because the previous cleanup only killed the direct background PIDs. A real smoke also showed this Taskfile shell only accepts `EXIT` trap syntax reliably, so cleanup now stays on the exit trap that actually fires when Task receives Ctrl+C.

## Validation
- `task --dry dev | shellcheck -s sh -`
- `git diff --check`
- real `task dev` smoke with temporary config and ports:
  - runnerd on `127.0.0.1:25502`
  - Vite on `127.0.0.1:56173`
  - `/healthz` returned `{"status":"ok"}`
  - `/admin/` returned `HTTP/1.1 200 OK`
  - Ctrl+C cleaned temporary Vite, smee, reflex, go run, and runnerd processes
