### PR TITLE
fix(state): preserve SQLite runner request data

### DIFF
--- a/.agents/rules/project-architecture.md
+++ b/.agents/rules/project-architecture.md
@@ -38,7 +38,7 @@
 - Runtime state can use sqlite, Postgres, or MySQL.
 - Do not document multi-instance support until two runnerd processes have been verified against the same database.
 - State schema is defined mostly by GORM tags in `internal/state/records.go`.
-- Startup migration runs a narrow legacy compatibility pass in `internal/state/db.go`, then GORM `AutoMigrate`.
+- Startup migration runs a narrow legacy compatibility pass in `internal/state/db.go`, then GORM `AutoMigrate`. Existing SQLite `runner_requests` tables use additive missing-column/index migration instead of generic table recreation so ALTER-added historical fields remain intact.
 - GORM foreign-key creation is intentionally disabled. Legacy compatibility may remove old constraints or reset incompatible legacy scope tables; keep every such action narrow and covered by old-schema tests. Pre-scope account preference/secret rows are intentionally erased, requiring Sandbox reconfiguration and GitHub reauthentication before installation sync.
 - Keep old-schema upgrade tests when changing state records, GORM tags, indexes, required columns, or relationship constraints.
 - Do not reintroduce legacy `users` migration behavior unless the user explicitly asks for that compatibility path.

--- a/.agents/rules/testing-and-verification.md
+++ b/.agents/rules/testing-and-verification.md
@@ -30,7 +30,14 @@ go test ./...
 task test
 ```
 
-Old-schema upgrade coverage is required when adding required columns, changing uniqueness semantics, or altering relationship constraints. Fresh sqlite creation is not enough. Assert preserved data where migration promises preservation and explicit data reset where the compatibility contract requires reconfiguration.
+Old-schema upgrade coverage is required when adding required columns, changing uniqueness semantics, or altering relationship constraints. Fresh sqlite creation is not enough. Existing SQLite `runner_requests` migration is additive-only; non-additive changes require an explicit compatibility helper instead of generic table recreation. Assert preserved Installation ID, Sandbox snapshot fields, and `updated_at` values where migration promises preservation, and explicit data reset where the compatibility contract requires reconfiguration. For production snapshots, compare total rows plus populated `github_installation_id`, `sandbox_api_url`, `sandbox_api_key_encrypted`, and `sandbox_config_source` counts across two consecutive starts.
+
+Use the state-only snapshot gate when a production export is available:
+
+```bash
+RUNNERD_SQLITE_SNAPSHOT=/path/to/runnerd-export.db \
+  go test ./internal/state -run TestMigrateSQLiteRunnerRequestSnapshot -count=1 -v
+```
 
 ## Go Server Or API
 

--- a/.agents/skills/runnerd-state-schema/SKILL.md
+++ b/.agents/skills/runnerd-state-schema/SKILL.md
@@ -21,7 +21,7 @@ Keep runnerd's database schema model-driven through GORM while preserving known 
 
 ## Rules
 
-- Prefer GORM tags and `AutoMigrate` for normal schema source of truth.
+- Prefer GORM tags and `AutoMigrate` for normal schema source of truth. Existing SQLite `runner_requests` tables are additive-only: create missing model columns and indexes without generic table recreation.
 - Use handwritten SQL only for genuine GORM gaps.
 - Keep every legacy compatibility action narrow and explicit. This includes column additions, obsolete constraint removal, and destructive reset of legacy tables that cannot represent the current scope model. Document required operator reconfiguration and user reauthentication.
 - GORM foreign-key creation is disabled intentionally. Preserve the foreign-keyless schema convention unless a separately tested migration changes it.
@@ -44,14 +44,21 @@ sed -n '1,220p' internal/state/db.go
 rg -n "Migrate|Legacy|default_available|runner_group_name|AutoMigrate" internal/state
 ```
 
-3. For schema edits, update the model tags first. Change `migrateLegacySchemaColumns` only when old databases cannot safely migrate through `AutoMigrate` alone. Cover column additions, constraint removal, or legacy-table reset with an old-schema fixture that proves the required cleanup and asserts preservation or intentional data loss according to the compatibility contract.
+3. For schema edits, update the model tags first. Change `migrateLegacySchemaColumns` only when old databases cannot safely migrate through `AutoMigrate` alone. Keep existing SQLite `runner_requests` changes additive; any non-additive change requires a narrow explicit compatibility migration. Cover column additions, constraint removal, or legacy-table reset with an old-schema fixture that proves the required cleanup and asserts preservation or intentional data loss according to the compatibility contract.
 
-4. Add or update tests before relying on the fix. Include old sqlite upgrade coverage for required columns, unique indexes with existing rows, and relationship changes.
+4. Add or update tests before relying on the fix. Include old sqlite upgrade coverage for required columns, unique indexes with existing rows, and relationship changes. Assert preservation of `github_installation_id`, Sandbox snapshot fields, and `updated_at` for existing runner requests.
 
 5. Run:
 
 ```bash
 go test ./internal/state -count=1
+```
+
+When a production SQLite export is available, also run:
+
+```bash
+RUNNERD_SQLITE_SNAPSHOT=/path/to/runnerd-export.db \
+  go test ./internal/state -run TestMigrateSQLiteRunnerRequestSnapshot -count=1 -v
 ```
 
 6. If callers or server behavior changed, also run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Use this guide for future Codex or agent work in this repository.
 - Current admin browser routes include `/admin/`, `/admin/accounts`, and `/admin/sandbox_service`; keep admin routes and role-gated APIs explicit when changing shared `ui/` code.
 - `/admin/accounts` lists OAuth/bootstrap-created accounts and linked identities. Its only mutation changes another account's `admin`/`user` role atomically with an audit event; self-role changes and changes that could leave no administrator are rejected.
 - Runtime state can use sqlite, Postgres, or MySQL. Do not document multi-instance support until two runnerd processes have been verified against the same database.
