### PR TITLE
fix(ui): improve account settings feedback

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -170,6 +170,61 @@ func (c *Client) ListInstallationRepositories(ctx context.Context, installationI
 	return repositories, nil
 }
 
+func (c *Client) ListUserInstallations(ctx context.Context, token string) ([]Installation, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil, fmt.Errorf("github oauth token is required")
+	}
+	nextURL := fmt.Sprintf("%s/user/installations?per_page=100", c.baseURL)
+	var installations []Installation
+	for nextURL != "" {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		setGitHubHeaders(req)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read github user installations response: %w", readErr)
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("github user installations: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		var out struct {
+			Installations []struct {
+				ID      int64 `json:"id"`
+				Account struct {
+					Login     string `json:"login"`
+					Name      string `json:"name"`
+					AvatarURL string `json:"avatar_url"`
+				} `json:"account"`
+			} `json:"installations"`
+		}
+		if err := json.Unmarshal(body, &out); err != nil {
+			return nil, err
+		}
+		for _, item := range out.Installations {
+			if item.ID <= 0 {
+				continue
+			}
+			installations = append(installations, Installation{
+				ID:            item.ID,
+				AccountLogin:  item.Account.Login,
+				AccountName:   item.Account.Name,
+				AccountAvatar: item.Account.AvatarURL,
+			})
+		}
+		nextURL = nextLink(resp.Header.Get("Link"))
+	}
+	return installations, nil
+}
+
 func NewClient(baseURL string, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -457,6 +457,29 @@ func TestDownloadWorkflowJobLogsFollowsRedirectWithoutGitHubAuth(t *testing.T) {
 	}
 }
 
+func TestListUserInstallationsUsesOAuthToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/user/installations" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+		if r.Header.Get("Authorization") != "Bearer user-token" {
+			t.Fatalf("expected bearer user token, got %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"installations":[{"id":987,"account":{"login":"octo-org","name":"Octo Org","avatar_url":"https://avatars.example/o.png"}}]}`))
+	}))
+	defer ts.Close()
+
+	client := NewClient(ts.URL, ts.Client())
+	installations, err := client.ListUserInstallations(t.Context(), "user-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installations) != 1 || installations[0].ID != 987 || installations[0].AccountLogin != "octo-org" {
+		t.Fatalf("unexpected installations: %#v", installations)
+	}
+}
+
 func TestDownloadWorkflowJobLogsRedirectUsesConfiguredTransport(t *testing.T) {
 	client := NewTokenClient("https://api.github.test", "github-token", &http.Client{
 		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -104,6 +104,7 @@ const (
 	defaultRunnerRequestListLimit = 100
 	maxRunnerRequestListLimit     = 500
 	oauthStateCookieName          = "runnerd_oauth_state"
+	oauthReturnToCookieName       = "runnerd_oauth_return_to"
 	githubAppSetupStateCookieName = "runnerd_github_app_setup_state"
 	adminSessionCookieName        = "runnerd_admin_session"
 )
@@ -225,6 +226,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /github-app/setup", s.handleGitHubAppSetupRedirect)
 	s.mux.HandleFunc("GET /user/github-app", s.handleUserGitHubApp)
 	s.mux.HandleFunc("POST /user/github-app/installations", s.handleUserSaveGitHubInstallation)
+	s.mux.HandleFunc("POST /user/github-app/installations/sync", s.handleUserSyncGitHubInstallations)
 	s.mux.HandleFunc("GET /user/github-app/installations/{id}/repositories", s.handleUserListGitHubInstallationRepositories)
 	s.mux.HandleFunc("DELETE /user/github-app/installations/{id}", s.handleUserDeleteGitHubInstallation)
 	s.mux.HandleFunc("GET /user/runner_requests", s.handleUserListRunners)

--- a/internal/server/server_auth.go
+++ b/internal/server/server_auth.go
@@ -36,6 +36,7 @@ func (s *Server) handleGitHubOAuthLogin(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	stateToken := newID()
+	returnTo := sanitizeOAuthReturnTo(r.URL.Query().Get("return_to"))
 	http.SetCookie(w, &http.Cookie{
 		Name:     oauthStateCookieName,
 		Value:    stateToken,
@@ -45,6 +46,19 @@ func (s *Server) handleGitHubOAuthLogin(w http.ResponseWriter, r *http.Request) 
 		Secure:   requestIsSecure(r),
 		MaxAge:   int((10 * time.Minute).Seconds()),
 	})
+	if returnTo != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     oauthReturnToCookieName,
+			Value:    returnTo,
+			Path:     "/auth/github",
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   requestIsSecure(r),
+			MaxAge:   int((10 * time.Minute).Seconds()),
+		})
+	} else {
+		clearCookie(w, oauthReturnToCookieName, "/auth/github", requestIsSecure(r))
+	}
 	values := url.Values{
 		"client_id":    {s.cfg.GitHubOAuthClientID},
 		"state":        {stateToken},
@@ -100,6 +114,22 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusInternalServerError, "save github oauth account")
 		return
 	}
+	encryptedToken, err := encryptSecret(token, s.cfg.AuthEncryptionKey)
+	if err != nil {
+		s.logger.Warn("github oauth token encrypt failed", "login", user.Login, "error", err)
+		writeError(w, http.StatusInternalServerError, "save github oauth token")
+		return
+	}
+	if _, err := s.store.UpsertAccountSecret(state.AccountSecret{
+		ScopeType:      state.AccountScopeTypeAccount,
+		ScopeID:        account.ID,
+		KeyType:        state.AccountSecretTypeGitHubOAuthToken,
+		EncryptedValue: encryptedToken,
+	}); err != nil {
+		s.logger.Warn("github oauth token save failed", "login", user.Login, "error", err)
+		writeError(w, http.StatusInternalServerError, "save github oauth token")
+		return
+	}
 	session := adminSession{
 		Provider:  "github",
 		Subject:   user.Subject(),
@@ -123,7 +153,14 @@ func (s *Server) handleGitHubOAuthCallback(w http.ResponseWriter, r *http.Reques
 		Secure:   requestIsSecure(r),
 		MaxAge:   int(s.cfg.AuthSessionTTL.Seconds()),
 	})
