### PR TITLE
fix(ui): truncate long identifiers

### DIFF
--- a/ui/src/components/admin-sections.tsx
+++ b/ui/src/components/admin-sections.tsx
@@ -199,8 +199,8 @@ export function AuditSection({ auditEvents }: { auditEvents: AuditEvent[] }) {
                   <TableCell>
                     {event.resource_type} · {event.resource_id}
                   </TableCell>
-                  <TableCell className="max-w-[420px] truncate text-xs text-muted-foreground">
-                    {event.payload_json || "-"}
+                  <TableCell className="text-xs text-muted-foreground">
+                    <div className="max-w-[420px] truncate">{event.payload_json || "-"}</div>
                   </TableCell>
                 </TableRow>
               ))

--- a/ui/src/components/admin-sections.tsx
+++ b/ui/src/components/admin-sections.tsx
@@ -76,11 +76,11 @@ export function OverviewSection({
             {runnerSpecs.map((runnerSpec) => (
               <div
                 key={runnerSpec.name}
-                className="rounded-md border p-3 text-sm"
+                className="min-w-0 rounded-md border p-3 text-sm"
                 onClick={() => onEditRunnerSpec(runnerSpec)}
               >
-                <div className="font-medium">{runnerSpec.name}</div>
-                <div className="text-xs text-muted-foreground">
+                <div className="truncate font-medium">{runnerSpec.name}</div>
+                <div className="truncate text-xs text-muted-foreground">
                   {runnerSpec.labels.join(", ")} · template {runnerSpec.template_id}
                 </div>
               </div>
@@ -91,11 +91,11 @@ export function OverviewSection({
             {runnerPolicies.map((policy) => (
               <div
                 key={policy.id}
-                className="rounded-md border p-3 text-sm"
+                className="min-w-0 rounded-md border p-3 text-sm"
                 onClick={() => onEditPolicy(policy)}
               >
-                <div className="font-medium">{policy.repository_full_name}</div>
-                <div className="text-xs text-muted-foreground">{policy.runner_spec_name}</div>
+                <div className="truncate font-medium">{policy.repository_full_name}</div>
+                <div className="truncate text-xs text-muted-foreground">{policy.runner_spec_name}</div>
               </div>
             ))}
           </div>

--- a/ui/src/components/runner-groups-section.tsx
+++ b/ui/src/components/runner-groups-section.tsx
@@ -102,8 +102,8 @@ export function RunnerGroupsSection({
             <TableBody>
               {runnerGroups.map((group) => (
                 <TableRow key={group.name} className="cursor-pointer" onClick={() => onEditRunnerGroup(group)}>
-                  <TableCell className="max-w-[220px] truncate">{group.name}</TableCell>
-                  <TableCell className="max-w-[420px] truncate">{group.spec_names.join(", ") || "-"}</TableCell>
+                  <TableCell><div className="max-w-[220px] truncate">{group.name}</div></TableCell>
+                  <TableCell><div className="max-w-[420px] truncate">{group.spec_names.join(", ") || "-"}</div></TableCell>
                   <TableCell>{group.enabled ? "yes" : "no"}</TableCell>
                   <TableCell>{formatTime(group.updated_at)}</TableCell>
                   <TableCell>

--- a/ui/src/components/runner-groups-section.tsx
+++ b/ui/src/components/runner-groups-section.tsx
@@ -102,7 +102,7 @@ export function RunnerGroupsSection({
             <TableBody>
               {runnerGroups.map((group) => (
                 <TableRow key={group.name} className="cursor-pointer" onClick={() => onEditRunnerGroup(group)}>
-                  <TableCell>{group.name}</TableCell>
+                  <TableCell className="max-w-[220px] truncate">{group.name}</TableCell>
                   <TableCell className="max-w-[420px] truncate">{group.spec_names.join(", ") || "-"}</TableCell>
                   <TableCell>{group.enabled ? "yes" : "no"}</TableCell>
                   <TableCell>{formatTime(group.updated_at)}</TableCell>

--- a/ui/src/components/runner-policies-section.tsx
+++ b/ui/src/components/runner-policies-section.tsx
@@ -114,8 +114,8 @@ export function RunnerPoliciesSection({
             <TableBody>
               {runnerPolicies.map((policy) => (
                 <TableRow key={policy.id} className="cursor-pointer" onClick={() => onEditRunnerPolicy(policy)}>
-                  <TableCell>{policy.repository_full_name}</TableCell>
-                  <TableCell>
+                  <TableCell className="max-w-[260px] truncate">{policy.repository_full_name}</TableCell>
+                  <TableCell className="max-w-[260px] truncate">
                     {policy.runner_group_name
                       ? `group:${policy.runner_group_name}`
                       : `spec:${policy.runner_spec_name || "-"}`}

--- a/ui/src/components/runner-policies-section.tsx
+++ b/ui/src/components/runner-policies-section.tsx
@@ -114,11 +114,13 @@ export function RunnerPoliciesSection({
             <TableBody>
               {runnerPolicies.map((policy) => (
                 <TableRow key={policy.id} className="cursor-pointer" onClick={() => onEditRunnerPolicy(policy)}>
-                  <TableCell className="max-w-[260px] truncate">{policy.repository_full_name}</TableCell>
-                  <TableCell className="max-w-[260px] truncate">
-                    {policy.runner_group_name
-                      ? `group:${policy.runner_group_name}`
-                      : `spec:${policy.runner_spec_name || "-"}`}
+                  <TableCell><div className="max-w-[260px] truncate">{policy.repository_full_name}</div></TableCell>
+                  <TableCell>
+                    <div className="max-w-[260px] truncate">
+                      {policy.runner_group_name
+                        ? `group:${policy.runner_group_name}`
+                        : `spec:${policy.runner_spec_name || "-"}`}
+                    </div>
                   </TableCell>
                   <TableCell>{policy.enabled ? "yes" : "no"}</TableCell>
                   <TableCell>{formatTime(policy.created_at)}</TableCell>

--- a/ui/src/components/runner-requests-section.tsx
+++ b/ui/src/components/runner-requests-section.tsx
@@ -269,16 +269,16 @@ export function RunnerRequestsSection({
                     <TableCell>
                       <StatusBadge status={runner.status} />
                     </TableCell>
-                    <TableCell className="max-w-[220px] truncate">
-                      {runner.repository_full_name || "-"}
+                    <TableCell>
+                      <div className="max-w-[220px] truncate">{runner.repository_full_name || "-"}</div>
                     </TableCell>
                     <TableCell>{runner.runner_spec_name || "-"}</TableCell>
                     <TableCell className="max-w-[260px]">
                       <div className="truncate font-medium">{runner.runner_name || runner.id}</div>
                       <div className="truncate text-xs text-muted-foreground">{runner.id}</div>
                     </TableCell>
-                    <TableCell className="max-w-[180px] truncate">
-                      {runner.sandbox_id || "-"}
+                    <TableCell>
+                      <div className="max-w-[180px] truncate">{runner.sandbox_id || "-"}</div>
                     </TableCell>
                     <TableCell>
                       {runner.github_job_url ? (

--- a/ui/src/components/runner-requests-section.tsx
+++ b/ui/src/components/runner-requests-section.tsx
@@ -273,9 +273,9 @@ export function RunnerRequestsSection({
                       {runner.repository_full_name || "-"}
                     </TableCell>
                     <TableCell>{runner.runner_spec_name || "-"}</TableCell>
-                    <TableCell>
-                      <div className="font-medium">{runner.runner_name || runner.id}</div>
-                      <div className="text-xs text-muted-foreground">{runner.id}</div>
+                    <TableCell className="max-w-[260px]">
+                      <div className="truncate font-medium">{runner.runner_name || runner.id}</div>
+                      <div className="truncate text-xs text-muted-foreground">{runner.id}</div>
                     </TableCell>
                     <TableCell className="max-w-[180px] truncate">
                       {runner.sandbox_id || "-"}

--- a/ui/src/components/runner-specs-section.tsx
+++ b/ui/src/components/runner-specs-section.tsx
@@ -119,11 +119,11 @@ export function RunnerSpecsSection({
             <TableBody>
               {runnerSpecs.map((runnerSpec) => (
                 <TableRow key={runnerSpec.name} className="cursor-pointer" onClick={() => onEditRunnerSpec(runnerSpec)}>
-                  <TableCell>{runnerSpec.name}</TableCell>
+                  <TableCell className="max-w-[220px] truncate">{runnerSpec.name}</TableCell>
                   <TableCell className="max-w-[260px] truncate">{runnerSpec.labels.join(", ")}</TableCell>
-                  <TableCell>{runnerSpec.template_id}</TableCell>
-                  <TableCell>{runnerSpec.runner_group || "-"}</TableCell>
-                  <TableCell>{groupNamesForSpec(runnerSpec.name).join(", ") || "-"}</TableCell>
+                  <TableCell className="max-w-[220px] truncate">{runnerSpec.template_id}</TableCell>
+                  <TableCell className="max-w-[220px] truncate">{runnerSpec.runner_group || "-"}</TableCell>
+                  <TableCell className="max-w-[260px] truncate">{groupNamesForSpec(runnerSpec.name).join(", ") || "-"}</TableCell>
                   <TableCell>{runnerSpec.default_available ? "yes" : "no"}</TableCell>
                   <TableCell>{runnerSpec.max_concurrency}</TableCell>
                   <TableCell>

--- a/ui/src/components/runner-specs-section.tsx
+++ b/ui/src/components/runner-specs-section.tsx
@@ -119,11 +119,11 @@ export function RunnerSpecsSection({
             <TableBody>
               {runnerSpecs.map((runnerSpec) => (
                 <TableRow key={runnerSpec.name} className="cursor-pointer" onClick={() => onEditRunnerSpec(runnerSpec)}>
-                  <TableCell className="max-w-[220px] truncate">{runnerSpec.name}</TableCell>
-                  <TableCell className="max-w-[260px] truncate">{runnerSpec.labels.join(", ")}</TableCell>
-                  <TableCell className="max-w-[220px] truncate">{runnerSpec.template_id}</TableCell>
-                  <TableCell className="max-w-[220px] truncate">{runnerSpec.runner_group || "-"}</TableCell>
-                  <TableCell className="max-w-[260px] truncate">{groupNamesForSpec(runnerSpec.name).join(", ") || "-"}</TableCell>
+                  <TableCell><div className="max-w-[220px] truncate">{runnerSpec.name}</div></TableCell>
+                  <TableCell><div className="max-w-[260px] truncate">{runnerSpec.labels.join(", ")}</div></TableCell>
+                  <TableCell><div className="max-w-[220px] truncate">{runnerSpec.template_id}</div></TableCell>
+                  <TableCell><div className="max-w-[220px] truncate">{runnerSpec.runner_group || "-"}</div></TableCell>
+                  <TableCell><div className="max-w-[260px] truncate">{groupNamesForSpec(runnerSpec.name).join(", ") || "-"}</div></TableCell>
                   <TableCell>{runnerSpec.default_available ? "yes" : "no"}</TableCell>
                   <TableCell>{runnerSpec.max_concurrency}</TableCell>
                   <TableCell>

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -1003,22 +1003,24 @@ function PullRequestsPage({
                             <JobField
                               label="Job Name"
                               value={selectedJob.github_job_url ? (
-                                <a className={cn("inline-flex min-w-0 items-center gap-1 hover:underline", jobStatusTextClass(selectedJob.status))} href={selectedJob.github_job_url} target="_blank" rel="noreferrer">
+                                <a className={cn("inline-flex max-w-full min-w-0 items-center gap-1 hover:underline", jobStatusTextClass(selectedJob.status))} href={selectedJob.github_job_url} target="_blank" rel="noreferrer">
                                   <span className="truncate">{runnerJobTitle(selectedJob)}</span>
                                   <ExternalLink className="h-3.5 w-3.5 shrink-0" />
                                 </a>
                               ) : (
-                                <span className={jobStatusTextClass(selectedJob.status)}>{runnerJobTitle(selectedJob)}</span>
+                                <span className={cn("block truncate", jobStatusTextClass(selectedJob.status))}>{runnerJobTitle(selectedJob)}</span>
                               )}
                             />
                             <JobField
                               label="Workflow"
                               value={workflowRunURL(selectedJob) ? (
-                                <a className="inline-flex min-w-0 items-center gap-1 text-primary hover:underline" href={workflowRunURL(selectedJob)} target="_blank" rel="noreferrer">
+                                <a className="inline-flex max-w-full min-w-0 items-center gap-1 text-primary hover:underline" href={workflowRunURL(selectedJob)} target="_blank" rel="noreferrer">
                                   <span className="truncate">{selectedJob.workflow_name || "Workflow"}</span>
                                   <ExternalLink className="h-3.5 w-3.5 shrink-0" />
                                 </a>
-                              ) : selectedJob.workflow_name || "Workflow"}
+                              ) : (
+                                <span className="block truncate">{selectedJob.workflow_name || "Workflow"}</span>
+                              )}
                             />
                             <JobField label="Duration" value={formatRunnerDuration(selectedJob) || "-"} />
                           </>


### PR DESCRIPTION
## Summary

- truncate long job and workflow labels in the ordinary-user Jobs view
- constrain long runner identifiers in admin overview cards and runner request rows
- cap long runner spec, group, and policy table columns without affecting status or action columns

## Why

Long workflow and runner identifiers could expand flex and table content beyond the intended layout instead of displaying an ellipsis.

## Validation

- `npm run lint`
- `npm run build`