### PR TITLE
feat(sandbox): inherit account credentials

### DIFF
--- a/internal/server/server_sandbox_service.go
+++ b/internal/server/server_sandbox_service.go
@@ -92,6 +92,13 @@ func (s *Server) sandboxServiceForScope(scope accountPreferenceScope) (sandboxru
 		if value.SourceAccountID <= 0 {
 			return nil, sandboxServiceConfigSnapshot{}, fmt.Errorf("sandbox service inherited account is not configured for %s:%d: %w", scope.Type, scope.ID, errSandboxServiceNotConfigured)
 		}
+		ok, err := s.githubInstallationLinkedToAccount(value.SourceAccountID, scope.ID)
+		if err != nil {
+			return nil, sandboxServiceConfigSnapshot{}, err
+		}
+		if !ok {
+			return nil, sandboxServiceConfigSnapshot{}, fmt.Errorf("sandbox service inherited account no longer has github installation %d: %w", scope.ID, errSandboxServiceNotConfigured)
+		}
 		return s.sandboxServiceForScope(accountPreferenceScope{Type: state.AccountScopeTypeAccount, ID: value.SourceAccountID})
 	}
 	apiURL := strings.TrimSpace(value.APIURL)
@@ -111,6 +118,19 @@ func (s *Server) sandboxServiceForScope(scope accountPreferenceScope) (sandboxru
 	}
 	svc, err := s.sandboxServiceForConfig(snapshot)
 	return svc, snapshot, err