-- State schema is defined mostly by GORM tags in `internal/state/records.go`; startup migration runs a narrow legacy compatibility pass and then `AutoMigrate` in `internal/state/db.go`. GORM foreign-key creation is disabled intentionally, so preserve the foreign-keyless schema convention unless a separately tested migration changes it. Legacy account preference/secret tables without scope columns are intentionally reset; operator docs must warn about Sandbox reconfiguration and GitHub reauthentication before installation sync.
+- State schema is defined mostly by GORM tags in `internal/state/records.go`; startup migration runs a narrow legacy compatibility pass and then `AutoMigrate` in `internal/state/db.go`. Existing SQLite `runner_requests` tables are the exception: migrate them additively by creating missing columns and indexes because generic table recreation can erase ALTER-added historical values. GORM foreign-key creation is disabled intentionally, so preserve the foreign-keyless schema convention unless a separately tested migration changes it. Legacy account preference/secret tables without scope columns are intentionally reset; operator docs must warn about Sandbox reconfiguration and GitHub reauthentication before installation sync.
 - Runner specs, runner groups, and repository policies are admin API/UI data, not `runnerd.yaml` fields.
 - The recommended production GitHub auth path is GitHub App auth for runner operations plus GitHub App OAuth sign-in for ordinary users and administrators. Local account roles authorize management APIs. Token and basic auth still exist as compatibility modes, but their long-term product status is undecided.
 
@@ -40,7 +40,7 @@ Use `task build` when verifying production embedded UI behavior because it rebui
 
 Use `cd ui && bun run test` for focused UI tests. `task test` rebuilds the UI, runs the Bun UI tests, and then runs Go tests with race detection and coverage.
 
-When changing state records, GORM tags, indexes, or migration helpers, run `go test ./internal/state -count=1` first. Old sqlite schema upgrade tests are intentional compatibility coverage; do not remove them just because fresh database creation passes.
+When changing state records, GORM tags, indexes, or migration helpers, run `go test ./internal/state -count=1` first. Old sqlite schema upgrade tests are intentional compatibility coverage; do not remove them just because fresh database creation passes. When a production export is available, run `RUNNERD_SQLITE_SNAPSHOT=/path/to/runnerd-export.db go test ./internal/state -run TestMigrateSQLiteRunnerRequestSnapshot -count=1 -v`.
 
 ## Local Agent Assets
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Authenticated users can inspect Sandbox resources in the same account or organiz
 `/webhooks/github` uses GitHub HMAC signature verification. The manual management API under `/runner_requests` requires a valid GitHub OAuth admin session cookie.
 
 Runner state is persisted in a DB-backed store instead of per-request JSON directories. Control/stdout/stderr logs are kept as runner events and remain available from the admin API and UI.
-Schema creation is GORM-model driven on startup. Existing state databases run through a narrow legacy compatibility pass before `AutoMigrate`, so keep old-schema upgrade tests green when changing state records. Upgrading a database whose legacy `account_preferences` or `account_secrets` tables predate `scope_type`/`scope_id` intentionally drops and recreates those tables. Reconfigure the affected Sandbox Preferences and API keys, and have affected users sign in with GitHub again before syncing installations.
+Schema creation is GORM-model driven on startup. Existing SQLite `runner_requests` tables use additive column/index migration instead of GORM table recreation so historical installation and Sandbox configuration fields remain intact; non-additive changes to that table require an explicit compatibility migration with preserved-data coverage. Other existing state tables run through a narrow legacy compatibility pass before `AutoMigrate`, so keep old-schema upgrade tests green when changing state records. Upgrading a database whose legacy `account_preferences` or `account_secrets` tables predate `scope_type`/`scope_id` intentionally drops and recreates those tables. Reconfigure the affected Sandbox Preferences and API keys, and have affected users sign in with GitHub again before syncing installations.
 
 ## Run
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -52,7 +52,7 @@ Sandbox service API URL 和 API key 通常在普通用户的 account 或 organiz
 `/webhooks/github` 使用 GitHub HMAC signature verification。`/runner_requests` 下的手动管理 API 需要有效的 GitHub OAuth admin session cookie。
 
 Runner state 持久化到 DB-backed store，不再使用按请求拆分的 JSON 目录。Control/stdout/stderr logs 会作为 runner events 保存，并继续通过 admin API 和 UI 查看。
-Schema 创建由 GORM model 驱动，启动时会先对旧状态数据库执行窄范围 legacy compatibility pass，再运行 `AutoMigrate`。修改 state records 时需要保持旧 schema upgrade tests 通过。如果旧数据库的 `account_preferences` 或 `account_secrets` 表早于 `scope_type`/`scope_id`，升级会有意删除并重建这些表。升级后需要重新配置受影响的 Sandbox Preferences 和 API keys，相关用户还需重新使用 GitHub 登录，才能继续同步 installations。
+Schema 创建由 GORM model 驱动。已有 SQLite `runner_requests` 表只执行 additive column/index migration，不再由 GORM 重建整张表，以保留历史 installation 和 Sandbox configuration 字段；这张表未来如需 non-additive 变更，必须增加显式 compatibility migration 和数据保全测试。其他旧状态表会先执行窄范围 legacy compatibility pass，再运行 `AutoMigrate`。修改 state records 时需要保持旧 schema upgrade tests 通过。如果旧数据库的 `account_preferences` 或 `account_secrets` 表早于 `scope_type`/`scope_id`，升级会有意删除并重建这些表。升级后需要重新配置受影响的 Sandbox Preferences 和 API keys，相关用户还需重新使用 GitHub 登录，才能继续同步 installations。
 
 ## 运行
 

