### PR TITLE
fix(runner): preserve busy job lifecycle

### DIFF
--- a/internal/server/server_helpers_test.go
+++ b/internal/server/server_helpers_test.go
@@ -1103,6 +1103,59 @@ func TestRunnerExitedWithNonZeroExitCodeTransitionsToFailed(t *testing.T) {
 	}
 }
 
+func TestRunnerExitedKeepsSandboxWhenGitHubRunnerIsBusy(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/actions/runners" {
+			w.Write([]byte(`{"runners":[{"id":99,"name":"e2b-exited-busy","status":"online","busy":true}]}`))
+			return
+		}
+		t.Fatalf("unexpected github request: %s %s", r.Method, r.URL.String())
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	fake := &fakeSandbox{}
+	srv := newTestServer(t, store, ghServer.URL, fake)
+
+	_, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "exited-busy",
+		Source:             "test",
+		Labels:             []string{"self-hosted"},
+		RunnerName:         "e2b-exited-busy",
+		RepositoryFullName: "o/r",
+		ProfileName:        "default",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Status = state.StatusRunning
+	st.SandboxID = "sb-exited-busy"
+	st.ProcessPID = 42
+	if err := store.WriteState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	srv.runnerExited("exited-busy", sandboxrunner.ExitResult{ExitCode: -1, Error: "deadline_exceeded: context deadline exceeded"}, nil)
+
+	got, err := store.ReadState("exited-busy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusRunning {
+		t.Fatalf("runnerExited busy: expected status=running, got %s", got.Status)
+	}
+	if got.LastErrorCode != "github_runner_busy" || !got.LastErrorRetryable {
+		t.Fatalf("runnerExited busy: expected retryable busy marker, got code=%q retryable=%v", got.LastErrorCode, got.LastErrorRetryable)
+	}
+	if got.AssignedJobName != runnerJobStartedMarker {
+		t.Fatalf("runnerExited busy: expected job started marker, got %q", got.AssignedJobName)
+	}
+	if fake.stoppedCount() != 0 {
+		t.Fatalf("runnerExited busy: expected sandbox to remain running, got %d stops", fake.stoppedCount())
+	}
+}
+
 // ---------- reconcileOnce ----------
 
 func TestReconcileOnceSignalsQueueForQueuedRunner(t *testing.T) {

--- a/internal/server/server_loops.go
+++ b/internal/server/server_loops.go
@@ -114,6 +114,7 @@ func (s *Server) sweepOnce(ctx context.Context) {
 		return
 	}
 	now := time.Now().UTC()
+	stoppedRunning := make(map[string]struct{})
 	for _, st := range states {
 		switch st.Status {
 		case state.StatusCreating:
@@ -122,15 +123,11 @@ func (s *Server) sweepOnce(ctx context.Context) {
 				s.retryOrFail(st, "sweeper_create_timeout", fmt.Errorf("runner create timed out"))
 			}
 		case state.StatusRunning:
-			if s.shouldStopIdleRunner(st, now) {
-				s.logger.Info("sweeper stopping idle runner", "id", st.ID, "sandbox_id", st.SandboxID, "running_at", st.RunningAt, "idle_timeout", s.cfg.RunnerIdleTimeout)
-				s.store.AppendLog(st.ID, "control.log", []byte("sweeper stopping idle runner that never accepted a job\n"))
-				s.stopIfExists(ctx, st.ID, github.WorkflowJob{})
-				continue
-			}
 			if !st.RunningAt.IsZero() && now.Sub(st.RunningAt) > s.cfg.SandboxTimeout {
 				s.logger.Info("sweeper stopping timed out runner", "id", st.ID, "sandbox_id", st.SandboxID, "running_at", st.RunningAt)
 				s.failAndStopRunner(ctx, st.ID, "sandbox_timeout", "timeout", "runner exceeded sandbox timeout")
+				stoppedRunning[st.ID] = struct{}{}
+				continue
 			}
 		case state.StatusStopping:
 			if !st.NextRetryAt.IsZero() && now.Before(st.NextRetryAt) {
@@ -140,6 +137,27 @@ func (s *Server) sweepOnce(ctx context.Context) {
 				s.logger.Info("sweeper retrying timed out stop", "id", st.ID, "sandbox_id", st.SandboxID, "stopping_at", st.StoppingAt)
 				s.stopIfExists(ctx, st.ID, github.WorkflowJob{})
 			}
+		}
+	}
+	for _, st := range states {
+		if st.Status != state.StatusRunning || !s.shouldStopIdleRunner(st, now) {
+			continue
+		}
+		if _, ok := stoppedRunning[st.ID]; ok {
+			continue
+		}
+		busy, err := s.githubRunnerBusy(ctx, st)
+		if err != nil {
+			s.logger.Warn("sweeper skipped idle runner stop because github runner status could not be verified", "id", st.ID, "runner_name", st.RunnerName, "error", err)
+			s.store.AppendLog(st.ID, "control.log", []byte("sweeper skipped idle stop because github runner status could not be verified: "+err.Error()+"\n"))
+		} else if busy {
+			s.logger.Info("sweeper keeping idle-timed-out runner because github reports it is busy", "id", st.ID, "runner_name", st.RunnerName)
+			s.store.AppendLog(st.ID, "control.log", []byte("sweeper kept runner because github reports it is running a job\n"))
+			s.markRunnerJobStarted(st.ID)
+		} else {
+			s.logger.Info("sweeper stopping idle runner", "id", st.ID, "sandbox_id", st.SandboxID, "running_at", st.RunningAt, "idle_timeout", s.cfg.RunnerIdleTimeout)
+			s.store.AppendLog(st.ID, "control.log", []byte("sweeper stopping idle runner that never accepted a job\n"))
+			s.stopIfExists(ctx, st.ID, github.WorkflowJob{})
 		}
 	}
 }
@@ -152,6 +170,25 @@ func (s *Server) shouldStopIdleRunner(st state.RunnerState, now time.Time) bool 
 		return false
 	}
 	return now.Sub(st.RunningAt) > s.cfg.RunnerIdleTimeout