-	http.Redirect(w, r, "/", http.StatusFound)
+	returnTo := "/"
+	if cookie, err := r.Cookie(oauthReturnToCookieName); err == nil {
+		clearCookie(w, oauthReturnToCookieName, "/auth/github", requestIsSecure(r))
+		if sanitized := sanitizeOAuthReturnTo(cookie.Value); sanitized != "" {
+			returnTo = sanitized
+		}
+	}
+	http.Redirect(w, r, returnTo, http.StatusFound)
 }
 
 func (s *Server) isGitHubAppSetupCallback(r *http.Request) bool {
@@ -133,7 +170,19 @@ func (s *Server) isGitHubAppSetupCallback(r *http.Request) bool {
 func (s *Server) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
 	clearCookie(w, adminSessionCookieName, "/", requestIsSecure(r))
 	clearCookie(w, oauthStateCookieName, "/auth/github", requestIsSecure(r))
+	clearCookie(w, oauthReturnToCookieName, "/auth/github", requestIsSecure(r))
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func sanitizeOAuthReturnTo(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || !strings.HasPrefix(value, "/") || strings.HasPrefix(value, "//") {
+		return ""
+	}
+	if parsed, err := url.Parse(value); err != nil || parsed.IsAbs() || parsed.Host != "" {
+		return ""
+	}
+	return value
 }
 
 type githubOAuthTokenResponse struct {

--- a/internal/server/server_auth.go
+++ b/internal/server/server_auth.go
@@ -176,7 +176,7 @@ func (s *Server) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
 
 func sanitizeOAuthReturnTo(value string) string {
 	value = strings.TrimSpace(value)
-	if value == "" || !strings.HasPrefix(value, "/") || strings.HasPrefix(value, "//") {
+	if value == "" || !strings.HasPrefix(value, "/") || strings.HasPrefix(value, "//") || strings.Contains(value, "\\") {
 		return ""
 	}
 	if parsed, err := url.Parse(value); err != nil || parsed.IsAbs() || parsed.Host != "" {

--- a/internal/server/server_auth_helpers.go
+++ b/internal/server/server_auth_helpers.go
@@ -225,6 +225,10 @@ func writeError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, map[string]string{"error": message})
 }
 
+func writeErrorCode(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, map[string]string{"code": code, "error": message})
+}
+
 func newID() string {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -557,6 +557,17 @@ func TestUserSyncGitHubInstallationsFromOAuthToken(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	stale, err := store.UpsertGitHubInstallation(state.GitHubInstallation{
+		AccountID:      account.ID,
+		InstallationID: 654,
+		AccountLogin:   "stale-org",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stale.ID <= 0 {
+		t.Fatalf("expected stale installation id, got %#v", stale)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/user/github-app/installations/sync", nil)
 	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
@@ -571,6 +582,25 @@ func TestUserSyncGitHubInstallationsFromOAuthToken(t *testing.T) {
 	}
 	if len(installations) != 1 || installations[0].InstallationID != 987 || installations[0].AccountLogin != "octo-org" {
 		t.Fatalf("unexpected synced installations: %#v", installations)
+	}
+}
+
+func TestUserSyncGitHubInstallationsRequiresOAuthTokenCode(t *testing.T) {
+	store := state.New(t.TempDir())
+	srv := newTestServer(t, store, "https://github.example", &fakeSandbox{})
+	if _, _, err := store.GetAccountByOAuthIdentity("github", "hubot-id"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/user/github-app/installations/sync", nil)
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("unexpected sync status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"REAUTH_REQUIRED"`) {
+		t.Fatalf("expected reauth code response, got %s", rec.Body.String())
 	}
 }
 
@@ -1085,6 +1115,17 @@ func TestGitHubOAuthLoginCreatesAdminSession(t *testing.T) {
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"role":"admin"`) {
 		t.Fatalf("expected session role response, status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSanitizeOAuthReturnToRejectsBackslashRedirects(t *testing.T) {
+	for _, value := range []string{`/\example.com`, `/\\example.com`, `/account\repositories`} {
+		if got := sanitizeOAuthReturnTo(value); got != "" {
+			t.Fatalf("expected %q to be rejected, got %q", value, got)
+		}
+	}
+	if got := sanitizeOAuthReturnTo("/account/repositories"); got != "/account/repositories" {
+		t.Fatalf("expected account path to be preserved, got %q", got)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -524,6 +524,56 @@ func TestUserGitHubAppConfigurationAndRunnerList(t *testing.T) {
 	}
 }
 
+func TestUserSyncGitHubInstallationsFromOAuthToken(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/user/installations":
+			if r.Header.Get("Authorization") != "Bearer user-token" {
+				t.Fatalf("expected oauth token authorization, got %q", r.Header.Get("Authorization"))
+			}
+			w.Write([]byte(`{"installations":[{"id":987,"account":{"login":"octo-org","name":"Octo Org","avatar_url":"https://avatars.example/o.png"}}]}`))
+		default:
+			t.Fatalf("unexpected github sync request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	srv := newTestServer(t, store, ghServer.URL, &fakeSandbox{})
+	account, _, err := store.GetAccountByOAuthIdentity("github", "hubot-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	encryptedToken, err := encryptSecret("user-token", srv.cfg.AuthEncryptionKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertAccountSecret(state.AccountSecret{
+		ScopeType:      state.AccountScopeTypeAccount,
+		ScopeID:        account.ID,
+		KeyType:        state.AccountSecretTypeGitHubOAuthToken,
+		EncryptedValue: encryptedToken,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/user/github-app/installations/sync", nil)
+	req.AddCookie(testSessionCookie("hubot-id", "hubot", "user"))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected sync status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	installations, err := store.ListGitHubInstallations(account.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installations) != 1 || installations[0].InstallationID != 987 || installations[0].AccountLogin != "octo-org" {
+		t.Fatalf("unexpected synced installations: %#v", installations)
+	}
+}
+
 func TestUserRunnerDetailLogAndTerminal(t *testing.T) {
 	store := state.New(t.TempDir())
 	account, _, err := store.UpsertAccountForOAuthIdentity(state.OAuthIdentity{OAuthProvider: "github", OAuthSubject: "hubot-id", OAuthLogin: "hubot"}, "user")
@@ -936,7 +986,7 @@ func TestGitHubOAuthLoginCreatesAdminSession(t *testing.T) {
 		t.Fatalf("expected oauth-enabled session response, status=%d body=%s", rec.Code, rec.Body.String())
 	}
 
-	req = httptest.NewRequest(http.MethodGet, "/auth/github/login", nil)
+	req = httptest.NewRequest(http.MethodGet, "/auth/github/login?return_to=/account/repositories", nil)
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusFound {
@@ -956,16 +1006,34 @@ func TestGitHubOAuthLoginCreatesAdminSession(t *testing.T) {
 	if stateCookie == nil || stateCookie.Value == "" {
 		t.Fatal("expected oauth state cookie")
 	}
+	loginCookies := rec.Result().Cookies()
+	if returnCookie := testCookie(loginCookies, oauthReturnToCookieName); returnCookie == nil || returnCookie.Value != "/account/repositories" {
+		t.Fatalf("expected oauth return_to cookie, got %#v", returnCookie)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/auth/github/login", nil)
+	req.AddCookie(&http.Cookie{Name: oauthReturnToCookieName, Value: "/account/repositories"})
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected plain login redirect, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	clearedReturnCookie := testCookie(rec.Result().Cookies(), oauthReturnToCookieName)
+	if clearedReturnCookie == nil || clearedReturnCookie.MaxAge >= 0 {
+		t.Fatalf("expected plain login to clear stale return_to cookie, got %#v", clearedReturnCookie)
+	}
 
 	req = httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=oauth-code&state="+stateCookie.Value, nil)
-	req.AddCookie(stateCookie)
+	for _, cookie := range loginCookies {
+		req.AddCookie(cookie)
+	}
 	rec = httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusFound {
 		t.Fatalf("expected callback redirect, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	if loc := rec.Header().Get("Location"); loc != "/" {
-		t.Fatalf("expected admin callback to redirect to /, got %q", loc)
+	if loc := rec.Header().Get("Location"); loc != "/account/repositories" {
+		t.Fatalf("expected admin callback to redirect to return_to path, got %q", loc)
 	}
 	if gotTokenAuth != "Bearer user-token" {
 		t.Fatalf("expected user fetch bearer token, got %q", gotTokenAuth)
@@ -986,6 +1054,21 @@ func TestGitHubOAuthLoginCreatesAdminSession(t *testing.T) {
 	}
 	if session.Role != "admin" {
 		t.Fatalf("expected admin session role, got %q", session.Role)
+	}
+	account, _, err := store.GetAccountByOAuthIdentity("github", "12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+	savedToken, err := store.GetAccountSecret(state.AccountScopeTypeAccount, account.ID, state.AccountSecretTypeGitHubOAuthToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decryptedToken, err := decryptSecret(savedToken.EncryptedValue, srv.cfg.AuthEncryptionKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decryptedToken != "user-token" {
+		t.Fatalf("unexpected saved github oauth token: %q", decryptedToken)
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "/runner_requests", nil)
@@ -3523,6 +3606,15 @@ func testSessionCookie(subject, login, role string) *http.Cookie {
 		Value: payloadValue + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil)),
 		Path:  "/",
 	}
+}
+
+func testCookie(cookies []*http.Cookie, name string) *http.Cookie {
+	for _, cookie := range cookies {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+	return nil
 }
 
 func testServerPrivateKeyFile(t *testing.T) string {

--- a/internal/server/server_user_handlers.go
+++ b/internal/server/server_user_handlers.go
@@ -178,6 +178,57 @@ func (s *Server) handleUserDeleteGitHubInstallation(w http.ResponseWriter, r *ht
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+func (s *Server) handleUserSyncGitHubInstallations(w http.ResponseWriter, r *http.Request) {
+	session, account, ok := s.requireUserSession(w, r)
+	if !ok {
+		return
+	}
+	if s.gh == nil {
+		writeError(w, http.StatusInternalServerError, "github client is not configured")
+		return
+	}
+	secret, err := s.store.GetAccountSecret(state.AccountScopeTypeAccount, account.ID, state.AccountSecretTypeGitHubOAuthToken)
+	if err != nil {
+		if errors.Is(err, state.ErrNotFound) {
+			writeError(w, http.StatusBadRequest, "sign in with GitHub again before syncing installations")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	token, err := decryptSecret(secret.EncryptedValue, s.cfg.AuthEncryptionKey)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "decrypt github oauth token")
+		return
+	}
+	remoteInstallations, err := s.gh.ListUserInstallations(r.Context(), token)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	synced := make([]state.GitHubInstallation, 0, len(remoteInstallations))
+	for _, remote := range remoteInstallations {
+		installation, err := s.store.UpsertGitHubInstallation(state.GitHubInstallation{
+			AccountID:      account.ID,
+			InstallationID: remote.ID,
+			AccountLogin:   remote.AccountLogin,
+			AccountName:    remote.AccountName,
+			AccountAvatar:  remote.AccountAvatar,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		synced = append(synced, installation)
+	}
+	s.recordAudit("github:"+session.Subject, "github_app.sync", "account", strconv.FormatInt(account.ID, 10), map[string]any{
+		"count": len(synced),
+	})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"installations": synced,
+	})
+}
+
 func (s *Server) handleUserListGitHubInstallationRepositories(w http.ResponseWriter, r *http.Request) {
 	_, account, ok := s.requireUserSession(w, r)
 	if !ok {

--- a/internal/server/server_user_handlers.go
+++ b/internal/server/server_user_handlers.go
@@ -190,7 +190,7 @@ func (s *Server) handleUserSyncGitHubInstallations(w http.ResponseWriter, r *htt
 	secret, err := s.store.GetAccountSecret(state.AccountScopeTypeAccount, account.ID, state.AccountSecretTypeGitHubOAuthToken)
 	if err != nil {
 		if errors.Is(err, state.ErrNotFound) {
-			writeError(w, http.StatusBadRequest, "sign in with GitHub again before syncing installations")
+			writeErrorCode(w, http.StatusBadRequest, "REAUTH_REQUIRED", "sign in with GitHub again before syncing installations")
 			return
 		}
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -206,8 +206,15 @@ func (s *Server) handleUserSyncGitHubInstallations(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	existingInstallations, err := s.store.ListGitHubInstallations(account.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	remoteIDs := make(map[int64]struct{}, len(remoteInstallations))
 	synced := make([]state.GitHubInstallation, 0, len(remoteInstallations))
 	for _, remote := range remoteInstallations {
+		remoteIDs[remote.ID] = struct{}{}
 		installation, err := s.store.UpsertGitHubInstallation(state.GitHubInstallation{
 			AccountID:      account.ID,
 			InstallationID: remote.ID,
@@ -221,8 +228,20 @@ func (s *Server) handleUserSyncGitHubInstallations(w http.ResponseWriter, r *htt
 		}
 		synced = append(synced, installation)
 	}
+	removed := 0
+	for _, existing := range existingInstallations {
+		if _, ok := remoteIDs[existing.InstallationID]; ok {
+			continue
+		}
+		if err := s.store.DeleteGitHubInstallation(account.ID, existing.ID); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		removed++
+	}
 	s.recordAudit("github:"+session.Subject, "github_app.sync", "account", strconv.FormatInt(account.ID, 10), map[string]any{
-		"count": len(synced),
+		"count":   len(synced),
+		"removed": removed,
 	})
 	writeJSON(w, http.StatusOK, map[string]any{
 		"installations": synced,

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -170,9 +170,10 @@ type GitHubInstallation struct {
 }
 
 const (
-	AccountSecretTypeSandboxAPIKey = "sandbox_api_key"
-	AccountScopeTypeAccount        = "account"
-	AccountScopeTypeGitHubInstall  = "github_installation"
+	AccountSecretTypeSandboxAPIKey    = "sandbox_api_key"
+	AccountSecretTypeGitHubOAuthToken = "github_oauth_token"
+	AccountScopeTypeAccount           = "account"
+	AccountScopeTypeGitHubInstall     = "github_installation"
 )
 
 // AccountSecret stores an encrypted named secret for one account.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -83,6 +83,7 @@ function App() {
   const [userPreferences, setUserPreferences] = useState<UserPreferences | null>(null)
   const [authorizedRepositories, setAuthorizedRepositories] = useState<Record<number, string[]>>({})
   const [loadingRepositoriesFor, setLoadingRepositoriesFor] = useState<number | null>(null)
+  const [syncingGitHubInstallations, setSyncingGitHubInstallations] = useState(false)
   const [userSelectedKey, setUserSelectedKey] = useState(() => userJobsGroupKeyFromLocation(window.location.pathname, window.location.search))
 
   const setSection = useCallback((next: string) => {
@@ -346,7 +347,9 @@ function App() {
   }, [request])
 
   const syncGitHubInstallations = useCallback(async () => {
+    if (syncingGitHubInstallations) return
     setLoading(true)
+    setSyncingGitHubInstallations(true)
     try {
       const data = (await request("/user/github-app/installations/sync", { method: "POST" })) as SyncedGitHubInstallations
       const count = data.installations?.length ?? 0
@@ -361,9 +364,10 @@ function App() {
       }
       toast.error(message)
     } finally {
+      setSyncingGitHubInstallations(false)
       setLoading(false)
     }
-  }, [loadUserAll, refreshGitHubOAuthLogin, request])
+  }, [loadUserAll, refreshGitHubOAuthLogin, request, syncingGitHubInstallations])
 
   const saveSandboxConfig = useCallback(async (
     apiURL: string,
@@ -703,6 +707,7 @@ function App() {
           accountSettingsRoute={accountSettingsRoute || defaultAccountSettingsRoute(authSession.login)}
           authorizedRepositories={authorizedRepositories}
           loadingRepositoriesFor={loadingRepositoriesFor}
+          syncingGitHubInstallations={syncingGitHubInstallations}
           onLoadAuthorizedRepositories={(id) => void loadAuthorizedRepositories(id)}
           onSyncGitHubInstallations={() => void syncGitHubInstallations()}
           onSaveSandboxConfig={saveSandboxConfig}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -49,6 +49,7 @@ type AccountSettingsRoute = {
   accountLogin?: string
   tab: AccountSettingsTab
 }
+type RequestError = Error & { code?: string }
 
 function App() {
   const [authSession, setAuthSession] = useState<AuthSession>({ authenticated: false, oauth_enabled: false })
@@ -202,13 +203,17 @@ function App() {
       if (!response.ok) {
         const text = await response.text()
         let message = text
+        let code = ""
         try {
-          const parsed = JSON.parse(text) as { error?: string }
+          const parsed = JSON.parse(text) as { code?: string; error?: string }
+          code = parsed.code || ""
           message = parsed.error || text
         } catch {
           // Keep the raw response body for non-JSON errors.
         }
-        throw new Error(message || `${response.status} ${response.statusText}`)
+        const error = new Error(message || `${response.status} ${response.statusText}`) as RequestError
+        error.code = code
+        throw error
       }
       const contentType = response.headers.get("content-type") || ""
       if (contentType.includes("application/json")) return response.json()
@@ -356,8 +361,9 @@ function App() {
       toast.success(count === 1 ? "Synced 1 GitHub App account" : `Synced ${count} GitHub App accounts`)
       await loadUserAll()
     } catch (error) {
+      const requestError = error as RequestError
       const message = error instanceof Error ? error.message : "Failed to sync GitHub App accounts"
-      if (message === "sign in with GitHub again before syncing installations") {
+      if (requestError.code === "REAUTH_REQUIRED" || message === "sign in with GitHub again before syncing installations") {
         toast.message("Refreshing GitHub sign-in...")
         refreshGitHubOAuthLogin()
         return

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -39,6 +39,7 @@ import {
   type RunnerSpecMatch,
   type RunnerState,
   type RunnerStatus,
+  type SyncedGitHubInstallations,
   type UserPreferences,
 } from "@/admin-types"
 import { useRunnerCatalog } from "@/hooks/use-runner-catalog"
@@ -199,7 +200,14 @@ function App() {
       }
       if (!response.ok) {
         const text = await response.text()
-        throw new Error(text || `${response.status} ${response.statusText}`)
+        let message = text
+        try {
+          const parsed = JSON.parse(text) as { error?: string }
+          message = parsed.error || text
+        } catch {
+          // Keep the raw response body for non-JSON errors.
+        }
+        throw new Error(message || `${response.status} ${response.statusText}`)
       }
       const contentType = response.headers.get("content-type") || ""
       if (contentType.includes("application/json")) return response.json()
@@ -213,6 +221,11 @@ function App() {
       .split(",")
       .map((label) => label.trim())
       .filter(Boolean)
+
+  const refreshGitHubOAuthLogin = useCallback(() => {
+    const returnTo = window.location.pathname + window.location.search
+    window.location.href = `/auth/github/login?return_to=${encodeURIComponent(returnTo || "/")}`
+  }, [])
 
   const loadLog = useCallback(
     async (id: string, name: (typeof logNames)[number]) => {
@@ -305,14 +318,14 @@ function App() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ installation_id: installationID, setup_state: setupState }),
       })) as GitHubInstallation
-      toast.success("GitHub App account connected")
+      toast.success("GitHub App account synced")
       const nextPath = accountSettingsPathForInstallation(installation, authSession.login, "repositories")
       window.history.replaceState(null, "", nextPath)
       setLocationPath(window.location.pathname)
       setLocationSearch(window.location.search)
       await loadUserAll()
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to sync GitHub App repositories")
+      toast.error(error instanceof Error ? error.message : "Failed to sync GitHub App account")
     } finally {
       setLoading(false)
     }
@@ -331,6 +344,26 @@ function App() {
       setLoadingRepositoriesFor(null)
     }
   }, [request])
+
+  const syncGitHubInstallations = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = (await request("/user/github-app/installations/sync", { method: "POST" })) as SyncedGitHubInstallations
+      const count = data.installations?.length ?? 0
+      toast.success(count === 1 ? "Synced 1 GitHub App account" : `Synced ${count} GitHub App accounts`)
+      await loadUserAll()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to sync GitHub App accounts"
+      if (message === "sign in with GitHub again before syncing installations") {
+        toast.message("Refreshing GitHub sign-in...")
+        refreshGitHubOAuthLogin()
+        return
+      }
+      toast.error(message)
+    } finally {
+      setLoading(false)
+    }
+  }, [loadUserAll, refreshGitHubOAuthLogin, request])
 
   const saveSandboxConfig = useCallback(async (
     apiURL: string,
@@ -671,6 +704,7 @@ function App() {
           authorizedRepositories={authorizedRepositories}
           loadingRepositoriesFor={loadingRepositoriesFor}
           onLoadAuthorizedRepositories={(id) => void loadAuthorizedRepositories(id)}
+          onSyncGitHubInstallations={() => void syncGitHubInstallations()}
           onSaveSandboxConfig={saveSandboxConfig}
           onDeleteSandboxAPIKey={deleteSandboxAPIKey}
           onNavigate={setUserPage}

--- a/ui/src/admin-types.ts
+++ b/ui/src/admin-types.ts
@@ -158,6 +158,10 @@ export type AuthorizedRepositories = {
   repositories: string[]
 }
 
+export type SyncedGitHubInstallations = {
+  installations: GitHubInstallation[]
+}
+
 export type Metric = {
   label: string
   value: number

--- a/ui/src/components/sandbox-catalog-sections.tsx
+++ b/ui/src/components/sandbox-catalog-sections.tsx
@@ -33,9 +33,9 @@ function Header({
   children?: ReactNode
 }) {
   return (
-    <CardHeader className="flex flex-col gap-4 border-b 2xl:flex-row 2xl:items-center 2xl:justify-between">
+    <CardHeader className="flex flex-col gap-3 pb-3 2xl:flex-row 2xl:items-center 2xl:justify-between">
       <div>
-        <CardTitle>{title}</CardTitle>
+        <CardTitle className="text-base">{title}</CardTitle>
         <CardDescription className="mt-1">{description}</CardDescription>
       </div>
       <div className="flex w-full flex-wrap justify-end gap-2 2xl:w-auto">
@@ -102,7 +102,7 @@ export function SandboxTemplatesSection({
   }, [load])
 
   return (
-    <Card className="overflow-hidden">
+    <Card className="rounded-lg">
       <Header
         title="Sandbox templates"
         description="Runnable images available to runner specs in the selected region."
@@ -111,44 +111,46 @@ export function SandboxTemplatesSection({
         onRegion={setRegion}
         onRefresh={() => void load()}
       />
-      <CardContent className="p-0">
+      <CardContent>
         {error ? (
-          <p className="p-6 text-sm text-destructive">{error}</p>
+          <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Template</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Resources</TableHead>
-                <TableHead>Visibility</TableHead>
-                <TableHead className="text-right">Spawns</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {items.map((item) => (
-                <TableRow key={item.template_id}>
-                  <TableCell>
-                    <div className="font-medium">{item.aliases?.[0] || item.template_id}</div>
-                    <div className="max-w-[360px] truncate text-xs text-muted-foreground">{item.template_id}</div>
-                  </TableCell>
-                  <TableCell>{item.build_status || "unknown"}</TableCell>
-                  <TableCell>
-                    {item.cpu_count} CPU · {item.memory_mb} MB · {item.disk_size_mb} MB disk
-                  </TableCell>
-                  <TableCell>{item.public ? "Public" : "Private"}</TableCell>
-                  <TableCell className="text-right tabular-nums">{item.spawn_count}</TableCell>
-                </TableRow>
-              ))}
-              {!loading && items.length === 0 ? (
+          <div className="overflow-x-auto rounded-md border">
+            <Table>
+              <TableHeader>
                 <TableRow>
-                  <TableCell colSpan={5} className="h-32 text-center text-muted-foreground">
-                    No templates in this region.
-                  </TableCell>
+                  <TableHead>Template</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Resources</TableHead>
+                  <TableHead>Visibility</TableHead>
+                  <TableHead className="text-right">Spawns</TableHead>
                 </TableRow>
-              ) : null}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {items.map((item) => (
+                  <TableRow key={item.template_id}>
+                    <TableCell>
+                      <div className="font-medium">{item.aliases?.[0] || item.template_id}</div>
+                      <div className="max-w-[360px] truncate text-xs text-muted-foreground">{item.template_id}</div>
+                    </TableCell>
+                    <TableCell>{item.build_status || "unknown"}</TableCell>
+                    <TableCell>
+                      {item.cpu_count} CPU · {item.memory_mb} MB · {item.disk_size_mb} MB disk
+                    </TableCell>
+                    <TableCell>{item.public ? "Public" : "Private"}</TableCell>
+                    <TableCell className="text-right tabular-nums">{item.spawn_count}</TableCell>
+                  </TableRow>
+                ))}
+                {!loading && items.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="h-32 text-center text-muted-foreground">
+                      No templates in this region.
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+              </TableBody>
+            </Table>
+          </div>
         )}
       </CardContent>
     </Card>
@@ -238,7 +240,7 @@ export function SandboxesSection({
   })
 
   return (
-    <Card className="overflow-hidden">
+    <Card className="rounded-lg">
       <Header
         title="Sandbox instances"
         description="Live and recent sandbox capacity in the selected region."
@@ -267,48 +269,50 @@ export function SandboxesSection({
           </SelectContent>
         </Select>
       </Header>
-      <CardContent className="p-0">
+      <CardContent>
         {error ? (
-          <p className="p-6 text-sm text-destructive">{error}</p>
+          <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Sandbox</TableHead>
-                <TableHead>State</TableHead>
-                <TableHead>Template</TableHead>
-                <TableHead>Resources</TableHead>
-                <TableHead>Started</TableHead>
-                <TableHead>Expires</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {items.map((item) => (
-                <TableRow key={item.sandbox_id}>
-                  <TableCell>
-                    <div className="font-medium">{item.alias || item.sandbox_id}</div>
-                    <div className="max-w-[300px] truncate text-xs text-muted-foreground">{item.sandbox_id}</div>
-                  </TableCell>
-                  <TableCell>{item.state}</TableCell>
-                  <TableCell>
-                    <div className="max-w-[260px] truncate">{item.template_id}</div>
-                  </TableCell>
-                  <TableCell>
-                    {item.cpu_count} CPU · {item.memory_mb} MB
-                  </TableCell>
-                  <TableCell>{formatOptionalTime(item.started_at)}</TableCell>
-                  <TableCell>{formatOptionalTime(item.expires_at)}</TableCell>
-                </TableRow>
-              ))}
-              {!loading && items.length === 0 ? (
+          <div className="overflow-x-auto rounded-md border">
+            <Table>
+              <TableHeader>
                 <TableRow>
-                  <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
-                    No sandboxes match these filters.
-                  </TableCell>
+                  <TableHead>Sandbox</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead>Template</TableHead>
+                  <TableHead>Resources</TableHead>
+                  <TableHead>Started</TableHead>
+                  <TableHead>Expires</TableHead>
                 </TableRow>
-              ) : null}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {items.map((item) => (
+                  <TableRow key={item.sandbox_id}>
+                    <TableCell>
+                      <div className="font-medium">{item.alias || item.sandbox_id}</div>
+                      <div className="max-w-[300px] truncate text-xs text-muted-foreground">{item.sandbox_id}</div>
+                    </TableCell>
+                    <TableCell>{item.state}</TableCell>
+                    <TableCell>
+                      <div className="max-w-[260px] truncate">{item.template_id}</div>
+                    </TableCell>
+                    <TableCell>
+                      {item.cpu_count} CPU · {item.memory_mb} MB
+                    </TableCell>
+                    <TableCell>{formatOptionalTime(item.started_at)}</TableCell>
+                    <TableCell>{formatOptionalTime(item.expires_at)}</TableCell>
+                  </TableRow>
+                ))}
+                {!loading && items.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
+                      No sandboxes match these filters.
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+              </TableBody>
+            </Table>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -115,6 +115,7 @@ export function UserDashboard({
   authorizedRepositories,
   loadingRepositoriesFor,
   onLoadAuthorizedRepositories,
+  onSyncGitHubInstallations,
   onSaveSandboxConfig,
   onDeleteSandboxAPIKey,
   onNavigate,
@@ -136,6 +137,7 @@ export function UserDashboard({
   authorizedRepositories: Record<number, string[]>
   loadingRepositoriesFor: number | null
   onLoadAuthorizedRepositories: (id: number) => void
+  onSyncGitHubInstallations: () => void
   onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number, mode?: "custom" | "inherit", replaceInheritedSource?: boolean) => Promise<void>
   onDeleteSandboxAPIKey: (installationID?: number) => Promise<void>
   onNavigate: (page: UserPage) => void
@@ -228,6 +230,8 @@ export function UserDashboard({
       {page === "repositories" ? (
         <ActivityRepositoriesPage
           installations={installations}
+          canSyncGitHubInstallations={Boolean(githubApp)}
+          onSyncGitHubInstallations={onSyncGitHubInstallations}
         />
       ) : page === "settings" ? (
         <AccountsPage
@@ -238,6 +242,7 @@ export function UserDashboard({
           loadingRepositoriesFor={loadingRepositoriesFor}
           route={accountSettingsRoute}
           onLoadAuthorizedRepositories={onLoadAuthorizedRepositories}
+          onSyncGitHubInstallations={onSyncGitHubInstallations}
           onSaveSandboxConfig={onSaveSandboxConfig}
           onDeleteSandboxAPIKey={onDeleteSandboxAPIKey}
           currentLogin={authSession.login}
@@ -252,7 +257,8 @@ export function UserDashboard({
           selectedJobGroup={selectedJobGroup}
           selectedJobID={selectedJobID}
           onSelectKey={onSelectKey}
-          onNavigate={onNavigate}
+          canSyncGitHubInstallations={Boolean(githubApp)}
+          onSyncGitHubInstallations={onSyncGitHubInstallations}
           onOpenJob={onOpenJob}
           request={request}
         />
@@ -263,8 +269,12 @@ export function UserDashboard({
 
 function ActivityRepositoriesPage({
   installations,
+  canSyncGitHubInstallations,
+  onSyncGitHubInstallations,
 }: {
   installations: NonNullable<GitHubAppConfig["installations"]>
+  canSyncGitHubInstallations: boolean
+  onSyncGitHubInstallations: () => void
 }) {
   const [selectedID, setSelectedID] = useState<number | null>(null)
   const selected = installations.find((installation) => installation.id === selectedID) || installations[0]
@@ -303,7 +313,7 @@ function ActivityRepositoriesPage({
                 ))
               ) : (
                 <div className="p-4 text-sm text-muted-foreground">
-                  Connect a GitHub App account, then trigger a workflow job to show active repositories here.
+                  Sync existing GitHub App accounts, then trigger a workflow job to show active repositories here.
                 </div>
               )}
             </div>
@@ -349,8 +359,23 @@ function ActivityRepositoriesPage({
               </Card>
             </div>
           ) : (
-            <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
-              Connect a GitHub App account, then trigger a workflow job to show active repositories here.
+            <div className="rounded-lg border bg-muted/30 p-6">
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <h2 className="text-base font-semibold">Sync existing GitHub App accounts</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {canSyncGitHubInstallations
+                      ? "Use this if the GitHub App is already installed but this runnerd instance has no local account record yet."
+                      : "Set up GitHub App auth before syncing local account records."}
+                  </p>
+                </div>
+                {canSyncGitHubInstallations ? (
+                  <Button type="button" onClick={onSyncGitHubInstallations}>
+                    <Github className="h-4 w-4" />
+                    Sync accounts
+                  </Button>
+                ) : null}
+              </div>
             </div>
           )}
         </section>
@@ -367,6 +392,7 @@ function AccountsPage({
   loadingRepositoriesFor,
   route,
   onLoadAuthorizedRepositories,
+  onSyncGitHubInstallations,
   onSaveSandboxConfig,
   onDeleteSandboxAPIKey,
   currentLogin,
@@ -380,6 +406,7 @@ function AccountsPage({
   loadingRepositoriesFor: number | null
   route: AccountSettingsRoute
   onLoadAuthorizedRepositories: (id: number) => void
+  onSyncGitHubInstallations: () => void
   onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number, mode?: "custom" | "inherit", replaceInheritedSource?: boolean) => Promise<void>
   onDeleteSandboxAPIKey: (installationID?: number) => Promise<void>
   currentLogin?: string
@@ -417,12 +444,18 @@ function AccountsPage({
           </div>
           <div className="flex flex-wrap items-center gap-2">
             {githubApp?.install_url ? (
-              <Button type="button" asChild>
-                <a href={githubApp.install_url}>
+              <>
+                <Button type="button" variant="outline" onClick={onSyncGitHubInstallations}>
                   <Github className="h-4 w-4" />
-                  Install GitHub App
-                </a>
-              </Button>
+                  Sync existing installations
+                </Button>
+                <Button type="button" asChild>
+                  <a href={githubApp.install_url}>
+                    <Github className="h-4 w-4" />
+                    Install GitHub App
+                  </a>
+                </Button>
+              </>
             ) : (
               <Badge variant="outline">Set github.app.slug to enable the install link</Badge>
             )}
@@ -457,7 +490,7 @@ function AccountsPage({
                 ))
               ) : (
                 <div className="p-4 text-sm text-muted-foreground">
-                  Install the GitHub App to connect a user or organization.
+                  Install the GitHub App or sync existing installations to link a user or organization.
                 </div>
               )}
             </div>
@@ -610,8 +643,23 @@ function AccountsPage({
                 <SandboxesSection request={request} />
               </div>
             ) : (
-              <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
-                Install the GitHub App to connect a user or organization.
+              <div className="rounded-lg border bg-muted/30 p-6">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div className="min-w-0">
+                    <h2 className="text-base font-semibold">No local GitHub App accounts</h2>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {githubApp
+                        ? "Sync existing GitHub App installations to create the local account links for this runnerd instance."
+                        : "Set up GitHub App auth before syncing local account records."}
+                    </p>
+                  </div>
+                  {githubApp ? (
+                    <Button type="button" onClick={onSyncGitHubInstallations}>
+                      <Github className="h-4 w-4" />
+                      Sync existing installations
+                    </Button>
+                  ) : null}
+                </div>
               </div>
             )
           )}
@@ -932,7 +980,8 @@ function PullRequestsPage({
   selectedJobGroup,
   selectedJobID,
   onSelectKey,
-  onNavigate,
+  canSyncGitHubInstallations,
+  onSyncGitHubInstallations,
   onOpenJob,
   request,
 }: {
@@ -942,7 +991,8 @@ function PullRequestsPage({
   selectedJobGroup: RunnerJobGroup | null
   selectedJobID: string
   onSelectKey: (key: string) => void
-  onNavigate: (page: UserPage) => void
+  canSyncGitHubInstallations: boolean
+  onSyncGitHubInstallations: () => void
   onOpenJob: (id: string) => void
   request: (url: string, options?: RequestInit) => Promise<unknown>
 }) {
@@ -997,13 +1047,7 @@ function PullRequestsPage({
                   {hasInstallations ? (
                     "No jobs yet. Trigger a workflow in an installed repository, then refresh."
                   ) : (
-                    <button
-                      type="button"
-                      className="text-left text-primary hover:underline"
-                      onClick={() => onNavigate("settings")}
-                    >
-                      Connect a GitHub App account to start tracking jobs.
-                    </button>
+                    "Sync existing GitHub App accounts to start tracking jobs."
                   )}
                 </div>
               )}
@@ -1074,19 +1118,34 @@ function PullRequestsPage({
               </div>
             </div>
           ) : (
-            <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
+            <div className="p-4 lg:p-6">
               {groups.length ? (
-                "This job group was not found. It may have aged out of the local runner history or belongs to an account that is not connected."
+                <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
+                  This job group was not found. It may have aged out of the local runner history or belongs to an account that is not connected.
+                </div>
               ) : hasInstallations ? (
-                "No runner jobs are available yet. Trigger a workflow in an installed repository to see jobs here."
+                <div className="rounded-lg border bg-muted/30 p-6 text-sm text-muted-foreground">
+                  No runner jobs are available yet. Trigger a workflow in an installed repository to see jobs here.
+                </div>
               ) : (
-                <button
-                  type="button"
-                  className="text-left text-primary hover:underline"
-                  onClick={() => onNavigate("settings")}
-                >
-                  Connect a GitHub App account to start tracking jobs.
-                </button>
+                <div className="rounded-lg border bg-muted/30 p-6">
+                  <div className="flex flex-wrap items-center justify-between gap-4">
+                    <div className="min-w-0">
+                      <h2 className="text-base font-semibold">Sync existing GitHub App accounts</h2>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {canSyncGitHubInstallations
+                          ? "Use this if the GitHub App is already installed but this runnerd instance has no local account record yet."
+                          : "Set up GitHub App auth before syncing local account records."}
+                      </p>
+                    </div>
+                    {canSyncGitHubInstallations ? (
+                      <Button type="button" onClick={onSyncGitHubInstallations}>
+                        <Github className="h-4 w-4" />
+                        Sync accounts
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
               )}
             </div>
           )}

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -11,6 +11,7 @@ import {
   Monitor,
   Moon,
   Play,
+  Pencil,
   RefreshCw,
   Settings,
   ShieldCheck,
@@ -157,6 +158,7 @@ export function UserDashboard({
     () => orderInstallationsByCurrentAccount(githubApp?.installations ?? [], authSession.login),
     [authSession.login, githubApp?.installations]
   )
+  const canSyncGitHubInstallations = Boolean(githubApp?.install_url || githubApp?.app_slug)
   const hasInstallations = installations.length > 0
   const navItemClass = (active: boolean) =>
     cn(
@@ -231,7 +233,7 @@ export function UserDashboard({
       {page === "repositories" ? (
         <ActivityRepositoriesPage
           installations={installations}
-          canSyncGitHubInstallations={Boolean(githubApp)}
+          canSyncGitHubInstallations={canSyncGitHubInstallations}
           syncingGitHubInstallations={syncingGitHubInstallations}
           onSyncGitHubInstallations={onSyncGitHubInstallations}
         />
@@ -260,7 +262,7 @@ export function UserDashboard({
           selectedJobGroup={selectedJobGroup}
           selectedJobID={selectedJobID}
           onSelectKey={onSelectKey}
-          canSyncGitHubInstallations={Boolean(githubApp)}
+          canSyncGitHubInstallations={canSyncGitHubInstallations}
           syncingGitHubInstallations={syncingGitHubInstallations}
           onSyncGitHubInstallations={onSyncGitHubInstallations}
           onOpenJob={onOpenJob}
@@ -697,7 +699,7 @@ function AccountsPage({
                         : "Set up GitHub App auth before syncing local account records."}
                     </p>
                   </div>
-                  {githubApp ? (
+                  {githubApp?.install_url || githubApp?.app_slug ? (
                     <SyncGitHubInstallationsButton
                       isSyncing={syncingGitHubInstallations}
                       label="Sync existing installations"
@@ -729,6 +731,7 @@ function SandboxAPIKeyCard({
   const [apiURL, setAPIURL] = useState("")
   const [apiKey, setAPIKey] = useState("")
   const [credentialMode, setCredentialMode] = useState<"custom" | "inherit">("custom")
+  const [customAPIURLOpen, setCustomAPIURLOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false)
@@ -742,14 +745,15 @@ function SandboxAPIKeyCard({
   const sourceAvailable = Boolean(preferences?.sandbox?.source_available)
   const updatedAt = preferences?.sandbox?.api_key?.updated_at
   const savedAPIURL = preferences?.sandbox?.api_url ?? ""
-  const canUseSavedAPIURL = !(allowInheritance && preferences?.sandbox?.inherited && credentialMode === "custom")
+  const canUseSavedAPIURL = !customAPIURLOpen && !(allowInheritance && preferences?.sandbox?.inherited && credentialMode === "custom")
   const effectiveAPIURL = apiURL || (canUseSavedAPIURL ? savedAPIURL : "")
   const selectedRegion = findSandboxRegionByAPIURL(effectiveAPIURL)
-  const showsCustomAPIURL = Boolean(effectiveAPIURL.trim()) && !selectedRegion
+  const showsCustomAPIURL = customAPIURLOpen || (Boolean(effectiveAPIURL.trim()) && !selectedRegion)
 
   useEffect(() => {
     const resolvedAPIURL = resolveSandboxRegionAPIURL(savedAPIURL)
     setAPIURL(resolvedAPIURL)
+    setCustomAPIURLOpen(Boolean(savedAPIURL.trim()) && !findSandboxRegionByAPIURL(resolvedAPIURL))
   }, [savedAPIURL])
 
   useEffect(() => {
@@ -883,6 +887,7 @@ function SandboxAPIKeyCard({
                 onValueChange={(regionID) => {
                   const region = sandboxRegions.find((region) => region.id === regionID)
                   setAPIURL(region?.apiURL ?? "")
+                  setCustomAPIURLOpen(false)
                 }}
                 disabled={saving || deleting || credentialMode === "inherit"}
               >
@@ -902,6 +907,20 @@ function SandboxAPIKeyCard({
                   ))}
                 </SelectContent>
               </Select>
+              {!showsCustomAPIURL && credentialMode === "custom" ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setAPIURL("")
+                    setCustomAPIURLOpen(true)
+                  }}
+                  disabled={saving || deleting}
+                >
+                  <Pencil className="h-4 w-4" />
+                  Custom endpoint
+                </Button>
+              ) : null}
               {showsCustomAPIURL && credentialMode === "custom" ? (
                 <Input
                   value={apiURL}

--- a/ui/src/components/user-dashboard.tsx
+++ b/ui/src/components/user-dashboard.tsx
@@ -87,7 +87,6 @@ type GitHubLogState =
 
 const jobLogTabsListClassName = "h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent p-0 text-muted-foreground"
 const jobLogTabsTriggerClassName = "h-10 flex-none rounded-none border-x-0 border-t-0 border-b-2 border-transparent bg-transparent px-0 py-2 text-sm font-medium shadow-none hover:text-foreground data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none dark:data-[state=active]:bg-transparent"
-const customSandboxRegionID = "__custom__"
 
 function normalizeSandboxAPIURL(value: string) {
   return value.trim().replace(/\/+$/, "")
@@ -114,6 +113,7 @@ export function UserDashboard({
   accountSettingsRoute,
   authorizedRepositories,
   loadingRepositoriesFor,
+  syncingGitHubInstallations,
   onLoadAuthorizedRepositories,
   onSyncGitHubInstallations,
   onSaveSandboxConfig,
@@ -136,6 +136,7 @@ export function UserDashboard({
   accountSettingsRoute: AccountSettingsRoute
   authorizedRepositories: Record<number, string[]>
   loadingRepositoriesFor: number | null
+  syncingGitHubInstallations: boolean
   onLoadAuthorizedRepositories: (id: number) => void
   onSyncGitHubInstallations: () => void
   onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number, mode?: "custom" | "inherit", replaceInheritedSource?: boolean) => Promise<void>
@@ -231,6 +232,7 @@ export function UserDashboard({
         <ActivityRepositoriesPage
           installations={installations}
           canSyncGitHubInstallations={Boolean(githubApp)}
+          syncingGitHubInstallations={syncingGitHubInstallations}
           onSyncGitHubInstallations={onSyncGitHubInstallations}
         />
       ) : page === "settings" ? (
@@ -241,6 +243,7 @@ export function UserDashboard({
           authorizedRepositories={authorizedRepositories}
           loadingRepositoriesFor={loadingRepositoriesFor}
           route={accountSettingsRoute}
+          syncingGitHubInstallations={syncingGitHubInstallations}
           onLoadAuthorizedRepositories={onLoadAuthorizedRepositories}
           onSyncGitHubInstallations={onSyncGitHubInstallations}
           onSaveSandboxConfig={onSaveSandboxConfig}
@@ -258,6 +261,7 @@ export function UserDashboard({
           selectedJobID={selectedJobID}
           onSelectKey={onSelectKey}
           canSyncGitHubInstallations={Boolean(githubApp)}
+          syncingGitHubInstallations={syncingGitHubInstallations}
           onSyncGitHubInstallations={onSyncGitHubInstallations}
           onOpenJob={onOpenJob}
           request={request}
@@ -270,10 +274,12 @@ export function UserDashboard({
 function ActivityRepositoriesPage({
   installations,
   canSyncGitHubInstallations,
+  syncingGitHubInstallations,
   onSyncGitHubInstallations,
 }: {
   installations: NonNullable<GitHubAppConfig["installations"]>
   canSyncGitHubInstallations: boolean
+  syncingGitHubInstallations: boolean
   onSyncGitHubInstallations: () => void
 }) {
   const [selectedID, setSelectedID] = useState<number | null>(null)
@@ -370,10 +376,12 @@ function ActivityRepositoriesPage({
                   </p>
                 </div>
                 {canSyncGitHubInstallations ? (
-                  <Button type="button" onClick={onSyncGitHubInstallations}>
-                    <Github className="h-4 w-4" />
-                    Sync accounts
-                  </Button>
+                  <SyncGitHubInstallationsButton
+                    isSyncing={syncingGitHubInstallations}
+                    label="Sync accounts"
+                    loadingLabel="Syncing..."
+                    onSync={onSyncGitHubInstallations}
+                  />
                 ) : null}
               </div>
             </div>
@@ -384,6 +392,37 @@ function ActivityRepositoriesPage({
   )
 }
 
+function SyncGitHubInstallationsButton({
+  isSyncing,
+  label,
+  loadingLabel,
+  onSync,
+  variant,
+}: {
+  isSyncing: boolean
+  label: string
+  loadingLabel: string
+  onSync: () => void
+  variant?: "default" | "outline"
+}) {
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      disabled={isSyncing}
+      className={cn(label.length > 16 ? "min-w-[13.5rem]" : "min-w-[8.5rem]")}
+      onClick={onSync}
+    >
+      {isSyncing ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <Github className="h-4 w-4" />
+      )}
+      {isSyncing ? loadingLabel : label}
+    </Button>
+  )
+}
+
 function AccountsPage({
   githubApp,
   userPreferences,
@@ -391,6 +430,7 @@ function AccountsPage({
   authorizedRepositories,
   loadingRepositoriesFor,
   route,
+  syncingGitHubInstallations,
   onLoadAuthorizedRepositories,
   onSyncGitHubInstallations,
   onSaveSandboxConfig,
@@ -405,6 +445,7 @@ function AccountsPage({
   authorizedRepositories: Record<number, string[]>
   loadingRepositoriesFor: number | null
   route: AccountSettingsRoute
+  syncingGitHubInstallations: boolean
   onLoadAuthorizedRepositories: (id: number) => void
   onSyncGitHubInstallations: () => void
   onSaveSandboxConfig: (apiURL: string, apiKey: string, installationID?: number, mode?: "custom" | "inherit", replaceInheritedSource?: boolean) => Promise<void>
@@ -445,10 +486,13 @@ function AccountsPage({
           <div className="flex flex-wrap items-center gap-2">
             {githubApp?.install_url ? (
               <>
-                <Button type="button" variant="outline" onClick={onSyncGitHubInstallations}>
-                  <Github className="h-4 w-4" />
-                  Sync existing installations
-                </Button>
+                <SyncGitHubInstallationsButton
+                  isSyncing={syncingGitHubInstallations}
+                  label="Sync existing installations"
+                  loadingLabel="Syncing installations..."
+                  onSync={onSyncGitHubInstallations}
+                  variant="outline"
+                />
                 <Button type="button" asChild>
                   <a href={githubApp.install_url}>
                     <Github className="h-4 w-4" />
@@ -654,10 +698,12 @@ function AccountsPage({
                     </p>
                   </div>
                   {githubApp ? (
-                    <Button type="button" onClick={onSyncGitHubInstallations}>
-                      <Github className="h-4 w-4" />
-                      Sync existing installations
-                    </Button>
+                    <SyncGitHubInstallationsButton
+                      isSyncing={syncingGitHubInstallations}
+                      label="Sync existing installations"
+                      loadingLabel="Syncing installations..."
+                      onSync={onSyncGitHubInstallations}
+                    />
                   ) : null}
                 </div>
               </div>
@@ -683,7 +729,6 @@ function SandboxAPIKeyCard({
   const [apiURL, setAPIURL] = useState("")
   const [apiKey, setAPIKey] = useState("")
   const [credentialMode, setCredentialMode] = useState<"custom" | "inherit">("custom")
-  const [regionSelection, setRegionSelection] = useState("")
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false)
@@ -696,16 +741,16 @@ function SandboxAPIKeyCard({
   const sourceAccountLogin = preferences?.sandbox?.source_account_login?.trim()
   const sourceAvailable = Boolean(preferences?.sandbox?.source_available)
   const updatedAt = preferences?.sandbox?.api_key?.updated_at
-  const selectedRegion = findSandboxRegionByAPIURL(apiURL)
-  const customAPIURL = regionSelection === customSandboxRegionID ? apiURL.trim() : ""
+  const savedAPIURL = preferences?.sandbox?.api_url ?? ""
+  const canUseSavedAPIURL = !(allowInheritance && preferences?.sandbox?.inherited && credentialMode === "custom")
+  const effectiveAPIURL = apiURL || (canUseSavedAPIURL ? savedAPIURL : "")
+  const selectedRegion = findSandboxRegionByAPIURL(effectiveAPIURL)
+  const showsCustomAPIURL = Boolean(effectiveAPIURL.trim()) && !selectedRegion
 
   useEffect(() => {
-    const savedAPIURL = preferences?.sandbox?.api_url ?? ""
     const resolvedAPIURL = resolveSandboxRegionAPIURL(savedAPIURL)
-    const savedRegion = findSandboxRegionByAPIURL(resolvedAPIURL)
     setAPIURL(resolvedAPIURL)
-    setRegionSelection(savedRegion?.id ?? (savedAPIURL.trim() ? customSandboxRegionID : ""))
-  }, [preferences?.sandbox?.api_url])
+  }, [savedAPIURL])
 
   useEffect(() => {
     setCredentialMode(allowInheritance && preferences?.sandbox?.mode === "inherit" ? "inherit" : "custom")
@@ -713,7 +758,7 @@ function SandboxAPIKeyCard({
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const nextAPIURL = apiURL.trim()
+    const nextAPIURL = effectiveAPIURL.trim()
     const nextAPIKey = apiKey.trim()
     if (credentialMode === "inherit") {
       setSaving(true)
@@ -777,153 +822,146 @@ function SandboxAPIKeyCard({
   }
 
   return (
-    <Card className="gap-0 rounded-lg py-0">
-      <form className="p-3" onSubmit={submit}>
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2 text-base font-semibold leading-none">
-              <KeyRound className="h-4 w-4 shrink-0" />
-              <span>Sandbox service</span>
+    <Card className="rounded-lg">
+      <form onSubmit={submit}>
+        <CardHeader className="gap-3 pb-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <KeyRound className="h-4 w-4 shrink-0" />
+                <span>Sandbox service</span>
+              </CardTitle>
+              <CardDescription className="mt-1">
+                Configure the account Sandbox service endpoint and encrypted API Key.
+              </CardDescription>
             </div>
-            <div className="mt-1 text-sm text-muted-foreground">
-              Configure the account Sandbox service endpoint and encrypted API Key.
-            </div>
+            <Badge variant={configured ? "success" : "outline"}>{configured ? "Configured" : "Not configured"}</Badge>
           </div>
-          <Badge variant={configured ? "secondary" : "outline"}>{configured ? "Configured" : "Not configured"}</Badge>
-        </div>
-
-        {allowInheritance ? (
-          <div className="mt-3 flex flex-wrap items-center gap-3 rounded-md border bg-muted/20 px-3 py-2">
-            <Switch
-              id="sandbox-use-account-default"
-              checked={credentialMode === "inherit"}
-              onCheckedChange={(checked) => {
-                setCredentialMode(checked ? "inherit" : "custom")
-                if (!checked && preferences?.sandbox?.inherited) {
-                  setAPIURL("")
-                  setAPIKey("")
-                  setRegionSelection("")
-                }
-                setError("")
-              }}
-              disabled={saving || deleting}
-            />
-            <Label htmlFor="sandbox-use-account-default" className="cursor-pointer text-sm font-medium">
-              Use account default credentials
-            </Label>
-            <span className="text-sm text-muted-foreground">
-              {credentialMode !== "inherit"
-                ? "This organization uses its own Sandbox service settings."
-                : !preferences?.sandbox?.inherited
-                  ? "Your account default credentials will be used after saving."
-                : !sourceAvailable
-                  ? sourceAccountLogin
-                    ? `Credentials provided by @${sourceAccountLogin} are unavailable because that account is no longer connected to this organization.`
-                    : "The inherited credentials are unavailable because the source account is no longer connected to this organization."
-                : sourceIsCurrentAccount
-                  ? "Using Sandbox credentials provided by your account."
-                  : sourceAccountLogin
-                    ? `Using Sandbox credentials provided by @${sourceAccountLogin}.`
-                    : "Using Sandbox credentials provided by another connected owner."}
-            </span>
-          </div>
-        ) : null}
-
-        <div className="mt-2.5 grid gap-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] lg:items-end">
-          <div className="grid min-w-0 gap-1.5">
-            <Label htmlFor="sandbox-api-region">Region</Label>
-            <Select
-              value={regionSelection}
-              onValueChange={(regionID) => {
-                if (regionID === customSandboxRegionID) {
-                  setRegionSelection(customSandboxRegionID)
-                  if (selectedRegion) {
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {allowInheritance ? (
+            <div className="flex flex-wrap items-center gap-3 rounded-md border bg-muted/20 px-3 py-3">
+              <Switch
+                id="sandbox-use-account-default"
+                checked={credentialMode === "inherit"}
+                onCheckedChange={(checked) => {
+                  setCredentialMode(checked ? "inherit" : "custom")
+                  if (!checked && preferences?.sandbox?.inherited) {
                     setAPIURL("")
+                    setAPIKey("")
                   }
-                  return
-                }
-                const region = sandboxRegions.find((region) => region.id === regionID)
-                setRegionSelection(region?.id ?? "")
-                setAPIURL(region?.apiURL ?? "")
-              }}
-              disabled={saving || deleting || credentialMode === "inherit"}
-            >
-              <SelectTrigger id="sandbox-api-region" className="w-full">
-                <SelectValue placeholder="Select Sandbox region" />
-              </SelectTrigger>
-              <SelectContent>
-                {sandboxRegions.map((region) => (
-                  <SelectItem key={region.id} value={region.id}>
-                    <span>{region.label}</span>
-                    <span className="text-muted-foreground">{region.id}</span>
-                  </SelectItem>
-                ))}
-                <SelectItem value={customSandboxRegionID}>
-                  <span>Custom endpoint</span>
-                  {customAPIURL ? <span className="text-muted-foreground">{customAPIURL}</span> : null}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-            {regionSelection === customSandboxRegionID && credentialMode === "custom" ? (
-              <Input
-                className="mt-1.5"
-                value={apiURL}
-                onChange={(event) => setAPIURL(event.target.value)}
-                placeholder="https://sandbox.example.test"
-                disabled={saving || deleting}
-                autoComplete="off"
-              />
-            ) : null}
-          </div>
-
-          <div className="grid min-w-0 gap-1.5">
-            <Label htmlFor="sandbox-api-key">API Key</Label>
-            <Input
-              id="sandbox-api-key"
-              type="password"
-              value={apiKey}
-              onChange={(event) => setAPIKey(event.target.value)}
-              autoComplete="off"
-              disabled={saving || deleting || credentialMode === "inherit"}
-              placeholder={customConfigured ? "••••••••••••••••" : "Enter Sandbox API Key"}
-            />
-          </div>
-
-          <div className="flex flex-wrap items-center gap-2">
-            {!inherited ? (
-              <Button type="submit" disabled={saving || deleting || (credentialMode === "custom" && (!apiURL.trim() || (!customConfigured && !apiKey.trim())))}>
-                <ShieldCheck className="h-4 w-4" />
-                {saving ? "Saving" : configured ? "Save changes" : "Save settings"}
-              </Button>
-            ) : null}
-            {inherited && !sourceIsCurrentAccount ? (
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => {
                   setError("")
-                  setReplaceSourceConfirmOpen(true)
                 }}
                 disabled={saving || deleting}
+              />
+              <Label htmlFor="sandbox-use-account-default" className="cursor-pointer text-sm font-medium">
+                Use account default credentials
+              </Label>
+              <span className="text-sm text-muted-foreground">
+                {credentialMode !== "inherit"
+                  ? "This organization uses its own Sandbox service settings."
+                  : !preferences?.sandbox?.inherited
+                    ? "Your account default credentials will be used after saving."
+                  : !sourceAvailable
+                    ? sourceAccountLogin
+                      ? `Credentials provided by @${sourceAccountLogin} are unavailable because that account is no longer connected to this organization.`
+                      : "The inherited credentials are unavailable because the source account is no longer connected to this organization."
+                  : sourceIsCurrentAccount
+                    ? "Using Sandbox credentials provided by your account."
+                    : sourceAccountLogin
+                      ? `Using Sandbox credentials provided by @${sourceAccountLogin}.`
+                      : "Using Sandbox credentials provided by another connected owner."}
+              </span>
+            </div>
+          ) : null}
+
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] xl:items-end">
+            <div className="grid min-w-0 gap-2">
+              <Label htmlFor="sandbox-api-region">Region</Label>
+              <Select
+                value={selectedRegion?.id ?? ""}
+                onValueChange={(regionID) => {
+                  const region = sandboxRegions.find((region) => region.id === regionID)
+                  setAPIURL(region?.apiURL ?? "")
+                }}
+                disabled={saving || deleting || credentialMode === "inherit"}
               >
-                <KeyRound className="h-4 w-4" />
-                Use my account credentials
-              </Button>
-            ) : null}
-            {customConfigured && credentialMode === "custom" ? (
-              <Button type="button" variant="outline" onClick={() => setRemoveConfirmOpen(true)} disabled={deleting || saving}>
-                <X className="h-4 w-4" />
-                {deleting ? "Removing" : "Remove"}
-              </Button>
-            ) : null}
+                <SelectTrigger id="sandbox-api-region" className="w-full">
+                  {selectedRegion ? (
+                    <span className="truncate">{selectedRegion.label}</span>
+                  ) : (
+                    <SelectValue placeholder="Select Sandbox region" />
+                  )}
+                </SelectTrigger>
+                <SelectContent>
+                  {sandboxRegions.map((region) => (
+                    <SelectItem key={region.id} value={region.id} textValue={region.label}>
+                      <span>{region.label}</span>
+                      <span className="text-muted-foreground">{region.id}</span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {showsCustomAPIURL && credentialMode === "custom" ? (
+                <Input
+                  value={apiURL}
+                  onChange={(event) => setAPIURL(event.target.value)}
+                  placeholder="https://sandbox.example.test"
+                  disabled={saving || deleting}
+                  autoComplete="off"
+                />
+              ) : null}
+            </div>
+
+            <div className="grid min-w-0 gap-2">
+              <Label htmlFor="sandbox-api-key">API Key</Label>
+              <Input
+                id="sandbox-api-key"
+                type="password"
+                value={apiKey}
+                onChange={(event) => setAPIKey(event.target.value)}
+                autoComplete="off"
+                disabled={saving || deleting || credentialMode === "inherit"}
+                placeholder={customConfigured ? "Enter a new API Key to replace the saved one" : "Enter Sandbox API Key"}
+              />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              {!inherited ? (
+                <Button type="submit" disabled={saving || deleting || (credentialMode === "custom" && (!effectiveAPIURL.trim() || (!customConfigured && !apiKey.trim())))}>
+                  <ShieldCheck className="h-4 w-4" />
+                  {saving ? "Saving" : configured ? "Save changes" : "Save settings"}
+                </Button>
+              ) : null}
+              {inherited && !sourceIsCurrentAccount ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setError("")
+                    setReplaceSourceConfirmOpen(true)
+                  }}
+                  disabled={saving || deleting}
+                >
+                  <KeyRound className="h-4 w-4" />
+                  Use my account credentials
+                </Button>
+              ) : null}
+              {customConfigured && credentialMode === "custom" ? (
+                <Button type="button" variant="outline" onClick={() => setRemoveConfirmOpen(true)} disabled={deleting || saving}>
+                  <X className="h-4 w-4" />
+                  {deleting ? "Removing" : "Remove"}
+                </Button>
+              ) : null}
+            </div>
           </div>
-        </div>
 
-        <div className="mt-1.5 text-sm text-muted-foreground">
-          {configured && updatedAt ? `Last updated ${formatTime(updatedAt)}` : "No Sandbox API Key is saved."}
-        </div>
+          <div className="text-sm text-muted-foreground">
+            {configured && updatedAt ? `Last updated ${formatTime(updatedAt)}` : "No Sandbox API Key is saved."}
+          </div>
 
-        {error ? <div className="mt-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div> : null}
+          {error ? <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div> : null}
+        </CardContent>
       </form>
       <Dialog open={removeConfirmOpen} onOpenChange={(open) => !deleting && setRemoveConfirmOpen(open)}>
         <DialogContent>
@@ -981,6 +1019,7 @@ function PullRequestsPage({
   selectedJobID,
   onSelectKey,
   canSyncGitHubInstallations,
+  syncingGitHubInstallations,
   onSyncGitHubInstallations,
   onOpenJob,
   request,
@@ -992,6 +1031,7 @@ function PullRequestsPage({
   selectedJobID: string
   onSelectKey: (key: string) => void
   canSyncGitHubInstallations: boolean
+  syncingGitHubInstallations: boolean
   onSyncGitHubInstallations: () => void
   onOpenJob: (id: string) => void
   request: (url: string, options?: RequestInit) => Promise<unknown>
@@ -1139,10 +1179,12 @@ function PullRequestsPage({
                       </p>
                     </div>
                     {canSyncGitHubInstallations ? (
-                      <Button type="button" onClick={onSyncGitHubInstallations}>
-                        <Github className="h-4 w-4" />
-                        Sync accounts
-                      </Button>
+                      <SyncGitHubInstallationsButton
+                        isSyncing={syncingGitHubInstallations}
+                        label="Sync accounts"
+                        loadingLabel="Syncing..."
+                        onSync={onSyncGitHubInstallations}
+                      />
                     ) : null}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

- sync existing GitHub App installations with loading feedback in the account UI
- align account settings, repository, template, and instance cards for a more consistent layout
- keep saved Sandbox regions visible while preserving inherited-to-custom credential behavior

## Validation

- npm run lint
- npm run build
- git diff --check