+}
+
+func (s *Server) githubInstallationLinkedToAccount(accountID, installationID int64) (bool, error) {
+	installations, err := s.store.ListGitHubInstallations(accountID)
+	if err != nil {
+		return false, err
+	}
+	for _, installation := range installations {
+		if installation.InstallationID == installationID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *Server) sandboxServiceForConfig(snapshot sandboxServiceConfigSnapshot) (sandboxrunner.Service, error) {

--- a/internal/server/server_sandbox_service.go
+++ b/internal/server/server_sandbox_service.go
@@ -88,6 +88,12 @@ func (s *Server) sandboxServiceForScope(scope accountPreferenceScope) (sandboxru
 	if err := json.Unmarshal([]byte(preference.ValueJSON), &value); err != nil {
 		return nil, sandboxServiceConfigSnapshot{}, err
 	}
+	if normalizeSandboxPreferenceMode(value.Mode, scope) == sandboxPreferenceModeInherit {
+		if value.SourceAccountID <= 0 {
+			return nil, sandboxServiceConfigSnapshot{}, fmt.Errorf("sandbox service inherited account is not configured for %s:%d: %w", scope.Type, scope.ID, errSandboxServiceNotConfigured)
+		}
+		return s.sandboxServiceForScope(accountPreferenceScope{Type: state.AccountScopeTypeAccount, ID: value.SourceAccountID})
+	}
 	apiURL := strings.TrimSpace(value.APIURL)
 	if apiURL == "" {
 		return nil, sandboxServiceConfigSnapshot{}, fmt.Errorf("sandbox service api_url is not configured for %s:%d", scope.Type, scope.ID)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1018,8 +1018,11 @@ func TestUserSandboxAPIKeyPreferencesAreEncrypted(t *testing.T) {
 	}
 	var preferences struct {
 		Sandbox struct {
-			APIURL string `json:"api_url"`
-			APIKey struct {
+			Mode            string `json:"mode"`
+			APIURL          string `json:"api_url"`
+			Inherited       bool   `json:"inherited"`
+			SourceAccountID int64  `json:"source_account_id"`
+			APIKey          struct {
 				Configured bool   `json:"configured"`
 				UpdatedAt  string `json:"updated_at"`
 			} `json:"api_key"`
@@ -1028,7 +1031,7 @@ func TestUserSandboxAPIKeyPreferencesAreEncrypted(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
 		t.Fatal(err)
 	}
-	if preferences.Sandbox.APIURL != "" || preferences.Sandbox.APIKey.Configured {
+	if preferences.Sandbox.Mode != "custom" || preferences.Sandbox.APIURL != "" || preferences.Sandbox.APIKey.Configured {
 		t.Fatalf("expected sandbox api key to start unconfigured: %#v", preferences)
 	}
 
@@ -1046,7 +1049,7 @@ func TestUserSandboxAPIKeyPreferencesAreEncrypted(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
 		t.Fatal(err)
 	}
-	if preferences.Sandbox.APIURL != "https://sandbox.example.test" || !preferences.Sandbox.APIKey.Configured || preferences.Sandbox.APIKey.UpdatedAt == "" {
+	if preferences.Sandbox.Mode != "custom" || preferences.Sandbox.APIURL != "https://sandbox.example.test" || !preferences.Sandbox.APIKey.Configured || preferences.Sandbox.APIKey.UpdatedAt == "" {
 		t.Fatalf("expected configured sandbox response: %#v", preferences)
 	}
 
@@ -1094,8 +1097,55 @@ func TestUserSandboxAPIKeyPreferencesAreEncrypted(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
 		t.Fatal(err)
 	}
-	if preferences.Sandbox.APIURL != "" || preferences.Sandbox.APIKey.Configured {
-		t.Fatalf("expected org sandbox preferences to be isolated from account preferences: %#v", preferences)
+	if preferences.Sandbox.Mode != "custom" || preferences.Sandbox.Inherited || preferences.Sandbox.SourceAccountID != 0 || preferences.Sandbox.APIURL != "" || preferences.Sandbox.APIKey.Configured {
+		t.Fatalf("expected org sandbox preferences to start unconfigured: %#v", preferences)
+	}
+
+	req = httptest.NewRequest(http.MethodPut, fmt.Sprintf("/user/preferences/sandbox?installation_id=%d", installation.ID), strings.NewReader(`{"api_url":"https://org-sandbox.example.test","api_key":"org-sandbox-secret-key"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected org custom save status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	if _, err := store.GetAccountSecret(state.AccountScopeTypeGitHubInstall, installation.InstallationID, state.AccountSecretTypeSandboxAPIKey); err != nil {
+		t.Fatal(err)
+	}
+
+	req = httptest.NewRequest(http.MethodPut, fmt.Sprintf("/user/preferences/sandbox?installation_id=%d", installation.ID), strings.NewReader(`{"mode":"inherit"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected org inherit save status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	config, err = store.GetAccountPreference(state.AccountScopeTypeGitHubInstall, installation.InstallationID, "sandbox", "service")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedOrgConfig := fmt.Sprintf(`{"mode":"inherit","source_account_id":%d}`, account.ID)
+	if config.ValueJSON != expectedOrgConfig {
+		t.Fatalf("unexpected org inherited sandbox preference value: %q", config.ValueJSON)
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
+		t.Fatal(err)
+	}
+	if preferences.Sandbox.Mode != "inherit" || !preferences.Sandbox.Inherited || preferences.Sandbox.APIURL != "https://sandbox.example.test" || !preferences.Sandbox.APIKey.Configured {
+		t.Fatalf("expected saved org sandbox preferences to inherit account preferences: %#v", preferences)
+	}
+	if _, err := store.GetAccountSecret(state.AccountScopeTypeGitHubInstall, installation.InstallationID, state.AccountSecretTypeSandboxAPIKey); err != state.ErrNotFound {
+		t.Fatalf("expected inherited org sandbox preference to delete scoped api key, got %v", err)
+	}
+
+	req = httptest.NewRequest(http.MethodPut, fmt.Sprintf("/user/preferences/sandbox?installation_id=%d", installation.ID), strings.NewReader(`{"api_url":"https://org-sandbox-updated.example.test"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected org custom save without new key to fail after inherit cleared scoped key, status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
 	req = httptest.NewRequest(http.MethodPut, "/user/preferences/sandbox", strings.NewReader(`{"api_url":"https://sandbox-updated.example.test"}`))
@@ -1112,7 +1162,7 @@ func TestUserSandboxAPIKeyPreferencesAreEncrypted(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
 		t.Fatal(err)
 	}
-	if preferences.Sandbox.APIURL != "https://sandbox-updated.example.test" || !preferences.Sandbox.APIKey.Configured {
+	if preferences.Sandbox.Mode != "custom" || preferences.Sandbox.APIURL != "https://sandbox-updated.example.test" || !preferences.Sandbox.APIKey.Configured {
 		t.Fatalf("expected updated url with existing api key: %#v", preferences)
 	}
 
@@ -1129,7 +1179,7 @@ func TestUserSandboxAPIKeyPreferencesAreEncrypted(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
 		t.Fatal(err)
 	}
-	if preferences.Sandbox.APIURL != "https://sandbox-updated.example.test" || preferences.Sandbox.APIKey.Configured {
+	if preferences.Sandbox.Mode != "custom" || preferences.Sandbox.APIURL != "https://sandbox-updated.example.test" || preferences.Sandbox.APIKey.Configured {
 		t.Fatalf("expected delete to preserve sandbox api url and clear key: %#v", preferences)
 	}
 }
@@ -1237,6 +1287,70 @@ func TestSandboxServiceFallsBackToPersonalAccountPreferences(t *testing.T) {
 	}
 	if svc, err := srv.sandboxServiceForRunnerRequest(context.Background(), state.RunnerRequest{ID: "req-1", GitHubInstallationID: 987}); err != nil || svc == nil {
 		t.Fatalf("expected sandbox service from personal account preferences, service=%T err=%v", svc, err)
+	}
+}
+
+func TestSandboxServiceUsesInheritedAccountPreferencesForOrgInstallation(t *testing.T) {
+	store := state.New(t.TempDir())
+	cfg := config.Config{
+		AuthEncryptionKey:    "encryption-key",
+		MaxConcurrentRunners: 10,
+	}
+	srv := New(cfg, store, github.NewClient("", http.DefaultClient), nil, nil)
+	account, _, err := store.EnsureAccountForOAuthIdentity(state.OAuthIdentity{OAuthProvider: "github", OAuthSubject: "100", OAuthLogin: "miclle"}, "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertGitHubInstallation(state.GitHubInstallation{
+		AccountID:      account.ID,
+		InstallationID: 987,
+		AccountLogin:   "gitwikitree",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	valueJSON, err := json.Marshal(accountSandboxServicePreferenceValue{APIURL: "https://sandbox.example.test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertAccountPreference(state.AccountPreference{
+		ScopeType: state.AccountScopeTypeAccount,
+		ScopeID:   account.ID,
+		Namespace: accountPreferenceNamespaceSandbox,
+		Key:       accountPreferenceKeySandboxService,
+		ValueJSON: string(valueJSON),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	inheritedValueJSON, err := json.Marshal(accountSandboxServicePreferenceValue{
+		Mode:            sandboxPreferenceModeInherit,
+		SourceAccountID: account.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertAccountPreference(state.AccountPreference{
+		ScopeType: state.AccountScopeTypeGitHubInstall,
+		ScopeID:   987,
+		Namespace: accountPreferenceNamespaceSandbox,
+		Key:       accountPreferenceKeySandboxService,
+		ValueJSON: string(inheritedValueJSON),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := encryptSecret("sandbox-secret-key", srv.cfg.AuthEncryptionKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertAccountSecret(state.AccountSecret{
+		ScopeType:      state.AccountScopeTypeAccount,
+		ScopeID:        account.ID,
+		KeyType:        state.AccountSecretTypeSandboxAPIKey,
+		EncryptedValue: encrypted,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if svc, err := srv.sandboxServiceForRunnerRequest(context.Background(), state.RunnerRequest{ID: "req-1", GitHubInstallationID: 987}); err != nil || svc == nil {
+		t.Fatalf("expected sandbox service from inherited account preferences, service=%T err=%v", svc, err)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1301,11 +1301,12 @@ func TestSandboxServiceUsesInheritedAccountPreferencesForOrgInstallation(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.UpsertGitHubInstallation(state.GitHubInstallation{
+	installation, err := store.UpsertGitHubInstallation(state.GitHubInstallation{
 		AccountID:      account.ID,
 		InstallationID: 987,
 		AccountLogin:   "gitwikitree",
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	valueJSON, err := json.Marshal(accountSandboxServicePreferenceValue{APIURL: "https://sandbox.example.test"})
@@ -1351,6 +1352,12 @@ func TestSandboxServiceUsesInheritedAccountPreferencesForOrgInstallation(t *test
 	}
 	if svc, err := srv.sandboxServiceForRunnerRequest(context.Background(), state.RunnerRequest{ID: "req-1", GitHubInstallationID: 987}); err != nil || svc == nil {
 		t.Fatalf("expected sandbox service from inherited account preferences, service=%T err=%v", svc, err)
+	}
+	if err := store.DeleteGitHubInstallation(account.ID, installation.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := srv.sandboxServiceForRunnerRequest(context.Background(), state.RunnerRequest{ID: "req-1", GitHubInstallationID: 987}); !errors.Is(err, errSandboxServiceNotConfigured) {
+		t.Fatalf("expected inherited sandbox service to require current installation link, got %v", err)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1184,6 +1184,152 @@ func TestUserSandboxAPIKeyPreferencesAreEncrypted(t *testing.T) {
 	}
 }
 
+func TestUserSandboxInheritanceRequiresExplicitSourceReplacement(t *testing.T) {
+	store := state.New(t.TempDir())
+	srv := newTestServer(t, store, "", &fakeSandbox{})
+	if _, _, err := store.UpsertAccountForOAuthIdentity(state.OAuthIdentity{OAuthProvider: "github", OAuthSubject: "alice-id", OAuthLogin: "alice"}, "user"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.UpsertAccountForOAuthIdentity(state.OAuthIdentity{OAuthProvider: "github", OAuthSubject: "bob-id", OAuthLogin: "bob"}, "user"); err != nil {
+		t.Fatal(err)
+	}
+
+	type sandboxPreferences struct {
+		Sandbox struct {
+			Mode                   string `json:"mode"`
+			APIURL                 string `json:"api_url"`
+			Inherited              bool   `json:"inherited"`
+			SourceAccountID        int64  `json:"source_account_id"`
+			SourceAccountLogin     string `json:"source_account_login"`
+			SourceIsCurrentAccount bool   `json:"source_is_current_account"`
+			APIKey                 struct {
+				Configured bool `json:"configured"`
+			} `json:"api_key"`
+		} `json:"sandbox"`
+	}
+
+	saveAccountDefault := func(subject, login, apiURL, apiKey string) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPut, "/user/preferences/sandbox", strings.NewReader(fmt.Sprintf(`{"api_url":%q,"api_key":%q}`, apiURL, apiKey)))
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(testSessionCookie(subject, login, "user"))
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("save %s account defaults: status=%d body=%s", login, rec.Code, rec.Body.String())
+		}
+	}
+
+	saveAccountDefault("alice-id", "alice", "https://alice-sandbox.example.test", "alice-key")
+	saveAccountDefault("bob-id", "bob", "https://bob-sandbox.example.test", "bob-key")
+	alice, _, err := store.GetAccountByOAuthIdentity("github", "alice-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bob, _, err := store.GetAccountByOAuthIdentity("github", "bob-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliceInstallation, err := store.UpsertGitHubInstallation(state.GitHubInstallation{AccountID: alice.ID, InstallationID: 987, AccountLogin: "example-org"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bobInstallation, err := store.UpsertGitHubInstallation(state.GitHubInstallation{AccountID: bob.ID, InstallationID: 987, AccountLogin: "example-org"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/user/preferences/sandbox?installation_id=%d", aliceInstallation.ID), strings.NewReader(`{"mode":"inherit"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(testSessionCookie("alice-id", "alice", "user"))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("alice enables inheritance: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/user/preferences?installation_id=%d", bobInstallation.ID), nil)
+	req.AddCookie(testSessionCookie("bob-id", "bob", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("bob reads inherited preferences: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var preferences sandboxPreferences
+	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
+		t.Fatal(err)
+	}
+	if preferences.Sandbox.SourceAccountID != alice.ID || preferences.Sandbox.SourceAccountLogin != "alice" || preferences.Sandbox.SourceIsCurrentAccount || preferences.Sandbox.APIURL != "https://alice-sandbox.example.test" {
+		t.Fatalf("expected bob to see alice as the inherited source: %#v", preferences)
+	}
+
+	req = httptest.NewRequest(http.MethodPut, fmt.Sprintf("/user/preferences/sandbox?installation_id=%d", bobInstallation.ID), strings.NewReader(`{"mode":"inherit"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(testSessionCookie("bob-id", "bob", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("bob preserves inherited source: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
+		t.Fatal(err)
+	}
+	if preferences.Sandbox.SourceAccountID != alice.ID || preferences.Sandbox.SourceIsCurrentAccount {
+		t.Fatalf("expected ordinary inherit save to preserve alice as source: %#v", preferences)
+	}
+
+	req = httptest.NewRequest(http.MethodPut, fmt.Sprintf("/user/preferences/sandbox?installation_id=%d", bobInstallation.ID), strings.NewReader(`{"mode":"inherit","replace_inherited_source":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(testSessionCookie("bob-id", "bob", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("bob replaces inherited source: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
+		t.Fatal(err)
+	}
+	if preferences.Sandbox.SourceAccountID != bob.ID || preferences.Sandbox.SourceAccountLogin != "bob" || !preferences.Sandbox.SourceIsCurrentAccount || preferences.Sandbox.APIURL != "https://bob-sandbox.example.test" {
+		t.Fatalf("expected explicit replacement to use bob as source: %#v", preferences)
+	}
+}
+
+func TestUserSandboxInheritanceRejectsUnconfiguredSourceAccount(t *testing.T) {
+	store := state.New(t.TempDir())
+	srv := newTestServer(t, store, "", &fakeSandbox{})
+	if _, _, err := store.UpsertAccountForOAuthIdentity(state.OAuthIdentity{OAuthProvider: "github", OAuthSubject: "alice-id", OAuthLogin: "alice"}, "user"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/user/preferences", nil)
+	req.AddCookie(testSessionCookie("alice-id", "alice", "user"))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create alice account: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	alice, _, err := store.GetAccountByOAuthIdentity("github", "alice-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation, err := store.UpsertGitHubInstallation(state.GitHubInstallation{AccountID: alice.ID, InstallationID: 987, AccountLogin: "example-org"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req = httptest.NewRequest(http.MethodPut, fmt.Sprintf("/user/preferences/sandbox?installation_id=%d", installation.ID), strings.NewReader(`{"mode":"inherit"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(testSessionCookie("alice-id", "alice", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "configure your account Sandbox service first") {
+		t.Fatalf("expected unconfigured inherited source to be rejected: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if _, err := store.GetAccountPreference(state.AccountScopeTypeGitHubInstall, installation.InstallationID, "sandbox", "service"); err != state.ErrNotFound {
+		t.Fatalf("expected rejected inheritance not to save an org preference, got %v", err)
+	}
+}
+
 func TestSandboxServiceUsesGitHubInstallationPreferences(t *testing.T) {
 	store := state.New(t.TempDir())
 	cfg := config.Config{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1202,6 +1202,7 @@ func TestUserSandboxInheritanceRequiresExplicitSourceReplacement(t *testing.T) {
 			SourceAccountID        int64  `json:"source_account_id"`
 			SourceAccountLogin     string `json:"source_account_login"`
 			SourceIsCurrentAccount bool   `json:"source_is_current_account"`
+			SourceAvailable        bool   `json:"source_available"`
 			APIKey                 struct {
 				Configured bool `json:"configured"`
 			} `json:"api_key"`
@@ -1259,7 +1260,7 @@ func TestUserSandboxInheritanceRequiresExplicitSourceReplacement(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
 		t.Fatal(err)
 	}
-	if preferences.Sandbox.SourceAccountID != alice.ID || preferences.Sandbox.SourceAccountLogin != "alice" || preferences.Sandbox.SourceIsCurrentAccount || preferences.Sandbox.APIURL != "https://alice-sandbox.example.test" {
+	if preferences.Sandbox.SourceAccountID != alice.ID || preferences.Sandbox.SourceAccountLogin != "alice" || preferences.Sandbox.SourceIsCurrentAccount || !preferences.Sandbox.SourceAvailable || preferences.Sandbox.APIURL != "https://alice-sandbox.example.test" {
 		t.Fatalf("expected bob to see alice as the inherited source: %#v", preferences)
 	}
 
@@ -1277,6 +1278,22 @@ func TestUserSandboxInheritanceRequiresExplicitSourceReplacement(t *testing.T) {
 	if preferences.Sandbox.SourceAccountID != alice.ID || preferences.Sandbox.SourceIsCurrentAccount {
 		t.Fatalf("expected ordinary inherit save to preserve alice as source: %#v", preferences)
 	}
+	if err := store.DeleteGitHubInstallation(alice.ID, aliceInstallation.ID); err != nil {
+		t.Fatal(err)
+	}
+	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/user/preferences?installation_id=%d", bobInstallation.ID), nil)
+	req.AddCookie(testSessionCookie("bob-id", "bob", "user"))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("bob reads unavailable inherited preferences: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
+		t.Fatal(err)
+	}
+	if !preferences.Sandbox.Inherited || preferences.Sandbox.SourceAvailable || preferences.Sandbox.SourceAccountID != alice.ID || preferences.Sandbox.SourceAccountLogin != "alice" || preferences.Sandbox.APIURL != "" || preferences.Sandbox.APIKey.Configured {
+		t.Fatalf("expected unlinked inherited source to be unavailable: %#v", preferences)
+	}
 
 	req = httptest.NewRequest(http.MethodPut, fmt.Sprintf("/user/preferences/sandbox?installation_id=%d", bobInstallation.ID), strings.NewReader(`{"mode":"inherit","replace_inherited_source":true}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -1289,7 +1306,7 @@ func TestUserSandboxInheritanceRequiresExplicitSourceReplacement(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &preferences); err != nil {
 		t.Fatal(err)
 	}
-	if preferences.Sandbox.SourceAccountID != bob.ID || preferences.Sandbox.SourceAccountLogin != "bob" || !preferences.Sandbox.SourceIsCurrentAccount || preferences.Sandbox.APIURL != "https://bob-sandbox.example.test" {
+	if preferences.Sandbox.SourceAccountID != bob.ID || preferences.Sandbox.SourceAccountLogin != "bob" || !preferences.Sandbox.SourceIsCurrentAccount || !preferences.Sandbox.SourceAvailable || preferences.Sandbox.APIURL != "https://bob-sandbox.example.test" {
 		t.Fatalf("expected explicit replacement to use bob as source: %#v", preferences)
 	}
 }

--- a/internal/server/server_user_handlers.go
+++ b/internal/server/server_user_handlers.go
@@ -32,6 +32,7 @@ type accountSandboxPreference struct {
 	SourceAccountID        int64                          `json:"source_account_id,omitempty"`
 	SourceAccountLogin     string                         `json:"source_account_login,omitempty"`
 	SourceIsCurrentAccount bool                           `json:"source_is_current_account,omitempty"`
+	SourceAvailable        bool                           `json:"source_available"`
 }
 
 type accountSandboxAPIKeyPreference struct {
@@ -407,6 +408,14 @@ func (s *Server) accountPreferencesResponse(scope accountPreferenceScope, viewer
 				return accountPreferencesResponse{}, err
 			}
 			response.Sandbox.SourceAccountLogin = identity.OAuthLogin
+			available, err := s.githubInstallationLinkedToAccount(value.SourceAccountID, scope.ID)
+			if err != nil {
+				return accountPreferencesResponse{}, err
+			}
+			response.Sandbox.SourceAvailable = available
+			if !available {
+				return response, nil
+			}
 			return s.fillSandboxResponseFromScope(response, accountPreferenceScope{Type: state.AccountScopeTypeAccount, ID: value.SourceAccountID})
 		}
 		response.Sandbox.APIURL = value.APIURL

--- a/internal/server/server_user_handlers.go
+++ b/internal/server/server_user_handlers.go
@@ -392,6 +392,7 @@ func (s *Server) accountPreferencesResponse(scope accountPreferenceScope, viewer
 			return accountPreferencesResponse{}, err
 		}
 		response.Sandbox.Mode = sandboxPreferenceModeCustom
+		return response, nil
 	} else {
 		var value accountSandboxServicePreferenceValue
 		if err := json.Unmarshal([]byte(preference.ValueJSON), &value); err != nil {

--- a/internal/server/server_user_handlers.go
+++ b/internal/server/server_user_handlers.go
@@ -236,7 +236,7 @@ func (s *Server) handleUserPreferences(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	response, err := s.accountPreferencesResponse(scope, account.ID)
+	response, err := s.accountPreferencesResponse(scope)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -324,12 +324,16 @@ func (s *Server) handleUserSaveSandboxConfig(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	s.recordAudit("github:"+session.Subject, "sandbox.configure", scope.Type, strconv.FormatInt(scope.ID, 10), map[string]any{
+	auditPayload := map[string]any{
 		"mode":           mode,
 		"api_url":        value.APIURL,
 		"api_key_update": apiKey != "",
-	})
-	response, err := s.accountPreferencesResponse(scope, account.ID)
+	}
+	if mode == sandboxPreferenceModeInherit {
+		auditPayload["source_account_id"] = value.SourceAccountID
+	}
+	s.recordAudit("github:"+session.Subject, "sandbox.configure", scope.Type, strconv.FormatInt(scope.ID, 10), auditPayload)
+	response, err := s.accountPreferencesResponse(scope)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -352,7 +356,7 @@ func (s *Server) handleUserDeleteSandboxAPIKey(w http.ResponseWriter, r *http.Re
 		return
 	}
 	s.recordAudit("github:"+session.Subject, "sandbox_api_key.delete", scope.Type, strconv.FormatInt(scope.ID, 10), nil)
-	response, err := s.accountPreferencesResponse(scope, account.ID)
+	response, err := s.accountPreferencesResponse(scope)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -360,7 +364,7 @@ func (s *Server) handleUserDeleteSandboxAPIKey(w http.ResponseWriter, r *http.Re
 	writeJSON(w, http.StatusOK, response)
 }
 
-func (s *Server) accountPreferencesResponse(scope accountPreferenceScope, accountID int64) (accountPreferencesResponse, error) {
+func (s *Server) accountPreferencesResponse(scope accountPreferenceScope) (accountPreferencesResponse, error) {
 	var response accountPreferencesResponse
 	preference, err := s.store.GetAccountPreference(scope.Type, scope.ID, accountPreferenceNamespaceSandbox, accountPreferenceKeySandboxService)
 	if err != nil {

--- a/internal/server/server_user_handlers.go
+++ b/internal/server/server_user_handlers.go
@@ -25,11 +25,13 @@ type accountPreferencesResponse struct {
 }
 
 type accountSandboxPreference struct {
-	Mode            string                         `json:"mode"`
-	APIURL          string                         `json:"api_url"`
-	APIKey          accountSandboxAPIKeyPreference `json:"api_key"`
-	Inherited       bool                           `json:"inherited"`
-	SourceAccountID int64                          `json:"source_account_id,omitempty"`
+	Mode                   string                         `json:"mode"`
+	APIURL                 string                         `json:"api_url"`
+	APIKey                 accountSandboxAPIKeyPreference `json:"api_key"`
+	Inherited              bool                           `json:"inherited"`
+	SourceAccountID        int64                          `json:"source_account_id,omitempty"`
+	SourceAccountLogin     string                         `json:"source_account_login,omitempty"`
+	SourceIsCurrentAccount bool                           `json:"source_is_current_account,omitempty"`
 }
 
 type accountSandboxAPIKeyPreference struct {
@@ -44,9 +46,10 @@ type accountSandboxServicePreferenceValue struct {
 }
 
 type upsertSandboxConfigRequest struct {
-	APIURL string `json:"api_url"`
-	APIKey string `json:"api_key"`
-	Mode   string `json:"mode"`
+	APIURL                 string `json:"api_url"`
+	APIKey                 string `json:"api_key"`
+	Mode                   string `json:"mode"`
+	ReplaceInheritedSource bool   `json:"replace_inherited_source"`
 }
 
 type accountPreferenceScope struct {
@@ -236,7 +239,7 @@ func (s *Server) handleUserPreferences(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	response, err := s.accountPreferencesResponse(scope)
+	response, err := s.accountPreferencesResponse(scope, account.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -268,7 +271,23 @@ func (s *Server) handleUserSaveSandboxConfig(w http.ResponseWriter, r *http.Requ
 			writeError(w, http.StatusBadRequest, "inherit mode is only supported for GitHub installation preferences")
 			return
 		}
-		value = accountSandboxServicePreferenceValue{Mode: sandboxPreferenceModeInherit, SourceAccountID: account.ID}
+		sourceAccountID, err := s.inheritedSandboxSourceAccountID(scope, account.ID, input.ReplaceInheritedSource)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if sourceAccountID == account.ID {
+			configured, err := s.sandboxSourceAccountConfigured(account.ID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if !configured {
+				writeError(w, http.StatusBadRequest, "configure your account Sandbox service first")
+				return
+			}
+		}
+		value = accountSandboxServicePreferenceValue{Mode: sandboxPreferenceModeInherit, SourceAccountID: sourceAccountID}
 	} else {
 		apiURL, err := normalizeHTTPURL(input.APIURL)
 		if err != nil {
@@ -333,7 +352,7 @@ func (s *Server) handleUserSaveSandboxConfig(w http.ResponseWriter, r *http.Requ
 		auditPayload["source_account_id"] = value.SourceAccountID
 	}
 	s.recordAudit("github:"+session.Subject, "sandbox.configure", scope.Type, strconv.FormatInt(scope.ID, 10), auditPayload)
-	response, err := s.accountPreferencesResponse(scope)
+	response, err := s.accountPreferencesResponse(scope, account.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -356,7 +375,7 @@ func (s *Server) handleUserDeleteSandboxAPIKey(w http.ResponseWriter, r *http.Re
 		return
 	}
 	s.recordAudit("github:"+session.Subject, "sandbox_api_key.delete", scope.Type, strconv.FormatInt(scope.ID, 10), nil)
-	response, err := s.accountPreferencesResponse(scope)
+	response, err := s.accountPreferencesResponse(scope, account.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -364,7 +383,7 @@ func (s *Server) handleUserDeleteSandboxAPIKey(w http.ResponseWriter, r *http.Re
 	writeJSON(w, http.StatusOK, response)
 }
 
-func (s *Server) accountPreferencesResponse(scope accountPreferenceScope) (accountPreferencesResponse, error) {
+func (s *Server) accountPreferencesResponse(scope accountPreferenceScope, viewerAccountID int64) (accountPreferencesResponse, error) {
 	var response accountPreferencesResponse
 	preference, err := s.store.GetAccountPreference(scope.Type, scope.ID, accountPreferenceNamespaceSandbox, accountPreferenceKeySandboxService)
 	if err != nil {
@@ -382,11 +401,62 @@ func (s *Server) accountPreferencesResponse(scope accountPreferenceScope) (accou
 		if mode == sandboxPreferenceModeInherit {
 			response.Sandbox.Inherited = true
 			response.Sandbox.SourceAccountID = value.SourceAccountID
+			response.Sandbox.SourceIsCurrentAccount = value.SourceAccountID == viewerAccountID
+			identity, err := s.store.GetOAuthIdentityForAccount(value.SourceAccountID, "github")
+			if err != nil && !errors.Is(err, state.ErrNotFound) {
+				return accountPreferencesResponse{}, err
+			}
+			response.Sandbox.SourceAccountLogin = identity.OAuthLogin
 			return s.fillSandboxResponseFromScope(response, accountPreferenceScope{Type: state.AccountScopeTypeAccount, ID: value.SourceAccountID})
 		}
 		response.Sandbox.APIURL = value.APIURL
 	}
 	return s.fillSandboxResponseFromScope(response, scope)
+}
+
+func (s *Server) inheritedSandboxSourceAccountID(scope accountPreferenceScope, currentAccountID int64, replace bool) (int64, error) {
+	if replace {
+		return currentAccountID, nil
+	}
+	preference, err := s.store.GetAccountPreference(scope.Type, scope.ID, accountPreferenceNamespaceSandbox, accountPreferenceKeySandboxService)
+	if err != nil {
+		if errors.Is(err, state.ErrNotFound) {
+			return currentAccountID, nil
+		}
+		return 0, err
+	}
+	var value accountSandboxServicePreferenceValue
+	if err := json.Unmarshal([]byte(preference.ValueJSON), &value); err != nil {
+		return 0, err
+	}
+	if normalizeSandboxPreferenceMode(value.Mode, scope) == sandboxPreferenceModeInherit && value.SourceAccountID > 0 {
+		return value.SourceAccountID, nil
+	}
+	return currentAccountID, nil
+}
+
+func (s *Server) sandboxSourceAccountConfigured(accountID int64) (bool, error) {
+	preference, err := s.store.GetAccountPreference(state.AccountScopeTypeAccount, accountID, accountPreferenceNamespaceSandbox, accountPreferenceKeySandboxService)
+	if err != nil {
+		if errors.Is(err, state.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	var value accountSandboxServicePreferenceValue
+	if err := json.Unmarshal([]byte(preference.ValueJSON), &value); err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(value.APIURL) == "" {
+		return false, nil
+	}
+	if _, err := s.store.GetAccountSecret(state.AccountScopeTypeAccount, accountID, state.AccountSecretTypeSandboxAPIKey); err != nil {
+		if errors.Is(err, state.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *Server) fillSandboxResponseFromScope(response accountPreferencesResponse, scope accountPreferenceScope) (accountPreferencesResponse, error) {

--- a/internal/server/server_user_handlers.go
+++ b/internal/server/server_user_handlers.go
@@ -25,8 +25,11 @@ type accountPreferencesResponse struct {
 }
 
 type accountSandboxPreference struct {
-	APIURL string                         `json:"api_url"`
-	APIKey accountSandboxAPIKeyPreference `json:"api_key"`
+	Mode            string                         `json:"mode"`
+	APIURL          string                         `json:"api_url"`
+	APIKey          accountSandboxAPIKeyPreference `json:"api_key"`
+	Inherited       bool                           `json:"inherited"`
+	SourceAccountID int64                          `json:"source_account_id,omitempty"`
 }
 
 type accountSandboxAPIKeyPreference struct {
@@ -35,12 +38,15 @@ type accountSandboxAPIKeyPreference struct {
 }
 
 type accountSandboxServicePreferenceValue struct {
-	APIURL string `json:"api_url"`
+	Mode            string `json:"mode,omitempty"`
+	APIURL          string `json:"api_url,omitempty"`
+	SourceAccountID int64  `json:"source_account_id,omitempty"`
 }
 
 type upsertSandboxConfigRequest struct {
 	APIURL string `json:"api_url"`
 	APIKey string `json:"api_key"`
+	Mode   string `json:"mode"`
 }
 
 type accountPreferenceScope struct {
@@ -230,7 +236,7 @@ func (s *Server) handleUserPreferences(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	response, err := s.accountPreferencesResponse(scope)
+	response, err := s.accountPreferencesResponse(scope, account.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -253,22 +259,47 @@ func (s *Server) handleUserSaveSandboxConfig(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusBadRequest, "invalid sandbox config payload")
 		return
 	}
-	apiURL, err := normalizeHTTPURL(input.APIURL)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+	mode := normalizeSandboxPreferenceMode(input.Mode, scope)
 	apiKey := strings.TrimSpace(input.APIKey)
-	_, currentKeyErr := s.store.GetAccountSecret(scope.Type, scope.ID, state.AccountSecretTypeSandboxAPIKey)
-	if apiKey == "" && errors.Is(currentKeyErr, state.ErrNotFound) {
-		writeError(w, http.StatusBadRequest, "api_key is required")
-		return
+	var value accountSandboxServicePreferenceValue
+	var secret *state.AccountSecret
+	if mode == sandboxPreferenceModeInherit {
+		if scope.Type != state.AccountScopeTypeGitHubInstall {
+			writeError(w, http.StatusBadRequest, "inherit mode is only supported for GitHub installation preferences")
+			return
+		}
+		value = accountSandboxServicePreferenceValue{Mode: sandboxPreferenceModeInherit, SourceAccountID: account.ID}
+	} else {
+		apiURL, err := normalizeHTTPURL(input.APIURL)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		_, currentKeyErr := s.store.GetAccountSecret(scope.Type, scope.ID, state.AccountSecretTypeSandboxAPIKey)
+		if apiKey == "" && errors.Is(currentKeyErr, state.ErrNotFound) {
+			writeError(w, http.StatusBadRequest, "api_key is required")
+			return
+		}
+		if currentKeyErr != nil && !errors.Is(currentKeyErr, state.ErrNotFound) {
+			writeError(w, http.StatusInternalServerError, currentKeyErr.Error())
+			return
+		}
+		value = accountSandboxServicePreferenceValue{APIURL: apiURL}
+		if apiKey != "" {
+			encryptedAPIKey, err := encryptSecret(apiKey, s.cfg.AuthEncryptionKey)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			secret = &state.AccountSecret{
+				ScopeType:      scope.Type,
+				ScopeID:        scope.ID,
+				KeyType:        state.AccountSecretTypeSandboxAPIKey,
+				EncryptedValue: encryptedAPIKey,
+			}
+		}
 	}
-	if currentKeyErr != nil && !errors.Is(currentKeyErr, state.ErrNotFound) {
-		writeError(w, http.StatusInternalServerError, currentKeyErr.Error())
-		return
-	}
-	valueJSON, err := json.Marshal(accountSandboxServicePreferenceValue{APIURL: apiURL})
+	valueJSON, err := json.Marshal(value)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -280,29 +311,25 @@ func (s *Server) handleUserSaveSandboxConfig(w http.ResponseWriter, r *http.Requ
 		Key:       accountPreferenceKeySandboxService,
 		ValueJSON: string(valueJSON),
 	}
-	var secret *state.AccountSecret
-	if apiKey != "" {
-		encryptedAPIKey, err := encryptSecret(apiKey, s.cfg.AuthEncryptionKey)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
-		}
-		secret = &state.AccountSecret{
-			ScopeType:      scope.Type,
-			ScopeID:        scope.ID,
-			KeyType:        state.AccountSecretTypeSandboxAPIKey,
-			EncryptedValue: encryptedAPIKey,
-		}
+	if mode == sandboxPreferenceModeInherit {
+		_, err = s.store.UpsertAccountPreferenceAndDeleteSecret(preference, state.AccountSecret{
+			ScopeType: scope.Type,
+			ScopeID:   scope.ID,
+			KeyType:   state.AccountSecretTypeSandboxAPIKey,
+		})
+	} else {
+		_, _, err = s.store.UpsertAccountPreferenceAndSecret(preference, secret)
 	}
-	if _, _, err := s.store.UpsertAccountPreferenceAndSecret(preference, secret); err != nil {
+	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	s.recordAudit("github:"+session.Subject, "sandbox.configure", scope.Type, strconv.FormatInt(scope.ID, 10), map[string]any{
-		"api_url":        apiURL,
+		"mode":           mode,
+		"api_url":        value.APIURL,
 		"api_key_update": apiKey != "",
 	})
-	response, err := s.accountPreferencesResponse(scope)
+	response, err := s.accountPreferencesResponse(scope, account.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -325,7 +352,7 @@ func (s *Server) handleUserDeleteSandboxAPIKey(w http.ResponseWriter, r *http.Re
 		return
 	}
 	s.recordAudit("github:"+session.Subject, "sandbox_api_key.delete", scope.Type, strconv.FormatInt(scope.ID, 10), nil)
-	response, err := s.accountPreferencesResponse(scope)
+	response, err := s.accountPreferencesResponse(scope, account.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -333,14 +360,40 @@ func (s *Server) handleUserDeleteSandboxAPIKey(w http.ResponseWriter, r *http.Re
 	writeJSON(w, http.StatusOK, response)
 }
 
-func (s *Server) accountPreferencesResponse(scope accountPreferenceScope) (accountPreferencesResponse, error) {
+func (s *Server) accountPreferencesResponse(scope accountPreferenceScope, accountID int64) (accountPreferencesResponse, error) {
 	var response accountPreferencesResponse
 	preference, err := s.store.GetAccountPreference(scope.Type, scope.ID, accountPreferenceNamespaceSandbox, accountPreferenceKeySandboxService)
 	if err != nil {
 		if !errors.Is(err, state.ErrNotFound) {
 			return accountPreferencesResponse{}, err
 		}
+		response.Sandbox.Mode = sandboxPreferenceModeCustom
 	} else {
+		var value accountSandboxServicePreferenceValue
+		if err := json.Unmarshal([]byte(preference.ValueJSON), &value); err != nil {
+			return accountPreferencesResponse{}, err
+		}
+		mode := normalizeSandboxPreferenceMode(value.Mode, scope)
+		response.Sandbox.Mode = mode
+		if mode == sandboxPreferenceModeInherit {
+			response.Sandbox.Inherited = true
+			response.Sandbox.SourceAccountID = value.SourceAccountID
+			return s.fillSandboxResponseFromScope(response, accountPreferenceScope{Type: state.AccountScopeTypeAccount, ID: value.SourceAccountID})
+		}
+		response.Sandbox.APIURL = value.APIURL
+	}
+	return s.fillSandboxResponseFromScope(response, scope)
+}
+
+func (s *Server) fillSandboxResponseFromScope(response accountPreferencesResponse, scope accountPreferenceScope) (accountPreferencesResponse, error) {
+	if strings.TrimSpace(response.Sandbox.APIURL) == "" {
+		preference, err := s.store.GetAccountPreference(scope.Type, scope.ID, accountPreferenceNamespaceSandbox, accountPreferenceKeySandboxService)
+		if err != nil {
+			if errors.Is(err, state.ErrNotFound) {
+				return response, nil
+			}
+			return accountPreferencesResponse{}, err
+		}
 		var value accountSandboxServicePreferenceValue
 		if err := json.Unmarshal([]byte(preference.ValueJSON), &value); err != nil {
 			return accountPreferencesResponse{}, err
@@ -357,6 +410,19 @@ func (s *Server) accountPreferencesResponse(scope accountPreferenceScope) (accou
 	response.Sandbox.APIKey.Configured = true
 	response.Sandbox.APIKey.UpdatedAt = key.UpdatedAt.Format(time.RFC3339)
 	return response, nil
+}
+
+const (
+	sandboxPreferenceModeCustom  = "custom"
+	sandboxPreferenceModeInherit = "inherit"
+)
+
+func normalizeSandboxPreferenceMode(mode string, scope accountPreferenceScope) string {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode == sandboxPreferenceModeInherit && scope.Type == state.AccountScopeTypeGitHubInstall {
+		return sandboxPreferenceModeInherit
+	}
+	return sandboxPreferenceModeCustom
 }
 
 func (s *Server) accountPreferenceScopeFromRequest(accountID int64, r *http.Request) (accountPreferenceScope, error) {

--- a/internal/state/account_preferences.go
+++ b/internal/state/account_preferences.go
@@ -66,6 +66,28 @@ func (s *DBStore) UpsertAccountPreferenceAndSecret(preference AccountPreference,
 	return savedPreference, savedSecret, nil
 }
 
+func (s *DBStore) UpsertAccountPreferenceAndDeleteSecret(preference AccountPreference, secret AccountSecret) (AccountPreference, error) {
+	db, err := s.dbOrEnsure()
+	if err != nil {
+		return AccountPreference{}, err
+	}
+	var savedPreference AccountPreference
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		var err error
+		savedPreference, err = upsertAccountPreference(tx, preference)
+		if err != nil {
+			return err
+		}
+		if err := deleteAccountSecret(tx, secret.ScopeType, secret.ScopeID, secret.KeyType); err != nil && err != ErrNotFound {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return AccountPreference{}, err
+	}
+	return savedPreference, nil
+}
+
 func upsertAccountPreference(db *gorm.DB, preference AccountPreference) (AccountPreference, error) {
 	scopeType := normalizeAccountScopeType(preference.ScopeType)
 	namespace := normalizeAccountPreferencePart(preference.Namespace)

--- a/internal/state/account_secrets.go
+++ b/internal/state/account_secrets.go
@@ -79,6 +79,10 @@ func (s *DBStore) DeleteAccountSecret(scopeType string, scopeID int64, keyType s
 	if err != nil {
 		return err
 	}
+	return deleteAccountSecret(db, scopeType, scopeID, keyType)
+}
+
+func deleteAccountSecret(db *gorm.DB, scopeType string, scopeID int64, keyType string) error {
 	scopeType = normalizeAccountScopeType(scopeType)
 	keyType = normalizeAccountSecretKeyType(keyType)
 	if scopeType == "" || scopeID <= 0 || keyType == "" {

--- a/internal/state/identity_audit.go
+++ b/internal/state/identity_audit.go
@@ -30,6 +30,25 @@ func (s *DBStore) GetAccountByOAuthIdentity(provider, subject string) (Account, 
 	return s.accountFromIdentity(db, identity)
 }
 
+func (s *DBStore) GetOAuthIdentityForAccount(accountID int64, provider string) (OAuthIdentity, error) {
+	db, err := s.dbOrEnsure()
+	if err != nil {
+		return OAuthIdentity{}, err
+	}
+	provider = normalizeOAuthProvider(provider)
+	if accountID <= 0 || provider == "" {
+		return OAuthIdentity{}, ErrNotFound
+	}
+	var identity oauthIdentityRecord
+	if err := db.First(&identity, "account_id = ? AND oauth_provider = ?", accountID, provider).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return OAuthIdentity{}, ErrNotFound
+		}
+		return OAuthIdentity{}, err
+	}
+	return recordToOAuthIdentity(identity), nil
+}
+
 func (s *DBStore) UpsertAccountForOAuthIdentity(identity OAuthIdentity, role string) (Account, OAuthIdentity, error) {
 	return s.saveOAuthIdentity(identity, role, true, 0)
 }

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -263,6 +263,7 @@ type AccountPreferenceStore interface {
 	GetAccountPreference(scopeType string, scopeID int64, namespace, key string) (AccountPreference, error)
 	UpsertAccountPreference(preference AccountPreference) (AccountPreference, error)
 	UpsertAccountPreferenceAndSecret(preference AccountPreference, secret *AccountSecret) (AccountPreference, *AccountSecret, error)
+	UpsertAccountPreferenceAndDeleteSecret(preference AccountPreference, secret AccountSecret) (AccountPreference, error)
 }
 
 type AuditStore interface {

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -240,6 +240,7 @@ type RunnerCatalogStore interface {
 
 type IdentityStore interface {
 	GetAccountByOAuthIdentity(provider, subject string) (Account, OAuthIdentity, error)
+	GetOAuthIdentityForAccount(accountID int64, provider string) (OAuthIdentity, error)
 	EnsureAccountForOAuthIdentity(identity OAuthIdentity, role string) (Account, OAuthIdentity, error)
 	UpsertAccountForOAuthIdentity(identity OAuthIdentity, role string) (Account, OAuthIdentity, error)
 	LinkOAuthIdentityToAccount(accountID int64, identity OAuthIdentity) (Account, OAuthIdentity, error)

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -288,6 +288,28 @@ func TestUpsertAccountForOAuthIdentityMaintainsRoleByOAuthIdentity(t *testing.T)
 	}
 }
 
+func TestGetOAuthIdentityForAccountByProvider(t *testing.T) {
+	store := New(t.TempDir())
+	account, _, err := store.UpsertAccountForOAuthIdentity(OAuthIdentity{OAuthProvider: "github", OAuthSubject: "12345", OAuthLogin: "octocat"}, "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.LinkOAuthIdentityToAccount(account.ID, OAuthIdentity{OAuthProvider: "gitlab", OAuthSubject: "abcde", OAuthLogin: "octocat-gitlab"}); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := store.GetOAuthIdentityForAccount(account.ID, " GITHUB ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.AccountID != account.ID || identity.OAuthProvider != "github" || identity.OAuthLogin != "octocat" {
+		t.Fatalf("unexpected github identity: %#v", identity)
+	}
+	if _, err := store.GetOAuthIdentityForAccount(account.ID, "missing"); err != ErrNotFound {
+		t.Fatalf("expected missing provider identity to return ErrNotFound, got %v", err)
+	}
+}
+
 func TestEnsureAccountForOAuthIdentityCreatesDefaultWithoutOverwritingExistingRole(t *testing.T) {
 	store := New(t.TempDir())
 	createdAccount, createdIdentity, err := store.EnsureAccountForOAuthIdentity(OAuthIdentity{OAuthProvider: "github", OAuthSubject: "12345", OAuthLogin: "octocat"}, "user")

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -332,11 +332,17 @@ function App() {
     }
   }, [request])
 
-  const saveSandboxConfig = useCallback(async (apiURL: string, apiKey: string, installationID?: number, mode: "custom" | "inherit" = "custom") => {
+  const saveSandboxConfig = useCallback(async (
+    apiURL: string,
+    apiKey: string,
+    installationID?: number,
+    mode: "custom" | "inherit" = "custom",
+    replaceInheritedSource = false,
+  ) => {
     const preferences = (await request(userPreferencesPath(installationID, "/user/preferences/sandbox"), {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ mode, api_url: apiURL, api_key: apiKey }),
+      body: JSON.stringify({ mode, api_url: apiURL, api_key: apiKey, replace_inherited_source: replaceInheritedSource }),
     })) as UserPreferences
     setUserPreferences(preferences)
     toast.success("Sandbox service settings saved")

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -332,11 +332,11 @@ function App() {
     }
   }, [request])
 
-  const saveSandboxConfig = useCallback(async (apiURL: string, apiKey: string, installationID?: number) => {
+  const saveSandboxConfig = useCallback(async (apiURL: string, apiKey: string, installationID?: number, mode: "custom" | "inherit" = "custom") => {
     const preferences = (await request(userPreferencesPath(installationID, "/user/preferences/sandbox"), {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ api_url: apiURL, api_key: apiKey }),
+      body: JSON.stringify({ mode, api_url: apiURL, api_key: apiKey }),
     })) as UserPreferences
     setUserPreferences(preferences)
     toast.success("Sandbox service settings saved")

--- a/ui/src/admin-types.ts
+++ b/ui/src/admin-types.ts
@@ -139,7 +139,10 @@ export type GitHubAppConfig = {
 
 export type UserPreferences = {
   sandbox: {
+    mode: "custom" | "inherit"
     api_url: string
+    inherited?: boolean
+    source_account_id?: number
     api_key: {
       configured: boolean
       updated_at?: string

--- a/ui/src/admin-types.ts
+++ b/ui/src/admin-types.ts
@@ -145,6 +145,7 @@ export type UserPreferences = {
     source_account_id?: number
     source_account_login?: string
     source_is_current_account?: boolean
+    source_available?: boolean
     api_key: {
       configured: boolean
       updated_at?: string

--- a/ui/src/admin-types.ts
+++ b/ui/src/admin-types.ts
@@ -143,6 +143,8 @@ export type UserPreferences = {
     api_url: string
     inherited?: boolean
     source_account_id?: number
+    source_account_login?: string
+    source_is_current_account?: boolean
     api_key: {
       configured: boolean
       updated_at?: string

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -146,7 +146,7 @@ export function UserDashboard({
   authorizedRepositories: Record<number, string[]>
   loadingRepositoriesFor: number | null
   onLoadAuthorizedRepositories: (id: number) => void
-  onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number, mode?: "custom" | "inherit") => Promise<void>
+  onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number, mode?: "custom" | "inherit", replaceInheritedSource?: boolean) => Promise<void>
   onDeleteSandboxAPIKey: (installationID?: number) => Promise<void>
   onNavigate: (page: UserPage) => void
   onNavigateAccountSettings: (accountLogin: string | undefined, tab: AccountSettingsTab) => void
@@ -388,7 +388,7 @@ function AccountsPage({
   loadingRepositoriesFor: number | null
   route: AccountSettingsRoute
   onLoadAuthorizedRepositories: (id: number) => void
-  onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number, mode?: "custom" | "inherit") => Promise<void>
+  onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number, mode?: "custom" | "inherit", replaceInheritedSource?: boolean) => Promise<void>
   onDeleteSandboxAPIKey: (installationID?: number) => Promise<void>
   currentLogin?: string
   onNavigateAccountSettings: (accountLogin: string | undefined, tab: AccountSettingsTab) => void
@@ -555,7 +555,7 @@ function AccountsPage({
                   <SandboxAPIKeyCard
                     preferences={userPreferences}
                     allowInheritance={Boolean(preferenceInstallationID)}
-                    onSave={(apiURL, apiKey, mode) => onSaveSandboxConfig(apiURL, apiKey, preferenceInstallationID, mode)}
+                    onSave={(apiURL, apiKey, mode, replaceInheritedSource) => onSaveSandboxConfig(apiURL, apiKey, preferenceInstallationID, mode, replaceInheritedSource)}
                     onDelete={() => onDeleteSandboxAPIKey(preferenceInstallationID)}
                   />
                 </TabsContent>
@@ -594,7 +594,7 @@ function SandboxAPIKeyCard({
 }: {
   preferences: UserPreferences | null
   allowInheritance?: boolean
-  onSave: (apiURL: string, apiKey: string, mode?: "custom" | "inherit") => Promise<void>
+  onSave: (apiURL: string, apiKey: string, mode?: "custom" | "inherit", replaceInheritedSource?: boolean) => Promise<void>
   onDelete: () => Promise<void>
 }) {
   const [apiURL, setAPIURL] = useState("")
@@ -604,9 +604,13 @@ function SandboxAPIKeyCard({
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false)
+  const [replaceSourceConfirmOpen, setReplaceSourceConfirmOpen] = useState(false)
   const [error, setError] = useState("")
   const configured = preferences?.sandbox?.api_key?.configured ?? false
   const customConfigured = configured && !preferences?.sandbox?.inherited
+  const inherited = credentialMode === "inherit" && Boolean(preferences?.sandbox?.inherited)
+  const sourceIsCurrentAccount = Boolean(preferences?.sandbox?.source_is_current_account)
+  const sourceAccountLogin = preferences?.sandbox?.source_account_login?.trim()
   const updatedAt = preferences?.sandbox?.api_key?.updated_at
   const selectedRegion = findSandboxRegionByAPIURL(apiURL)
   const customAPIURL = regionSelection === customSandboxRegionID ? apiURL.trim() : ""
@@ -674,6 +678,20 @@ function SandboxAPIKeyCard({
     }
   }
 
+  const replaceInheritedSource = async () => {
+    setSaving(true)
+    setError("")
+    try {
+      await onSave("", "", "inherit", true)
+      setAPIKey("")
+      setReplaceSourceConfirmOpen(false)
+    } catch (error) {
+      setError(error instanceof Error ? error.message : "Failed to use your account credentials.")
+    } finally {
+      setSaving(false)
+    }
+  }
+
   return (
     <Card className="gap-0 rounded-lg py-0">
       <form className="p-3" onSubmit={submit}>
@@ -710,7 +728,15 @@ function SandboxAPIKeyCard({
               Use account default credentials
             </Label>
             <span className="text-sm text-muted-foreground">
-              {credentialMode === "inherit" ? "This account uses the signed-in account Sandbox service settings." : "This account uses its own Sandbox service settings."}
+              {credentialMode !== "inherit"
+                ? "This organization uses its own Sandbox service settings."
+                : !preferences?.sandbox?.inherited
+                  ? "Your account default credentials will be used after saving."
+                : sourceIsCurrentAccount
+                  ? "Using Sandbox credentials provided by your account."
+                  : sourceAccountLogin
+                    ? `Using Sandbox credentials provided by @${sourceAccountLogin}.`
+                    : "Using Sandbox credentials provided by another connected owner."}
             </span>
           </div>
         ) : null}
@@ -776,10 +802,26 @@ function SandboxAPIKeyCard({
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
-            <Button type="submit" disabled={saving || deleting || (credentialMode === "custom" && (!apiURL.trim() || (!customConfigured && !apiKey.trim())))}>
-              <ShieldCheck className="h-4 w-4" />
-              {saving ? "Saving" : configured ? "Save changes" : "Save settings"}
-            </Button>
+            {!inherited ? (
+              <Button type="submit" disabled={saving || deleting || (credentialMode === "custom" && (!apiURL.trim() || (!customConfigured && !apiKey.trim())))}>
+                <ShieldCheck className="h-4 w-4" />
+                {saving ? "Saving" : configured ? "Save changes" : "Save settings"}
+              </Button>
+            ) : null}
+            {inherited && !sourceIsCurrentAccount ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setError("")
+                  setReplaceSourceConfirmOpen(true)
+                }}
+                disabled={saving || deleting}
+              >
+                <KeyRound className="h-4 w-4" />
+                Use my account credentials
+              </Button>
+            ) : null}
             {customConfigured && credentialMode === "custom" ? (
               <Button type="button" variant="outline" onClick={() => setRemoveConfirmOpen(true)} disabled={deleting || saving}>
                 <X className="h-4 w-4" />
@@ -812,6 +854,29 @@ function SandboxAPIKeyCard({
             <Button type="button" variant="destructive" onClick={remove} disabled={deleting}>
               <X className="h-4 w-4" />
               {deleting ? "Removing" : "Remove API Key"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={replaceSourceConfirmOpen} onOpenChange={(open) => !saving && setReplaceSourceConfirmOpen(open)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Use your account credentials?</DialogTitle>
+            <DialogDescription>
+              {sourceAccountLogin ? `This replaces the Sandbox credentials provided by @${sourceAccountLogin}. ` : "This replaces the current Sandbox credentials. "}
+              The change applies to all Runner jobs in this organization, and your account must have a complete Sandbox service configuration.
+            </DialogDescription>
+          </DialogHeader>
+          {error ? <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div> : null}
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline" disabled={saving}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="button" onClick={replaceInheritedSource} disabled={saving}>
+              <KeyRound className="h-4 w-4" />
+              {saving ? "Switching" : "Use my credentials"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -611,6 +611,7 @@ function SandboxAPIKeyCard({
   const inherited = credentialMode === "inherit" && Boolean(preferences?.sandbox?.inherited)
   const sourceIsCurrentAccount = Boolean(preferences?.sandbox?.source_is_current_account)
   const sourceAccountLogin = preferences?.sandbox?.source_account_login?.trim()
+  const sourceAvailable = Boolean(preferences?.sandbox?.source_available)
   const updatedAt = preferences?.sandbox?.api_key?.updated_at
   const selectedRegion = findSandboxRegionByAPIURL(apiURL)
   const customAPIURL = regionSelection === customSandboxRegionID ? apiURL.trim() : ""
@@ -732,6 +733,10 @@ function SandboxAPIKeyCard({
                 ? "This organization uses its own Sandbox service settings."
                 : !preferences?.sandbox?.inherited
                   ? "Your account default credentials will be used after saving."
+                : !sourceAvailable
+                  ? sourceAccountLogin
+                    ? `Credentials provided by @${sourceAccountLogin} are unavailable because that account is no longer connected to this organization.`
+                    : "The inherited credentials are unavailable because the source account is no longer connected to this organization."
                 : sourceIsCurrentAccount
                   ? "Using Sandbox credentials provided by your account."
                   : sourceAccountLogin

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -29,6 +29,15 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -40,6 +49,8 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useSandboxTerminal } from "@/hooks/use-sandbox-terminal"
 import { cn } from "@/lib/utils"
@@ -74,6 +85,28 @@ type GitHubLogState =
 
 const jobLogTabsListClassName = "h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent p-0 text-muted-foreground"
 const jobLogTabsTriggerClassName = "h-10 flex-none rounded-none border-x-0 border-t-0 border-b-2 border-transparent bg-transparent px-0 py-2 text-sm font-medium shadow-none hover:text-foreground data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none dark:data-[state=active]:bg-transparent"
+const sandboxRegions = [
+  {
+    id: "cn-yangzhou-1",
+    label: "China (Yangzhou 1)",
+    apiURL: "https://cn-yangzhou-1-sandbox.qiniuapi.com",
+  },
+  {
+    id: "us-south-1",
+    label: "United States (Dallas 1)",
+    apiURL: "https://us-south-1-sandbox.qiniuapi.com",
+  },
+]
+
+function normalizeSandboxAPIURL(value: string) {
+  return value.trim().replace(/\/+$/, "")
+}
+
+function resolveSandboxRegionAPIURL(value: string) {
+  const normalized = normalizeSandboxAPIURL(value)
+  const matchedRegion = sandboxRegions.find((region) => normalizeSandboxAPIURL(region.apiURL) === normalized)
+  return matchedRegion?.apiURL ?? ""
+}
 
 export function UserDashboard({
   authSession,
@@ -108,7 +141,7 @@ export function UserDashboard({
   authorizedRepositories: Record<number, string[]>
   loadingRepositoriesFor: number | null
   onLoadAuthorizedRepositories: (id: number) => void
-  onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number) => Promise<void>
+  onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number, mode?: "custom" | "inherit") => Promise<void>
   onDeleteSandboxAPIKey: (installationID?: number) => Promise<void>
   onNavigate: (page: UserPage) => void
   onNavigateAccountSettings: (accountLogin: string | undefined, tab: AccountSettingsTab) => void
@@ -350,7 +383,7 @@ function AccountsPage({
   loadingRepositoriesFor: number | null
   route: AccountSettingsRoute
   onLoadAuthorizedRepositories: (id: number) => void
-  onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number) => Promise<void>
+  onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number, mode?: "custom" | "inherit") => Promise<void>
   onDeleteSandboxAPIKey: (installationID?: number) => Promise<void>
   currentLogin?: string
   onNavigateAccountSettings: (accountLogin: string | undefined, tab: AccountSettingsTab) => void
@@ -516,7 +549,8 @@ function AccountsPage({
                 <TabsContent value="preferences">
                   <SandboxAPIKeyCard
                     preferences={userPreferences}
-                    onSave={(apiURL, apiKey) => onSaveSandboxConfig(apiURL, apiKey, preferenceInstallationID)}
+                    allowInheritance={Boolean(preferenceInstallationID)}
+                    onSave={(apiURL, apiKey, mode) => onSaveSandboxConfig(apiURL, apiKey, preferenceInstallationID, mode)}
                     onDelete={() => onDeleteSandboxAPIKey(preferenceInstallationID)}
                   />
                 </TabsContent>
@@ -531,7 +565,7 @@ function AccountsPage({
                 </div>
                 <SandboxAPIKeyCard
                   preferences={userPreferences}
-                  onSave={onSaveSandboxConfig}
+                  onSave={(apiURL, apiKey, mode) => onSaveSandboxConfig(apiURL, apiKey, undefined, mode)}
                   onDelete={onDeleteSandboxAPIKey}
                 />
               </div>
@@ -549,41 +583,65 @@ function AccountsPage({
 
 function SandboxAPIKeyCard({
   preferences,
+  allowInheritance = false,
   onSave,
   onDelete,
 }: {
   preferences: UserPreferences | null
-  onSave: (apiURL: string, apiKey: string) => Promise<void>
+  allowInheritance?: boolean
+  onSave: (apiURL: string, apiKey: string, mode?: "custom" | "inherit") => Promise<void>
   onDelete: () => Promise<void>
 }) {
   const [apiURL, setAPIURL] = useState("")
   const [apiKey, setAPIKey] = useState("")
+  const [credentialMode, setCredentialMode] = useState<"custom" | "inherit">("custom")
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false)
   const [error, setError] = useState("")
   const configured = preferences?.sandbox?.api_key?.configured ?? false
+  const customConfigured = configured && !preferences?.sandbox?.inherited
   const updatedAt = preferences?.sandbox?.api_key?.updated_at
+  const selectedRegion = sandboxRegions.find((region) => region.apiURL === apiURL)
 
   useEffect(() => {
-    setAPIURL(preferences?.sandbox?.api_url ?? "")
+    const savedAPIURL = preferences?.sandbox?.api_url ?? ""
+    setAPIURL(resolveSandboxRegionAPIURL(savedAPIURL))
   }, [preferences?.sandbox?.api_url])
+
+  useEffect(() => {
+    setCredentialMode(allowInheritance && preferences?.sandbox?.mode === "inherit" ? "inherit" : "custom")
+  }, [allowInheritance, preferences?.sandbox?.mode])
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const nextAPIURL = apiURL.trim()
     const nextAPIKey = apiKey.trim()
-    if (!nextAPIURL) {
-      setError("Sandbox service API URL is required.")
+    if (credentialMode === "inherit") {
+      setSaving(true)
+      setError("")
+      try {
+        await onSave("", "", "inherit")
+        setAPIKey("")
+      } catch (error) {
+        setError(error instanceof Error ? error.message : "Failed to save Sandbox service settings.")
+      } finally {
+        setSaving(false)
+      }
       return
     }
-    if (!configured && !nextAPIKey) {
+    if (!nextAPIURL) {
+      setError("Sandbox service region is required.")
+      return
+    }
+    if (!customConfigured && !nextAPIKey) {
       setError("Sandbox API Key is required.")
       return
     }
     setSaving(true)
     setError("")
     try {
-      await onSave(nextAPIURL, nextAPIKey)
+      await onSave(nextAPIURL, nextAPIKey, "custom")
       setAPIKey("")
     } catch (error) {
       setError(error instanceof Error ? error.message : "Failed to save Sandbox service settings.")
@@ -598,6 +656,7 @@ function SandboxAPIKeyCard({
     try {
       await onDelete()
       setAPIKey("")
+      setRemoveConfirmOpen(false)
     } catch (error) {
       setError(error instanceof Error ? error.message : "Failed to remove Sandbox API Key.")
     } finally {
@@ -621,16 +680,48 @@ function SandboxAPIKeyCard({
           <Badge variant={configured ? "secondary" : "outline"}>{configured ? "Configured" : "Not configured"}</Badge>
         </div>
 
+        {allowInheritance ? (
+          <div className="mt-3 flex flex-wrap items-center gap-3 rounded-md border bg-muted/20 px-3 py-2">
+            <Switch
+              id="sandbox-use-account-default"
+              checked={credentialMode === "inherit"}
+              onCheckedChange={(checked) => {
+                setCredentialMode(checked ? "inherit" : "custom")
+                setError("")
+              }}
+              disabled={saving || deleting}
+            />
+            <Label htmlFor="sandbox-use-account-default" className="cursor-pointer text-sm font-medium">
+              Use account default credentials
+            </Label>
+            <span className="text-sm text-muted-foreground">
+              {credentialMode === "inherit" ? "This account uses the signed-in account Sandbox service settings." : "This account uses its own Sandbox service settings."}
+            </span>
+          </div>
+        ) : null}
+
         <div className="mt-2.5 grid gap-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] lg:items-end">
           <div className="grid min-w-0 gap-1.5">
-            <Label htmlFor="sandbox-api-url">API URL</Label>
-            <Input
-              id="sandbox-api-url"
-              value={apiURL}
-              onChange={(event) => setAPIURL(event.target.value)}
-              autoComplete="off"
-              placeholder="https://api.e2b.dev"
-            />
+            <Label htmlFor="sandbox-api-region">Region</Label>
+            <Select
+              value={selectedRegion?.id ?? ""}
+              onValueChange={(regionID) => {
+                setAPIURL(sandboxRegions.find((region) => region.id === regionID)?.apiURL ?? "")
+              }}
+              disabled={saving || deleting || credentialMode === "inherit"}
+            >
+              <SelectTrigger id="sandbox-api-region" className="w-full">
+                <SelectValue placeholder="Select Sandbox region" />
+              </SelectTrigger>
+              <SelectContent>
+                {sandboxRegions.map((region) => (
+                  <SelectItem key={region.id} value={region.id}>
+                    <span>{region.label}</span>
+                    <span className="text-muted-foreground">{region.id}</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="grid min-w-0 gap-1.5">
@@ -641,21 +732,22 @@ function SandboxAPIKeyCard({
               value={apiKey}
               onChange={(event) => setAPIKey(event.target.value)}
               autoComplete="off"
-              placeholder={configured ? "••••••••••••••••" : "Enter Sandbox API Key"}
+              disabled={saving || deleting || credentialMode === "inherit"}
+              placeholder={customConfigured ? "••••••••••••••••" : "Enter Sandbox API Key"}
             />
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
-            {configured ? (
-              <Button type="button" variant="outline" size="sm" onClick={remove} disabled={deleting || saving}>
+            <Button type="submit" disabled={saving || deleting || (credentialMode === "custom" && (!apiURL.trim() || (!customConfigured && !apiKey.trim())))}>
+              <ShieldCheck className="h-4 w-4" />
+              {saving ? "Saving" : configured ? "Save changes" : "Save settings"}
+            </Button>
+            {customConfigured && credentialMode === "custom" ? (
+              <Button type="button" variant="outline" onClick={() => setRemoveConfirmOpen(true)} disabled={deleting || saving}>
                 <X className="h-4 w-4" />
                 {deleting ? "Removing" : "Remove"}
               </Button>
             ) : null}
-            <Button type="submit" size="sm" disabled={saving || deleting || !apiURL.trim() || (!configured && !apiKey.trim())}>
-              <ShieldCheck className="h-4 w-4" />
-              {saving ? "Saving" : configured ? "Save changes" : "Save settings"}
-            </Button>
           </div>
         </div>
 
@@ -665,6 +757,27 @@ function SandboxAPIKeyCard({
 
         {error ? <div className="mt-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div> : null}
       </form>
+      <Dialog open={removeConfirmOpen} onOpenChange={(open) => !deleting && setRemoveConfirmOpen(open)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove Sandbox API Key?</DialogTitle>
+            <DialogDescription>
+              This removes the saved Sandbox API Key for this account. Runner jobs cannot start new Sandbox instances until a key is saved again.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline" disabled={deleting}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="button" variant="destructive" onClick={remove} disabled={deleting}>
+              <X className="h-4 w-4" />
+              {deleting ? "Removing" : "Remove API Key"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   )
 }

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -103,9 +103,13 @@ function normalizeSandboxAPIURL(value: string) {
   return value.trim().replace(/\/+$/, "")
 }
 
-function resolveSandboxRegionAPIURL(value: string) {
+function findSandboxRegionByAPIURL(value: string) {
   const normalized = normalizeSandboxAPIURL(value)
-  const matchedRegion = sandboxRegions.find((region) => normalizeSandboxAPIURL(region.apiURL) === normalized)
+  return sandboxRegions.find((region) => normalizeSandboxAPIURL(region.apiURL) === normalized)
+}
+
+function resolveSandboxRegionAPIURL(value: string) {
+  const matchedRegion = findSandboxRegionByAPIURL(value)
   return matchedRegion?.apiURL ?? value
 }
 
@@ -596,6 +600,7 @@ function SandboxAPIKeyCard({
   const [apiURL, setAPIURL] = useState("")
   const [apiKey, setAPIKey] = useState("")
   const [credentialMode, setCredentialMode] = useState<"custom" | "inherit">("custom")
+  const [regionSelection, setRegionSelection] = useState("")
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false)
@@ -603,12 +608,15 @@ function SandboxAPIKeyCard({
   const configured = preferences?.sandbox?.api_key?.configured ?? false
   const customConfigured = configured && !preferences?.sandbox?.inherited
   const updatedAt = preferences?.sandbox?.api_key?.updated_at
-  const selectedRegion = sandboxRegions.find((region) => normalizeSandboxAPIURL(region.apiURL) === normalizeSandboxAPIURL(apiURL))
-  const customAPIURL = apiURL.trim() && !selectedRegion ? apiURL.trim() : ""
+  const selectedRegion = findSandboxRegionByAPIURL(apiURL)
+  const customAPIURL = regionSelection === customSandboxRegionID ? apiURL.trim() : ""
 
   useEffect(() => {
     const savedAPIURL = preferences?.sandbox?.api_url ?? ""
-    setAPIURL(resolveSandboxRegionAPIURL(savedAPIURL))
+    const resolvedAPIURL = resolveSandboxRegionAPIURL(savedAPIURL)
+    const savedRegion = findSandboxRegionByAPIURL(resolvedAPIURL)
+    setAPIURL(resolvedAPIURL)
+    setRegionSelection(savedRegion?.id ?? (savedAPIURL.trim() ? customSandboxRegionID : ""))
   }, [preferences?.sandbox?.api_url])
 
   useEffect(() => {
@@ -706,12 +714,18 @@ function SandboxAPIKeyCard({
           <div className="grid min-w-0 gap-1.5">
             <Label htmlFor="sandbox-api-region">Region</Label>
             <Select
-              value={selectedRegion?.id ?? (customAPIURL ? customSandboxRegionID : "")}
+              value={regionSelection}
               onValueChange={(regionID) => {
                 if (regionID === customSandboxRegionID) {
+                  setRegionSelection(customSandboxRegionID)
+                  if (selectedRegion) {
+                    setAPIURL("")
+                  }
                   return
                 }
-                setAPIURL(sandboxRegions.find((region) => region.id === regionID)?.apiURL ?? "")
+                const region = sandboxRegions.find((region) => region.id === regionID)
+                setRegionSelection(region?.id ?? "")
+                setAPIURL(region?.apiURL ?? "")
               }}
               disabled={saving || deleting || credentialMode === "inherit"}
             >
@@ -725,14 +739,22 @@ function SandboxAPIKeyCard({
                     <span className="text-muted-foreground">{region.id}</span>
                   </SelectItem>
                 ))}
-                {customAPIURL ? (
-                  <SelectItem value={customSandboxRegionID}>
-                    <span>Custom endpoint</span>
-                    <span className="text-muted-foreground">{customAPIURL}</span>
-                  </SelectItem>
-                ) : null}
+                <SelectItem value={customSandboxRegionID}>
+                  <span>Custom endpoint</span>
+                  {customAPIURL ? <span className="text-muted-foreground">{customAPIURL}</span> : null}
+                </SelectItem>
               </SelectContent>
             </Select>
+            {regionSelection === customSandboxRegionID && credentialMode === "custom" ? (
+              <Input
+                className="mt-1.5"
+                value={apiURL}
+                onChange={(event) => setAPIURL(event.target.value)}
+                placeholder="https://sandbox.example.test"
+                disabled={saving || deleting}
+                autoComplete="off"
+              />
+            ) : null}
           </div>
 
           <div className="grid min-w-0 gap-1.5">

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -697,6 +697,11 @@ function SandboxAPIKeyCard({
               checked={credentialMode === "inherit"}
               onCheckedChange={(checked) => {
                 setCredentialMode(checked ? "inherit" : "custom")
+                if (!checked && preferences?.sandbox?.inherited) {
+                  setAPIURL("")
+                  setAPIKey("")
+                  setRegionSelection("")
+                }
                 setError("")
               }}
               disabled={saving || deleting}

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -97,6 +97,7 @@ const sandboxRegions = [
     apiURL: "https://us-south-1-sandbox.qiniuapi.com",
   },
 ]
+const customSandboxRegionID = "__custom__"
 
 function normalizeSandboxAPIURL(value: string) {
   return value.trim().replace(/\/+$/, "")
@@ -105,7 +106,7 @@ function normalizeSandboxAPIURL(value: string) {
 function resolveSandboxRegionAPIURL(value: string) {
   const normalized = normalizeSandboxAPIURL(value)
   const matchedRegion = sandboxRegions.find((region) => normalizeSandboxAPIURL(region.apiURL) === normalized)
-  return matchedRegion?.apiURL ?? ""
+  return matchedRegion?.apiURL ?? value
 }
 
 export function UserDashboard({
@@ -602,7 +603,8 @@ function SandboxAPIKeyCard({
   const configured = preferences?.sandbox?.api_key?.configured ?? false
   const customConfigured = configured && !preferences?.sandbox?.inherited
   const updatedAt = preferences?.sandbox?.api_key?.updated_at
-  const selectedRegion = sandboxRegions.find((region) => region.apiURL === apiURL)
+  const selectedRegion = sandboxRegions.find((region) => normalizeSandboxAPIURL(region.apiURL) === normalizeSandboxAPIURL(apiURL))
+  const customAPIURL = apiURL.trim() && !selectedRegion ? apiURL.trim() : ""
 
   useEffect(() => {
     const savedAPIURL = preferences?.sandbox?.api_url ?? ""
@@ -704,8 +706,11 @@ function SandboxAPIKeyCard({
           <div className="grid min-w-0 gap-1.5">
             <Label htmlFor="sandbox-api-region">Region</Label>
             <Select
-              value={selectedRegion?.id ?? ""}
+              value={selectedRegion?.id ?? (customAPIURL ? customSandboxRegionID : "")}
               onValueChange={(regionID) => {
+                if (regionID === customSandboxRegionID) {
+                  return
+                }
                 setAPIURL(sandboxRegions.find((region) => region.id === regionID)?.apiURL ?? "")
               }}
               disabled={saving || deleting || credentialMode === "inherit"}
@@ -720,6 +725,12 @@ function SandboxAPIKeyCard({
                     <span className="text-muted-foreground">{region.id}</span>
                   </SelectItem>
                 ))}
+                {customAPIURL ? (
+                  <SelectItem value={customSandboxRegionID}>
+                    <span>Custom endpoint</span>
+                    <span className="text-muted-foreground">{customAPIURL}</span>
+                  </SelectItem>
+                ) : null}
               </SelectContent>
             </Select>
           </div>


### PR DESCRIPTION
## Summary

- add lightweight inherit/custom modes for Sandbox service preferences
- allow GitHub installation preferences to inherit the signed-in account default Sandbox credentials
- clear stale installation-scoped Sandbox API keys when switching to inherited credentials
- update the account preferences UI with region selection, confirmation before key removal, and a direct inherit switch for organization settings

## Validation

- go test -tags development ./internal/server -count=1
- go test ./internal/state -count=1
- task ui-lint
- task test