+}
+
+func (s *Server) githubRunnerBusy(ctx context.Context, st state.RunnerState) (bool, error) {
+	runnerName := strings.TrimSpace(st.RunnerName)
+	if runnerName == "" || strings.TrimSpace(st.RepositoryFullName) == "" {
+		return false, nil
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, workflowJobLookupTimeout)
+	defer cancel()
+	runners, err := s.gh.ListRunners(lookupCtx, st.RepositoryFullName, st.RunnerGroup)
+	if err != nil {
+		return false, err
+	}
+	for _, runner := range runners {
+		if runner.Name == runnerName {
+			return runner.Busy, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *Server) reconcileOnce(ctx context.Context) {

--- a/internal/server/server_runner_lifecycle.go
+++ b/internal/server/server_runner_lifecycle.go
@@ -456,16 +456,35 @@ func (s *Server) failStart(id string, st state.RunnerState, stage string, err er
 
 func (s *Server) runnerExited(id string, result sandboxrunner.ExitResult, err error) {
 	unlock := s.lockRunner(id)
-	defer unlock()
 
 	st, readErr := s.store.ReadState(id)
 	if readErr != nil {
+		unlock()
 		s.logger.Error("read state after runner exit", "id", id, "error", readErr)
 		return
 	}
 	if st.Status != state.StatusCreating && st.Status != state.StatusRunning {
+		unlock()
 		return
 	}
+	if shouldCheckGitHubBusyAfterRunnerExit(result, err) {
+		unlock()
+		if s.keepRunnerRunningWhenGitHubBusy(id, st, result, err) {
+			return
+		}
+		unlock = s.lockRunner(id)
+		st, readErr = s.store.ReadState(id)
+		if readErr != nil {
+			unlock()
+			s.logger.Error("read state after runner exit busy check", "id", id, "error", readErr)
+			return
+		}
+		if st.Status != state.StatusCreating && st.Status != state.StatusRunning {
+			unlock()
+			return
+		}
+	}
+	defer unlock()
 	if err != nil {
 		st.Status = state.StatusFailed
 		st.Error = err.Error()
@@ -524,6 +543,62 @@ func (s *Server) runnerExited(id string, result sandboxrunner.ExitResult, err er
 	}
 	s.writeStateOrLog(id, st, "write exited state")
 	s.refreshMetrics()
+}
+
+func shouldCheckGitHubBusyAfterRunnerExit(result sandboxrunner.ExitResult, err error) bool {
+	if err == nil && result.ExitCode == 0 {
+		return false
+	}
+	return true
+}
+
+func (s *Server) keepRunnerRunningWhenGitHubBusy(id string, st state.RunnerState, result sandboxrunner.ExitResult, err error) bool {
+	busy, busyErr := s.githubRunnerBusy(context.Background(), st)
+	if busyErr != nil {
+		s.logger.Warn("could not verify github runner busy state after runner exit", "id", id, "runner_name", st.RunnerName, "error", busyErr)
+		s.store.AppendLog(id, "control.log", []byte("could not verify github runner busy state after runner exit: "+busyErr.Error()+"\n"))
+		return false
+	}
+	if !busy {
+		return false
+	}
+	unlock := s.lockRunner(id)
+	defer unlock()
+	latest, readErr := s.store.ReadState(id)
+	if readErr != nil {
+		s.logger.Error("read state after busy runner exit check", "id", id, "error", readErr)
+		return false
+	}
+	if latest.Status != state.StatusCreating && latest.Status != state.StatusRunning {
+		return true
+	}
+	if latest.RunnerName != st.RunnerName || latest.SandboxID != st.SandboxID {
+		s.logger.Info("busy runner exit ignored because runner identity changed", "id", id, "runner_name", st.RunnerName, "sandbox_id", st.SandboxID)
+		return true
+	}
+	message := "runner process stream ended while GitHub still reports the runner is busy"
+	if err != nil {
+		message += ": " + err.Error()
+	} else {
+		message += ": " + runnerExitMessage(result)
+	}
+	latest.Status = state.StatusRunning
+	latest.LastErrorCode = "github_runner_busy"
+	latest.LastErrorMessage = message
+	latest.LastErrorRetryable = true
+	latest.Error = message
+	if latest.AssignedJobName == "" {
+		latest.AssignedJobName = runnerJobStartedMarker
+	}
+	if writeErr := s.store.WriteState(latest); writeErr != nil {
+		s.logger.Error("write running state after busy runner exit", "id", id, "error", writeErr)
+		s.store.AppendLog(id, "control.log", []byte("write running state after busy runner exit failed: "+writeErr.Error()+"\n"))
+		return false
+	}
+	s.logger.Warn("runner process stream ended while github runner is busy; keeping sandbox running", "id", id, "runner_name", latest.RunnerName, "sandbox_id", latest.SandboxID, "error", latest.Error)
+	s.store.AppendLog(id, "control.log", []byte(message+"; keeping sandbox running\n"))
+	s.refreshMetrics()
+	return true
 }
 
 func (s *Server) cleanupSandboxAfterExit(id string, st state.RunnerState) error {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2848,6 +2848,240 @@ func TestSweeperStopsIdleRunnerThatNeverAcceptedJob(t *testing.T) {
 	}
 }
 
+func TestSweeperKeepsIdleTimedOutRunnerWhenGitHubRunnerIsBusy(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/orgs/o/actions/runners" {
+			w.Write([]byte(`{"runners":[{"id":99,"name":"e2b-busy-on-github","status":"online","busy":true}]}`))
+			return
+		}
+		t.Fatalf("unexpected github request: %s %s", r.Method, r.URL.String())
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	if _, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "busy-on-github",
+		Source:             "test",
+		RepositoryFullName: "o/r",
+		Labels:             []string{"self-hosted", "e2b"},
+		ProfileName:        "default",
+		RunnerGroup:        "default",
+		RunnerName:         "e2b-busy-on-github",
+	}, nil); err != nil {
+		t.Fatal(err)
+	} else {
+		st.Status = state.StatusRunning
+		st.SandboxID = "sb-busy-on-github"
+		st.ProcessPID = 42
+		st.RunningAt = time.Now().Add(-10 * time.Minute).UTC()
+		if err := store.WriteState(st); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fake := &fakeSandbox{}
+	srv := newTestServerWithLimit(t, store, ghServer.URL, fake, 10)
+	srv.cfg.RunnerIdleTimeout = time.Minute
+	srv.sweepOnce(t.Context())
+	if fake.stoppedCount() != 0 {
+		t.Fatalf("expected sweeper to keep github-busy runner, got %d stops", fake.stoppedCount())
+	}
+	got, err := store.ReadState("busy-on-github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusRunning {
+		t.Fatalf("expected runner to stay running, got %s", got.Status)
+	}
+	if got.AssignedJobName != runnerJobStartedMarker {
+		t.Fatalf("expected github busy runner to be marked started, got assigned job name %q", got.AssignedJobName)
+	}
+}
+
+func TestSweeperStillStopsSandboxTimedOutRunnerWhenGitHubBusyCheckFails(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/orgs/o/actions/runners" {
+			http.Error(w, `{"message":"server error"}`, http.StatusInternalServerError)
+			return
+		}
+		t.Fatalf("unexpected github request: %s %s", r.Method, r.URL.String())
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	if _, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "timeout-after-busy-check-error",
+		Source:             "test",
+		RepositoryFullName: "o/r",
+		Labels:             []string{"self-hosted", "e2b"},
+		ProfileName:        "default",
+		RunnerGroup:        "default",
+		RunnerName:         "e2b-timeout-after-busy-check-error",
+	}, nil); err != nil {
+		t.Fatal(err)
+	} else {
+		st.Status = state.StatusRunning
+		st.SandboxID = "sb-timeout-after-busy-check-error"
+		st.ProcessPID = 42
+		st.RunningAt = time.Now().Add(-10 * time.Minute).UTC()
+		if err := store.WriteState(st); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fake := &fakeSandbox{}
+	srv := newTestServerWithLimit(t, store, ghServer.URL, fake, 10)
+	srv.cfg.RunnerIdleTimeout = time.Minute
+	srv.cfg.SandboxTimeout = time.Minute
+	srv.sweepOnce(t.Context())
+	if fake.stoppedCount() != 1 {
+		t.Fatalf("expected sweeper to stop sandbox-timed-out runner, got %d stops", fake.stoppedCount())
+	}
+	got, err := store.ReadState("timeout-after-busy-check-error")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusStopping || got.FailureStage != "sandbox_timeout" || got.FailureReason != "timeout" {
+		t.Fatalf("expected sandbox timeout failure, got %#v", got)
+	}
+}
+
+func TestSweeperHandlesSandboxTimeoutBeforeIdleBusyLookup(t *testing.T) {
+	lookupStarted := make(chan struct{})
+	releaseLookup := make(chan struct{})
+	var closeLookupStarted sync.Once
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodGet || r.URL.Path != "/orgs/o/actions/runners" {
+			t.Fatalf("unexpected github request: %s %s", r.Method, r.URL.String())
+		}
+		closeLookupStarted.Do(func() { close(lookupStarted) })
+		select {
+		case <-releaseLookup:
+		case <-r.Context().Done():
+			return
+		}
+		w.Write([]byte(`{"runners":[]}`))
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	if _, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:          "sandbox-timeout-before-idle",
+		Source:      "test",
+		Labels:      []string{"self-hosted", "e2b"},
+		ProfileName: "default",
+	}, nil); err != nil {
+		t.Fatal(err)
+	} else {
+		st.Status = state.StatusRunning
+		st.SandboxID = "sb-sandbox-timeout-before-idle"
+		st.ProcessPID = 42
+		st.RunningAt = time.Now().Add(-10 * time.Minute).UTC()
+		if err := store.WriteState(st); err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(time.Millisecond)
+	if _, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "idle-before-timeout",
+		Source:             "test",
+		RepositoryFullName: "o/r",
+		Labels:             []string{"self-hosted", "e2b"},
+		ProfileName:        "default",
+		RunnerGroup:        "default",
+		RunnerName:         "e2b-idle-before-timeout",
+	}, nil); err != nil {
+		t.Fatal(err)
+	} else {
+		st.Status = state.StatusRunning
+		st.SandboxID = "sb-idle-before-timeout"
+		st.ProcessPID = 42
+		st.RunningAt = time.Now().Add(-2 * time.Minute).UTC()
+		if err := store.WriteState(st); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fake := &fakeSandbox{}
+	srv := newTestServerWithLimit(t, store, ghServer.URL, fake, 10)
+	srv.cfg.RunnerIdleTimeout = time.Minute
+	srv.cfg.SandboxTimeout = 5 * time.Minute
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.sweepOnce(ctx)
+	}()
+	select {
+	case <-lookupStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for idle github runner lookup")
+	}
+	if fake.stoppedCount() != 1 {
+		t.Fatalf("expected sandbox timeout to be handled before idle github lookup, got %d stops", fake.stoppedCount())
+	}
+	close(releaseLookup)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for sweeper")
+	}
+}
+
+func TestSweeperStillStopsSandboxTimedOutRunnerWhenGitHubRunnerIsBusy(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/orgs/o/actions/runners":
+			w.Write([]byte(`{"runners":[{"id":99,"name":"e2b-busy-timeout","status":"online","busy":true}]}`))
+		case r.Method == http.MethodDelete && r.URL.Path == "/orgs/o/actions/runners/99":
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(`{"message":"Bad request - Runner e2b-busy-timeout is currently running a job and cannot be deleted.","status":"422"}`))
+		default:
+			t.Fatalf("unexpected github request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	if _, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "busy-timeout",
+		Source:             "test",
+		RepositoryFullName: "o/r",
+		Labels:             []string{"self-hosted", "e2b"},
+		ProfileName:        "default",
+		RunnerGroup:        "default",
+		RunnerName:         "e2b-busy-timeout",
+	}, nil); err != nil {
+		t.Fatal(err)
+	} else {
+		st.Status = state.StatusRunning
+		st.SandboxID = "sb-busy-timeout"
+		st.ProcessPID = 42
+		st.RunningAt = time.Now().Add(-10 * time.Minute).UTC()
+		if err := store.WriteState(st); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fake := &fakeSandbox{}
+	srv := newTestServerWithLimit(t, store, ghServer.URL, fake, 10)
+	srv.cfg.RunnerIdleTimeout = time.Minute
+	srv.cfg.SandboxTimeout = time.Minute
+	srv.sweepOnce(t.Context())
+	if fake.stoppedCount() != 1 {
+		t.Fatalf("expected sweeper to stop sandbox-timed-out busy runner, got %d stops", fake.stoppedCount())
+	}
+	got, err := store.ReadState("busy-timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusStopping || got.FailureStage != "sandbox_timeout" || got.FailureReason != "timeout" {
+		t.Fatalf("expected sandbox timeout cleanup retry, got %#v", got)
+	}
+}
+
 func TestSweeperKeepsRunnerAfterJobStarted(t *testing.T) {
 	store := state.New(t.TempDir())
 	if _, st, err := store.CreateRequest(state.RunnerRequest{

--- a/ui/src/components/runner-job-detail.tsx
+++ b/ui/src/components/runner-job-detail.tsx
@@ -272,7 +272,7 @@ export function RunnerJobDetail({ id, apiBase, onBack, onOpenJob, request }: Run
                 </CardContent>
               </Card>
             </TabsContent>
-            <TabsContent value="terminal" className="mt-4">
+            <TabsContent value="terminal" forceMount className="mt-4 data-[state=inactive]:hidden">
               <Card className="gap-0 py-0">
                 <CardHeader className="border-b px-5 py-4">
                   <div className="flex flex-wrap items-center justify-between gap-3">

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -1167,7 +1167,7 @@ function RunnerJobLogPanel({
             )}
           />
         </TabsContent>
-        <TabsContent value="web-console" className="m-0 flex min-h-0 flex-1 flex-col overflow-hidden pt-2">
+        <TabsContent value="web-console" forceMount className="m-0 flex min-h-0 flex-1 flex-col overflow-hidden pt-2 data-[state=inactive]:hidden">
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden border-y border-emerald-500/15 bg-[#111318] text-slate-100 shadow-[inset_3px_0_0_theme(colors.emerald.500/0.35)]">
             <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 bg-slate-900/95 px-4 py-3">
               <div className="min-w-0">


### PR DESCRIPTION
## Summary

Fix runnerd lifecycle handling when a GitHub self-hosted runner is still busy with a job but the local command stream or idle sweeper path thinks the runner can be cleaned up.

## What changed

- Check GitHub runner `busy` state before idle cleanup so an active job is not stopped before runnerd sees the in-progress webhook/stdout marker.
- Keep a runner request in `running` when the sandbox command stream exits or disconnects while GitHub still reports that runner as busy, allowing the completed webhook to perform normal cleanup.
- Preserve sandbox hard timeout enforcement even when the GitHub busy lookup fails.
- Keep Web Console / Terminal tabs mounted across tab switches without rendering inactive panels, so tab switching does not disconnect the terminal session.

## Root cause

A long-running job exposed two lifecycle gaps: runnerd could treat a runner as idle before local job-start markers were recorded, and the sandbox command stream could end with a transient deadline error while GitHub still had the job in progress. Both paths attempted cleanup early, which led GitHub to reject runner removal with `Runner ... is currently running a job and cannot be deleted`.

## Validation

- `go test ./internal/server -run 'TestSweeper(StillStopsSandboxTimedOutRunnerWhenGitHubBusyCheckFails|KeepsIdleTimedOutRunnerWhenGitHubRunnerIsBusy|StopsIdleRunnerThatNeverAcceptedJob)' -count=1`
- `go test ./internal/server -count=1`
- `task lint`
- `task test`
- Real E2E validation on `miclle/qiniu-ci-runner-test#7`: `Qiniu Runner E2E / Qiniu runner e2e` passed on self-hosted runner `e2b-86051248096`.