--- a/TODO.md
+++ b/TODO.md
@@ -9,12 +9,12 @@ This file tracks active project work. Completed behavior should move into `READM
 - Add an effective-config diagnostics view or config validation workflow if operators need to inspect runtime config from the UI.
 - Verify DB lease behavior with two runnerd processes sharing the same database before documenting multi-instance support.
 - Decide whether expvar diagnostics need a Prometheus/export adapter or histogram-style latency views for deployment observability.
-- Keep old-schema upgrade coverage whenever state records or GORM tags change; the current migration path is a narrow legacy compatibility pass followed by `AutoMigrate`, not a full handwritten migration history.
+- Keep old-schema upgrade coverage whenever state records or GORM tags change; the current migration path is a narrow legacy compatibility pass followed by `AutoMigrate`, with additive-only handling for existing SQLite `runner_requests`, not a full handwritten migration history.
 
 ## Maintenance
 
 - Keep `README.md` and `README.zh.md`, the paired English/Chinese files under `docs/`, and this roadmap in sync when build, dev, config, or UI asset workflows change.
 - Keep `docs/deployment-smoke.md` and `docs/zh/deployment-smoke.md` aligned with real GitHub App, webhook, Qiniu sandbox template, runner pickup, cleanup, and diagnostics behavior.
 - Keep generated production UI assets under `internal/server/ui/` out of hand edits; change source files in `ui/` and rebuild with `task build`.
-- When changing `internal/state/records.go` tags or migration helpers in `internal/state/db.go`, run `go test ./internal/state -count=1` before the broader test suite.
+- When changing `internal/state/records.go` tags or migration helpers in `internal/state/db.go`, run `go test ./internal/state -count=1` before the broader test suite, plus `TestMigrateSQLiteRunnerRequestSnapshot` when a production SQLite export is available.
 - Keep `.agents/` focused on agent-only rules and repeatable workflows; keep operator, architecture, and deployment content in `README.md` and `docs/`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -63,13 +63,29 @@ Runner spec, runner group, and repository policy are not `runnerd.yaml` fields. 
 
 `database.backend` supports `sqlite`, `postgres`, and `mysql`. Prefer sqlite for local development. Before documenting shared-database multi-instance deployment as supported, verify lease behavior with two runnerd processes sharing the same database.
 
-The state schema is mainly defined by GORM tags in `internal/state/records.go`. On startup, the service runs a narrow legacy compatibility pass for older columns, obsolete OAuth constraints, and incompatible legacy scope tables, then runs GORM `AutoMigrate`. Legacy `account_preferences` and `account_secrets` tables without `scope_type`/`scope_id` are dropped and recreated rather than data-migrated. Reconfigure their saved Sandbox Preferences and API keys after that upgrade; stored GitHub OAuth tokens are also cleared, so affected users must sign in with GitHub again before syncing installations. When changing state records, indexes, or migration helpers, run at least:
+The state schema is mainly defined by GORM tags in `internal/state/records.go`. On startup, an existing SQLite `runner_requests` table is migrated additively by creating missing model columns and indexes; it is deliberately excluded from generic SQLite `AutoMigrate` table recreation because historical ALTER-added columns must remain intact. A future non-additive `runner_requests` change requires a narrow explicit migration and a preserved-data regression fixture. Other tables run through a narrow legacy compatibility pass for older columns, obsolete OAuth constraints, and incompatible legacy scope tables, then run GORM `AutoMigrate`. Legacy `account_preferences` and `account_secrets` tables without `scope_type`/`scope_id` are dropped and recreated rather than data-migrated. Reconfigure their saved Sandbox Preferences and API keys after that upgrade; stored GitHub OAuth tokens are also cleared, so affected users must sign in with GitHub again before syncing installations. When changing state records, indexes, or migration helpers, run at least:
 
 ```bash
 go test ./internal/state -count=1
 ```
 
 Do not validate migrations only with a fresh sqlite file. Old-schema upgrade paths also need coverage, especially when adding `NOT NULL` columns, unique indexes, or relationship constraints.
+
+For a production SQLite snapshot, record data-integrity counts before and after starting the candidate binary against a disposable copy:
+
+```bash
+sqlite3 runnerd-export.db \
+  "SELECT COUNT(*), SUM(CASE WHEN github_installation_id > 0 THEN 1 ELSE 0 END), SUM(CASE WHEN sandbox_api_url <> '' THEN 1 ELSE 0 END), SUM(CASE WHEN sandbox_api_key_encrypted <> '' THEN 1 ELSE 0 END), SUM(CASE WHEN sandbox_config_source <> '' THEN 1 ELSE 0 END) FROM runner_requests;"
+```
+
+Run the migration twice. The total and all populated-field counts must remain unchanged on both starts, except that missing `github_installation_id` values may increase when `github_payload_json.installation.id` can repair them.
+
+The repository includes an opt-in state-only snapshot test that copies the source database before migration and does not start runner recovery:
+
+```bash
+RUNNERD_SQLITE_SNAPSHOT=/path/to/runnerd-export.db \
+  go test ./internal/state -run TestMigrateSQLiteRunnerRequestSnapshot -count=1 -v
+```
 
 ## 2. Configure GitHub Auth
 

--- a/docs/zh/testing.md
+++ b/docs/zh/testing.md
@@ -61,13 +61,29 @@ Runner spec、runner group 和 repository policy 不在 `runnerd.yaml` 中配置
 
 `database.backend` 支持 `sqlite`、`postgres` 和 `mysql`。本地开发优先使用 sqlite；共享数据库的多实例部署需要先用两个 runnerd 进程验证 lease 行为，再作为正式运行方式记录。
 
-状态表结构主要由 `internal/state/records.go` 里的 GORM tag 定义，服务启动时会先针对旧 columns、obsolete OAuth constraints 和不兼容的 legacy scope tables 执行窄范围 compatibility pass，再运行 GORM `AutoMigrate`。缺少 `scope_type`/`scope_id` 的旧 `account_preferences` 和 `account_secrets` 表会被删除并重建，而不是迁移原数据。升级后必须重新配置其中保存的 Sandbox Preferences 和 API keys；已保存的 GitHub OAuth tokens 也会被清除，相关用户需重新使用 GitHub 登录后才能同步 installations。修改 state record、索引或迁移 helper 时，至少先跑：
+状态表结构主要由 `internal/state/records.go` 里的 GORM tag 定义。服务启动时，已有 SQLite `runner_requests` 表只通过创建缺失的 model columns 和 indexes 做 additive migration；它会跳过通用 SQLite `AutoMigrate` 表重建，避免历史上通过 ALTER 添加的字段丢失。未来如需对 `runner_requests` 做 non-additive 变更，必须增加窄范围显式 migration 和数据保全回归 fixture。其他表会先针对旧 columns、obsolete OAuth constraints 和不兼容的 legacy scope tables 执行窄范围 compatibility pass，再运行 GORM `AutoMigrate`。缺少 `scope_type`/`scope_id` 的旧 `account_preferences` 和 `account_secrets` 表会被删除并重建，而不是迁移原数据。升级后必须重新配置其中保存的 Sandbox Preferences 和 API keys；已保存的 GitHub OAuth tokens 也会被清除，相关用户需重新使用 GitHub 登录后才能同步 installations。修改 state record、索引或迁移 helper 时，至少先跑：
 
 ```bash
 go test ./internal/state -count=1
 ```
 
 不要只用全新 sqlite 文件验证迁移；旧 schema 升级路径也需要覆盖，尤其是新增 `NOT NULL` 列、唯一索引或关系约束时。
+
+验证生产 SQLite snapshot 时，应在 disposable copy 启动前后记录数据完整性计数：
+
+```bash
+sqlite3 runnerd-export.db \
+  "SELECT COUNT(*), SUM(CASE WHEN github_installation_id > 0 THEN 1 ELSE 0 END), SUM(CASE WHEN sandbox_api_url <> '' THEN 1 ELSE 0 END), SUM(CASE WHEN sandbox_api_key_encrypted <> '' THEN 1 ELSE 0 END), SUM(CASE WHEN sandbox_config_source <> '' THEN 1 ELSE 0 END) FROM runner_requests;"
+```
+
+迁移需要连续运行两次。两次启动后的总行数和各字段非空计数都必须保持稳定；唯一允许增加的是可从 `github_payload_json.installation.id` 恢复的 `github_installation_id`。
+
+仓库提供了一个 opt-in 的 state-only snapshot test。它会先复制源数据库，不会启动 runner recovery：
+
+```bash
+RUNNERD_SQLITE_SNAPSHOT=/path/to/runnerd-export.db \
+  go test ./internal/state -run TestMigrateSQLiteRunnerRequestSnapshot -count=1 -v
+```
 
 ## 2. 配置 GitHub 鉴权
 

--- a/internal/state/conversions.go
+++ b/internal/state/conversions.go
@@ -154,6 +154,18 @@ type githubPayloadPullRequest struct {
 	Number int64 `json:"number"`
 }
 
+func githubInstallationIDFromPayload(payloadJSON string) int64 {
+	var payload struct {
+		Installation struct {
+			ID int64 `json:"id"`
+		} `json:"installation"`
+	}
+	if payloadJSON == "" || json.Unmarshal([]byte(payloadJSON), &payload) != nil {
+		return 0
+	}
+	return payload.Installation.ID
+}
+
 func githubLinksFromPayload(record runnerRequestRecord) githubPayloadLinks {
 	var payload struct {
 		WorkflowJob struct {

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -198,10 +198,10 @@ func migrateSQLiteRunnerRequestSchema(db *gorm.DB) error {
 	}
 	return db.Transaction(func(tx *gorm.DB) error {
 		for _, field := range stmt.Schema.Fields {
-			if field.IgnoreMigration || field.DBName == "" || tx.Migrator().HasColumn(&runnerRequestRecord{}, field.DBName) {
+			if field.IgnoreMigration || field.DBName == "" || tx.Migrator().HasColumn(&runnerRequestRecord{}, field.Name) {
 				continue
 			}
-			if err := tx.Migrator().AddColumn(&runnerRequestRecord{}, field.DBName); err != nil {
+			if err := tx.Migrator().AddColumn(&runnerRequestRecord{}, field.Name); err != nil {
 				return fmt.Errorf("add runner_requests.%s: %w", field.DBName, err)
 			}
 		}
@@ -267,6 +267,9 @@ func backfillRunnerRequestGitHubContext(db *gorm.DB) error {
 			return tx.Transaction(func(batchTx *gorm.DB) error {
 				for _, record := range records {
 					updates := runnerRequestGitHubContextBackfill(record)
+					if len(updates) == 0 {
+						continue
+					}
 					if err := batchTx.Model(&runnerRequestRecord{}).Where("id = ?", record.ID).UpdateColumns(updates).Error; err != nil {
 						return err
 					}
@@ -278,8 +281,9 @@ func backfillRunnerRequestGitHubContext(db *gorm.DB) error {
 
 func runnerRequestGitHubContextBackfill(record runnerRequestRecord) map[string]any {
 	links := githubLinksFromPayload(record)
-	updates := map[string]any{
-		"github_context_backfilled": true,
+	updates := make(map[string]any)
+	if !record.GitHubContextBackfilled {
+		updates["github_context_backfilled"] = true
 	}
 	if record.GitHubInstallationID == 0 {
 		if installationID := githubInstallationIDFromPayload(record.GitHubPayloadJSON); installationID > 0 {

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -153,8 +153,10 @@ func (s *DBStore) migrate(db *gorm.DB) error {
 	if err := migrateLegacySchemaColumns(db); err != nil {
 		return err
 	}
-	if err := db.AutoMigrate(
-		&runnerRequestRecord{},
+	existingSQLiteRunnerRequests :=
+		s.opts.Backend == BackendSQLite &&
+			db.Migrator().HasTable(&runnerRequestRecord{})
+	models := []any{
 		&runnerEventRecord{},
 		&runnerProfileRecord{},
 		&runnerGroupRecord{},
@@ -169,13 +171,50 @@ func (s *DBStore) migrate(db *gorm.DB) error {
 		&accountPreferenceRecord{},
 		&sandboxServiceDefaultRecord{},
 		&sandboxServiceDefaultAudienceRecord{},
-	); err != nil {
+	}
+	if existingSQLiteRunnerRequests {
+		if err := migrateSQLiteRunnerRequestSchema(db); err != nil {
+			return err
+		}
+	} else {
+		models = append([]any{&runnerRequestRecord{}}, models...)
+	}
+	if err := db.AutoMigrate(models...); err != nil {
 		return err
 	}
 	if err := backfillRunnerRequestGitHubContext(db); err != nil {
 		return err
 	}
 	return nil
+}
+
+func migrateSQLiteRunnerRequestSchema(db *gorm.DB) error {
+	// SQLite records columns added through ALTER TABLE outside the original
+	// CREATE TABLE body. Recreating that table through the current GORM SQLite
+	// migrator can omit those columns from the copy and then add them back empty.
+	stmt := &gorm.Statement{DB: db}
+	if err := stmt.Parse(&runnerRequestRecord{}); err != nil {
+		return err
+	}
+	return db.Transaction(func(tx *gorm.DB) error {
+		for _, field := range stmt.Schema.Fields {
+			if field.IgnoreMigration || field.DBName == "" || tx.Migrator().HasColumn(&runnerRequestRecord{}, field.DBName) {
+				continue
+			}
+			if err := tx.Migrator().AddColumn(&runnerRequestRecord{}, field.DBName); err != nil {
+				return fmt.Errorf("add runner_requests.%s: %w", field.DBName, err)
+			}
+		}
+		for _, index := range stmt.Schema.ParseIndexes() {
+			if tx.Migrator().HasIndex(&runnerRequestRecord{}, index.Name) {
+				continue
+			}
+			if err := tx.Migrator().CreateIndex(&runnerRequestRecord{}, index.Name); err != nil {
+				return fmt.Errorf("create runner_requests index %s: %w", index.Name, err)
+			}
+		}
+		return nil
+	})
 }
 
 func migrateLegacySchemaColumns(db *gorm.DB) error {
@@ -218,12 +257,17 @@ func backfillRunnerRequestGitHubContext(db *gorm.DB) error {
 	var records []runnerRequestRecord
 	return db.
 		Where("github_payload_json <> ''").
-		Where("github_context_backfilled IS NULL OR github_context_backfilled = ?", false).
+		Where(
+			"(github_context_backfilled IS NULL OR github_context_backfilled = ?) OR "+
+				"((github_installation_id IS NULL OR github_installation_id = 0) AND github_payload_json LIKE ?)",
+			false,
+			`%"installation"%`,
+		).
 		FindInBatches(&records, runnerRequestGitHubContextBackfillBatchSize, func(tx *gorm.DB, _ int) error {
 			return tx.Transaction(func(batchTx *gorm.DB) error {
 				for _, record := range records {
 					updates := runnerRequestGitHubContextBackfill(record)
-					if err := batchTx.Model(&runnerRequestRecord{}).Where("id = ?", record.ID).Updates(updates).Error; err != nil {
+					if err := batchTx.Model(&runnerRequestRecord{}).Where("id = ?", record.ID).UpdateColumns(updates).Error; err != nil {
 						return err
 					}
 				}
@@ -236,6 +280,11 @@ func runnerRequestGitHubContextBackfill(record runnerRequestRecord) map[string]a
 	links := githubLinksFromPayload(record)
 	updates := map[string]any{
 		"github_context_backfilled": true,
+	}
+	if record.GitHubInstallationID == 0 {
+		if installationID := githubInstallationIDFromPayload(record.GitHubPayloadJSON); installationID > 0 {
+			updates["github_installation_id"] = installationID
+		}
 	}
 	if record.WorkflowRunID == 0 && links.workflowRunID != 0 {
 		updates["workflow_run_id"] = links.workflowRunID

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -2726,6 +2726,63 @@ func TestMigrateRepairsMissingRunnerRequestInstallationID(t *testing.T) {
 	}
 }
 
+func TestMigrateDoesNotRewriteUnrecoverableRunnerRequestInstallationID(t *testing.T) {
+	dir := t.TempDir()
+	databaseURL := dir + "/runnerd.db"
+	store := NewWithOptions(Options{
+		Backend:        BackendSQLite,
+		DatabaseDSN:    databaseURL,
+		MigrateOnStart: true,
+	}).(*DBStore)
+	db, err := store.dbOrEnsure()
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflowJobID := int64(87401142868)
+	now := time.Now().UTC()
+	record := runnerRequestRecord{
+		ID:                      "87401142868",
+		Source:                  "github_webhook",
+		WorkflowJobID:           &workflowJobID,
+		GitHubContextBackfilled: true,
+		RepositoryFullName:      "qbox/las",
+		RequestedLabelsJSON:     `["github-runner-ubuntu-24-04"]`,
+		LabelsJSON:              `["self-hosted","e2b","github-runner-ubuntu-24-04"]`,
+		ProfileName:             "github-runner-ubuntu-24-04",
+		RunnerGroup:             "Default",
+		RunnerName:              "e2b-87401142868",
+		Status:                  StatusCompleted,
+		GitHubPayloadJSON:       `{"installation":null}`,
+		QueuedAt:                now.Add(-time.Minute),
+		UpdatedAt:               now,
+	}
+	if err := db.Create(&record).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`CREATE TRIGGER reject_unrecoverable_installation_rewrite
+		BEFORE UPDATE ON runner_requests
+		WHEN OLD.id = '87401142868'
+		BEGIN
+			SELECT RAISE(ABORT, 'unrecoverable installation row was rewritten');
+		END`).Error; err != nil {
+		t.Fatal(err)
+	}
+	closeTestDB(t, db)
+
+	for start := 1; start <= 2; start++ {
+		migrated := NewWithOptions(Options{
+			Backend:        BackendSQLite,
+			DatabaseDSN:    databaseURL,
+			MigrateOnStart: true,
+		}).(*DBStore)
+		db, err = migrated.dbOrEnsure()
+		if err != nil {
+			t.Fatalf("migration start %d rewrote unrecoverable installation row: %v", start, err)
+		}
+		closeTestDB(t, db)
+	}
+}
+
 func TestMigrateSQLiteRunnerRequestSnapshot(t *testing.T) {
 	sourcePath := strings.TrimSpace(os.Getenv("RUNNERD_SQLITE_SNAPSHOT"))
 	if sourcePath == "" {

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -3,6 +3,9 @@ package state
 import (
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -2542,4 +2545,283 @@ func TestMigrateBackfillsLegacyRunnerRequestGitHubContext(t *testing.T) {
 	if pendingBackfills != 0 {
 		t.Fatalf("expected no pending github context backfills, got %d", pendingBackfills)
 	}
+}
+
+func TestMigratePreservesAdditiveRunnerRequestColumns(t *testing.T) {
+	dir := t.TempDir()
+	databaseURL := dir + "/runnerd.db"
+	store := NewWithOptions(Options{
+		Backend:        BackendSQLite,
+		DatabaseDSN:    databaseURL,
+		MigrateOnStart: false,
+	}).(*DBStore)
+	db, err := store.open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`CREATE TABLE runner_requests (
+		id TEXT PRIMARY KEY,
+		source TEXT NOT NULL,
+		workflow_job_id INTEGER,
+		repository_full_name TEXT,
+		requested_labels_json TEXT,
+		labels_json TEXT NOT NULL,
+		profile_name TEXT,
+		runner_group TEXT,
+		runner_name TEXT NOT NULL,
+		status TEXT NOT NULL,
+		failure_stage TEXT,
+		failure_reason TEXT,
+		last_error_code TEXT,
+		last_error_message TEXT,
+		last_error_retryable BOOLEAN NOT NULL DEFAULT FALSE,
+		retry_count INTEGER NOT NULL DEFAULT 0,
+		sandbox_id TEXT,
+		process_pid INTEGER,
+		assigned_job_id INTEGER,
+		assigned_job_name TEXT,
+		error TEXT,
+		github_payload_json TEXT,
+		queued_at DATETIME NOT NULL,
+		last_attempt_at DATETIME,
+		next_retry_at DATETIME,
+		creating_at DATETIME,
+		running_at DATETIME,
+		stopping_at DATETIME,
+		completed_at DATETIME,
+		failed_at DATETIME,
+		lease_owner TEXT,
+		lease_expires_at DATETIME,
+		updated_at DATETIME NOT NULL,
+		version INTEGER NOT NULL DEFAULT 0
+	);`).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		"ALTER TABLE runner_requests ADD COLUMN github_installation_id INTEGER",
+		"ALTER TABLE runner_requests ADD COLUMN workflow_run_id INTEGER",
+		"ALTER TABLE runner_requests ADD COLUMN workflow_name TEXT",
+		"ALTER TABLE runner_requests ADD COLUMN workflow_run_attempt INTEGER",
+		"ALTER TABLE runner_requests ADD COLUMN head_branch TEXT",
+		"ALTER TABLE runner_requests ADD COLUMN head_sha TEXT",
+		"ALTER TABLE runner_requests ADD COLUMN github_job_url TEXT",
+		"ALTER TABLE runner_requests ADD COLUMN pull_request_number INTEGER",
+		"ALTER TABLE runner_requests ADD COLUMN github_context_backfilled NUMERIC NOT NULL DEFAULT FALSE",
+		"ALTER TABLE runner_requests ADD COLUMN sandbox_api_url TEXT",
+		"ALTER TABLE runner_requests ADD COLUMN sandbox_api_key_encrypted TEXT",
+		"ALTER TABLE runner_requests ADD COLUMN sandbox_config_source TEXT",
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	originalUpdatedAt := time.Date(2026, time.July, 15, 15, 49, 3, 0, time.UTC)
+	payload := `{"installation":{"id":135340026},"workflow_job":{"run_id":29401048027,"workflow_name":"CI Check And Test","run_attempt":2,"head_branch":"feature/migration-integrity","head_sha":"abc123"}}`
+	if err := db.Exec(
+		`INSERT INTO runner_requests (
+		id, source, workflow_job_id, repository_full_name, requested_labels_json,
+		labels_json, profile_name, runner_group, runner_name, status,
+		github_payload_json, queued_at, updated_at, version,
+		github_installation_id, workflow_run_id, workflow_name, workflow_run_attempt,
+		head_branch, head_sha, github_job_url, github_context_backfilled,
+		sandbox_api_url, sandbox_api_key_encrypted, sandbox_config_source
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"87401142867", "github_webhook", 87401142867, "qbox/las", `["github-runner-ubuntu-24-04"]`,
+		`["self-hosted","e2b","github-runner-ubuntu-24-04"]`, "github-runner-ubuntu-24-04", "Default",
+		"e2b-87401142867", StatusCompleted, payload, originalUpdatedAt.Add(-time.Minute), originalUpdatedAt, 7,
+		135340026, 29401048027, "CI Check And Test", 2, "feature/migration-integrity", "abc123",
+		"https://github.com/qbox/las/actions/runs/29401048027/job/87401142867", true,
+		"https://sandbox.example.test", "encrypted-api-key", "admin_default",
+	).Error; err != nil {
+		t.Fatal(err)
+	}
+	closeTestDB(t, db)
+
+	migrated := NewWithOptions(Options{
+		Backend:        BackendSQLite,
+		DatabaseDSN:    databaseURL,
+		MigrateOnStart: true,
+	}).(*DBStore)
+	db, err = migrated.dbOrEnsure()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record runnerRequestRecord
+	if err := db.First(&record, "id = ?", "87401142867").Error; err != nil {
+		t.Fatal(err)
+	}
+	if record.GitHubInstallationID != 135340026 {
+		t.Fatalf("github installation id changed during migration: %d", record.GitHubInstallationID)
+	}
+	if record.SandboxAPIURL != "https://sandbox.example.test" ||
+		record.SandboxAPIKeyEncrypted != "encrypted-api-key" ||
+		record.SandboxConfigSource != "admin_default" {
+		t.Fatalf("sandbox configuration changed during migration: %#v", record)
+	}
+	if !record.UpdatedAt.Equal(originalUpdatedAt) {
+		t.Fatalf("updated_at changed during migration: got %s want %s", record.UpdatedAt, originalUpdatedAt)
+	}
+}
+
+func TestMigrateRepairsMissingRunnerRequestInstallationID(t *testing.T) {
+	dir := t.TempDir()
+	databaseURL := dir + "/runnerd.db"
+	store := NewWithOptions(Options{
+		Backend:        BackendSQLite,
+		DatabaseDSN:    databaseURL,
+		MigrateOnStart: true,
+	}).(*DBStore)
+	db, err := store.dbOrEnsure()
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflowJobID := int64(87401142867)
+	originalUpdatedAt := time.Date(2026, time.July, 15, 15, 49, 3, 0, time.UTC)
+	record := runnerRequestRecord{
+		ID:                      "87401142867",
+		Source:                  "github_webhook",
+		WorkflowJobID:           &workflowJobID,
+		GitHubInstallationID:    0,
+		WorkflowRunID:           29401048027,
+		WorkflowName:            "CI Check And Test",
+		WorkflowRunAttempt:      2,
+		HeadBranch:              "feature/migration-integrity",
+		HeadSHA:                 "abc123",
+		GitHubContextBackfilled: true,
+		RepositoryFullName:      "qbox/las",
+		RequestedLabelsJSON:     `["github-runner-ubuntu-24-04"]`,
+		LabelsJSON:              `["self-hosted","e2b","github-runner-ubuntu-24-04"]`,
+		ProfileName:             "github-runner-ubuntu-24-04",
+		RunnerGroup:             "Default",
+		RunnerName:              "e2b-87401142867",
+		Status:                  StatusCompleted,
+		GitHubPayloadJSON:       `{"installation":{"id":135340026},"workflow_job":{"run_id":29401048027}}`,
+		QueuedAt:                originalUpdatedAt.Add(-time.Minute),
+		UpdatedAt:               originalUpdatedAt,
+		Version:                 7,
+	}
+	if err := db.Create(&record).Error; err != nil {
+		t.Fatal(err)
+	}
+	closeTestDB(t, db)
+
+	migrated := NewWithOptions(Options{
+		Backend:        BackendSQLite,
+		DatabaseDSN:    databaseURL,
+		MigrateOnStart: true,
+	}).(*DBStore)
+	db, err = migrated.dbOrEnsure()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var repaired runnerRequestRecord
+	if err := db.First(&repaired, "id = ?", record.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if repaired.GitHubInstallationID != 135340026 {
+		t.Fatalf("github installation id was not repaired: %d", repaired.GitHubInstallationID)
+	}
+	if !repaired.UpdatedAt.Equal(originalUpdatedAt) {
+		t.Fatalf("updated_at changed during repair: got %s want %s", repaired.UpdatedAt, originalUpdatedAt)
+	}
+}
+
+func TestMigrateSQLiteRunnerRequestSnapshot(t *testing.T) {
+	sourcePath := strings.TrimSpace(os.Getenv("RUNNERD_SQLITE_SNAPSHOT"))
+	if sourcePath == "" {
+		t.Skip("set RUNNERD_SQLITE_SNAPSHOT to verify a disposable copy of a production SQLite database")
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	databaseURL := filepath.Join(t.TempDir(), "runnerd.db")
+	destination, err := os.Create(databaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(destination, source); err != nil {
+		destination.Close()
+		t.Fatal(err)
+	}
+	if err := destination.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	type counts struct {
+		Total                            int64 `gorm:"column:total"`
+		GitHubInstallationIDs            int64 `gorm:"column:github_installation_ids"`
+		RecoverableGitHubInstallationIDs int64 `gorm:"column:recoverable_github_installation_ids"`
+		SandboxAPIURLs                   int64 `gorm:"column:sandbox_api_urls"`
+		SandboxAPIKeys                   int64 `gorm:"column:sandbox_api_keys"`
+		SandboxConfigSources             int64 `gorm:"column:sandbox_config_sources"`
+	}
+	readCounts := func(db *gorm.DB) counts {
+		t.Helper()
+		var result counts
+		if err := db.Raw(`SELECT
+			COUNT(*) AS total,
+			SUM(CASE WHEN github_installation_id > 0 THEN 1 ELSE 0 END) AS github_installation_ids,
+			SUM(CASE
+				WHEN github_installation_id > 0 THEN 0
+				WHEN json_valid(github_payload_json) THEN
+					CASE WHEN CAST(json_extract(github_payload_json, '$.installation.id') AS INTEGER) > 0 THEN 1 ELSE 0 END
+				ELSE 0
+			END) AS recoverable_github_installation_ids,
+			SUM(CASE WHEN sandbox_api_url <> '' THEN 1 ELSE 0 END) AS sandbox_api_urls,
+			SUM(CASE WHEN sandbox_api_key_encrypted <> '' THEN 1 ELSE 0 END) AS sandbox_api_keys,
+			SUM(CASE WHEN sandbox_config_source <> '' THEN 1 ELSE 0 END) AS sandbox_config_sources
+			FROM runner_requests`).Scan(&result).Error; err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+	openStore := func(migrate bool) *gorm.DB {
+		t.Helper()
+		store := NewWithOptions(Options{
+			Backend:        BackendSQLite,
+			DatabaseDSN:    databaseURL,
+			MigrateOnStart: migrate,
+		}).(*DBStore)
+		db, err := store.dbOrEnsure()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return db
+	}
+
+	db := openStore(false)
+	before := readCounts(db)
+	closeTestDB(t, db)
+
+	db = openStore(true)
+	afterFirstStart := readCounts(db)
+	closeTestDB(t, db)
+	if afterFirstStart.Total != before.Total {
+		t.Fatalf("runner request count changed after migration: before=%d after=%d", before.Total, afterFirstStart.Total)
+	}
+	expectedGitHubInstallationIDs := before.GitHubInstallationIDs + before.RecoverableGitHubInstallationIDs
+	if afterFirstStart.GitHubInstallationIDs != expectedGitHubInstallationIDs ||
+		afterFirstStart.RecoverableGitHubInstallationIDs != 0 {
+		t.Fatalf(
+			"github installation ids were not fully repaired: before=%#v after=%#v expected_ids=%d",
+			before,
+			afterFirstStart,
+			expectedGitHubInstallationIDs,
+		)
+	}
+	if afterFirstStart.SandboxAPIURLs != before.SandboxAPIURLs ||
+		afterFirstStart.SandboxAPIKeys != before.SandboxAPIKeys ||
+		afterFirstStart.SandboxConfigSources != before.SandboxConfigSources {
+		t.Fatalf("sandbox snapshot counts changed after migration: before=%#v after=%#v", before, afterFirstStart)
+	}
+
+	db = openStore(true)
+	afterSecondStart := readCounts(db)
+	closeTestDB(t, db)
+	if afterSecondStart != afterFirstStart {
+		t.Fatalf("second migration changed runner request data: first=%#v second=%#v", afterFirstStart, afterSecondStart)
+	}
+	t.Logf("runner request migration counts: before=%#v after=%#v", before, afterSecondStart)
 }


### PR DESCRIPTION
## Summary

- migrate existing SQLite `runner_requests` tables additively instead of allowing generic GORM table recreation
- repair missing `github_installation_id` values from stored GitHub webhook payloads without changing `updated_at`
- add old-schema and production-snapshot regression coverage, plus document the migration contract

## Root cause

The SQLite GORM migrator recreated `runner_requests` when the model changed. Columns previously added with `ALTER TABLE`, including GitHub installation and Sandbox snapshot fields, were omitted during the table copy and then recreated empty. This made locally imported production data appear missing after startup.

## Impact

Existing SQLite databases retain historical runner request fields during startup migration. Records whose installation ID was already lost can be repaired when `github_payload_json.installation.id` is available. PostgreSQL and MySQL continue using the normal GORM migration path.

## Validation

- `task test`
- `GOFLAGS=-buildvcs=false task lint`
- `RUNNERD_SQLITE_SNAPSHOT=/path/to/runnerd-export.db go test ./internal/state -run TestMigrateSQLiteRunnerRequestSnapshot -count=1 -v`
- production snapshot: 20,966 rows preserved; installation IDs repaired from 1,708 to 20,966; 321 Sandbox URL/key/source records preserved across two migrations
- mutation check: disabling installation-ID repair makes the snapshot gate fail with 19,258 recoverable records remaining