### PR TITLE
docs: 重构README提高对普通用户的可读性

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,35 +2,111 @@
 
 [中文](README.zh.md)
 
-Small Go service that starts ephemeral GitHub Actions self-hosted runners inside Qiniu sandbox instances.
+A lightweight Go service that runs ephemeral [GitHub Actions self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners) inside [Qiniu Sandbox](https://www.qiniu.com/) instances. Each workflow job gets a clean, isolated sandbox that is automatically created and destroyed.
+
+## Table of Contents
+
+- [Features](#features)
+- [How It Works](#how-it-works)
+- [Quick Start](#quick-start)
+- [Configuration](#configuration)
+  - [Config Value Obfuscation](#config-value-obfuscation)
+- [GitHub App Setup](#github-app-setup)
+  - [Required Permissions](#required-permissions)
+  - [OAuth Sign-in](#oauth-sign-in)
+  - [Webhook Events](#webhook-events)
+- [Webhook & Workflow Setup](#webhook--workflow-setup)
+- [Runner Specs & Policies](#runner-specs--policies)
+- [Admin Console](#admin-console)
+- [Troubleshooting](#troubleshooting)
+- [Docker](#docker)
+- [Build & Development](#build--development)
+- [Documentation](#documentation)
+
+## Features
+
+- **Ephemeral runners** — one sandbox per job, automatically cleaned up after completion
+- **GitHub App auth** — recommended production path with OAuth sign-in for the built-in web console
+- **Multi-database** — SQLite (default), PostgreSQL, or MySQL for runtime state
+- **Concurrency control** — global `max_concurrent_runners` and per-spec `max_concurrency` with queue-based backpressure
+- **Built-in web UI** — admin console for runner specs, groups, policies, accounts, and diagnostics; ordinary-user console for job groups, logs, and sandbox management
+- **Config obfuscation** — sensitive values can be hidden from casual config inspection
+- **Retry & recovery** — transient failures are retried with backoff; capacity signals defer without dropping requests
+
+## How It Works
+
+```
+GitHub webhook (workflow_job)
+        │
+        ▼
+   ┌─────────┐     create sandbox      ┌──────────────────┐
+   │ runnerd  │ ──────────────────────►  │  Qiniu Sandbox   │
+   │ (server) │     register runner     │  (ephemeral VM)  │
+   │          │ ──────────────────────►  │                  │
+   └─────────┘                          │  GitHub Actions  │
+        │                               │  self-hosted     │
+        │  job completed / timeout      │  runner          │
+        │◄────────────────────────────── │                  │
+        │     stop & cleanup sandbox    └──────────────────┘
+        ▼
+   state DB (sqlite / postgres / mysql)
+```
+
+1. GitHub sends a `workflow_job` (queued) webhook to runnerd.
+2. runnerd matches the job labels against runner specs and policies.
+3. runnerd creates a Qiniu Sandbox instance and registers a self-hosted runner inside it.
+4. GitHub Actions dispatches the job to the runner; the job executes in the sandbox.
+5. When the job completes (or times out), runnerd removes the runner registration and stops the sandbox.
+
+## Quick Start
+
+```bash
+# 1. Build
+task build
+
+# 2. Create config from example
+cp runnerd.yaml.example runnerd.yaml
+#    Edit runnerd.yaml: set database, GitHub App credentials, sandbox settings
+
+# 3. Bootstrap the first admin (one-time, exits without starting the server)
+./bin/runnerd --bootstrap-admin github:<github-user-id> --config runnerd.yaml
+
+# 4. Start runnerd
+./bin/runnerd --config runnerd.yaml
+```
+
+5. Open `http://<host>:25500/` and sign in with GitHub OAuth.
+6. Configure **Sandbox Service** credentials in account/org **Preferences** (or admin fallback at `/admin/sandbox_service`).
+7. In the **Admin Console**, create a **Runner Spec** with a meaningful label (e.g. `ubuntu-24-04`), set its `template_id`, and enable `default_available`.
+8. Configure a GitHub webhook → `POST http://<host>:25500/webhooks/github`.
+9. Use `runs-on: [self-hosted, <your-runner-label>]` in your workflow.
+
+For local development, use `task dev` with `runnerd.local.yaml`. See [docs/testing.md](docs/testing.md) for detailed local setup including GitHub App creation and webhook forwarding.
 
 ## Configuration
 
-Runtime configuration is file-first. `runnerd` reads `./runnerd.yaml` by default, or the path passed with `--config`.
+`runnerd` reads `./runnerd.yaml` by default, or the path passed with `--config`. See [`runnerd.yaml.example`](runnerd.yaml.example) for a fully commented reference.
 
-Start from the example:
+| Section | Description |
+| --- | --- |
+| `server` | Listen address, read/write/idle timeouts |
+| `database` | Backend (`sqlite` / `postgres` / `mysql`) and DSN |
+| `auth` | Session secret, encryption key, session TTL |
+| `sandbox` | Sandbox lifecycle timeouts (create, run, stop) |
+| `github` | Webhook secret, auth method (App / PAT / basic), OAuth, allowed repositories |
+| `worker` | Lease, retry, and concurrency settings |
 
-```bash
-cp runnerd.yaml.example runnerd.yaml
-```
+Key notes:
 
-The config file covers:
+- Relative `database.dsn` and `github.app.private_key_file` paths resolve from the config file's directory.
+- Use SQLite for local and single-node deployments. PostgreSQL and MySQL are supported but multi-instance operation on a shared database has not been verified.
+- GitHub Enterprise Server is **not** supported; use a GitHub.com App.
+- Configure exactly one GitHub auth method: `github.app`, `github.token`, or `github.basic_auth`.
+- When `github.app.installation_id` is omitted, runnerd resolves the installation dynamically per repository, allowing one App to serve multiple accounts.
 
-- server listen address and timeouts
-- sqlite, Postgres, or MySQL database backend and DSN/path
-- sandbox lifecycle timeouts
-- GitHub webhook settings plus GitHub App, PAT, or basic auth
-- GitHub App OAuth sign-in for the embedded ordinary-user and admin consoles
-- worker lease / retry / concurrency settings
+### Config Value Obfuscation
 
-Relative sqlite `database.dsn` and `github.app.private_key_file` paths are resolved from the directory containing `runnerd.yaml`. Legacy `database.url` is still accepted as a deprecated alias when `database.dsn` is empty.
-Use sqlite for local and small single-node deployments. Postgres and MySQL are supported by the state store, but shared-database multi-instance operation should be verified in your deployment before advertising it as supported.
-GitHub Enterprise Server is not currently supported; configure a GitHub.com App installation.
-Configure exactly one GitHub auth method: `github.app`, `github.token`, or `github.basic_auth`. For GitHub App auth, `github.app.installation_id` is optional. When it is omitted, runnerd resolves the installation from each job repository and caches installation transports, allowing one GitHub App to serve multiple installed accounts.
-
-### Config value obfuscation
-
-Sensitive scalar fields can use `RUNNERD_ENC(v1:...)` values so `runnerd.yaml` does not display their plaintext directly. Build runnerd, read the value without terminal echo, and generate an obfuscated value from stdin:
+Sensitive fields accept `RUNNERD_ENC(v1:...)` values to avoid plaintext in the config file:
 
 ```bash
 read -r -s secret_value
@@ -38,73 +114,96 @@ printf '%s' "$secret_value" | ./bin/runnerd --obfuscate-config-value
 unset secret_value
 ```
 
-Paste the output in place of the original value. Plaintext remains supported for compatibility. Obfuscation applies to `database.dsn`/`database.url`, `auth.session_secret`, `auth.encryption_key`, `github.webhook_secret`, `github.token`, `github.basic_auth.password`, and `github.oauth.client_secret`. These runtime values are also masked as `******` by their default text, structured-log, JSON, and YAML representations; application code must explicitly request the plaintext when using them.
+Supported fields: `database.dsn`, `auth.session_secret`, `auth.encryption_key`, `github.webhook_secret`, `github.token`, `github.basic_auth.password`, `github.oauth.client_secret`. These values are also masked as `******` in logs and serialized output.
 
-This feature prevents direct disclosure through casual config inspection or accidental logging. It is not encryption against a host user who can inspect or execute runnerd, because the decoding key is embedded in the binary. Continue to keep configuration files out of source control and restrict access wherever the host permits.
+> **Note:** This hides plaintext from casual inspection only — the decoding key is embedded in the binary. It is not encryption against a host-level attacker.
 
-### GitHub App permissions
+## GitHub App Setup
 
-When GitHub App auth is used, configure only the permissions below. The required runner-management permission depends on whether the matched runner spec sets `runner_group`.
+### Required Permissions
 
-| Scope | Permission | Access | Required use |
+| Scope | Permission | Access | Purpose |
 | --- | --- | --- | --- |
-| Repository | Actions | Read-only | Queries workflow job and run status, lists queued jobs, and reads job or run logs. This permission is also required when `workflow_job` and `workflow_run` events are delivered through the GitHub App webhook. |
-| Repository | Administration | Read and write | When the matched runner spec does not set `runner_group`, runnerd generates repository runner registration tokens, lists registered runners, and removes them after jobs finish. Without this permission, repository runner registration fails; only organization runners from specs that set `runner_group` can be used, so personal-account repositories are unsupported. |
-| Repository | Metadata | Read-only | Identifies repositories and their owners and lists repositories that the signed-in user and the GitHub App installation can both access. |
-| Repository | Pull requests | Read-only | Loads pull request titles for ordinary-user PR job groups, including private repositories. Without this permission, the groups remain available but show the title as unavailable. |
-| Organization | Self-hosted runners | Read and write | When the matched runner spec sets `runner_group`, runnerd generates organization runner registration tokens, registers runners in that group, and lists and removes them after jobs finish. |
+| Repository | Actions | Read-only | Query job/run status, list queued jobs, read logs; required for webhook events |
+| Repository | Administration | Read & write | Repository-level runner registration (when spec has no `runner_group`) |
+| Repository | Metadata | Read-only | Identify repositories and owners |
+| Repository | Pull requests | Read-only | Show PR titles in job groups |
+| Organization | Self-hosted runners | Read & write | Organization-level runner registration (when spec sets `runner_group`) |
 
-Set `github.app.slug` to the GitHub App URL slug when you want the ordinary-user UI to show an Install GitHub App link.
-`github.allowed_repositories` is an optional allowlist of `owner/repo` or `owner/*` patterns. Empty means all repositories that can deliver valid webhooks and match runner labels/policies are allowed.
+Set `github.app.slug` to show an "Install GitHub App" link in the user UI. Use `github.allowed_repositories` (patterns like `owner/repo` or `owner/*`) to restrict which repositories can use this runnerd instance.
 
-`github.oauth` enables GitHub App OAuth login for the embedded console. Use the GitHub App's Client ID and Client secret, set a separate `auth.session_secret` for signed sessions, set a separate `auth.encryption_key` for encrypted user secrets, and configure the app callback URL as `/auth/github/callback` on your runnerd origin. Local accounts carry roles, while OAuth identities are matched by provider and stable subject; for GitHub this is the numeric user ID, while login is stored as display metadata. The first OAuth callback creates an account with `role: user` and links the GitHub identity when none exists. Ordinary users install the configured GitHub App, and runnerd records the returned installation id. Ordinary-user Jobs lists, details, groups, logs, and terminals are authorized against exact `(installation_id, repository_full_name)` pairs from the intersection of the user's GitHub App access token and each linked installation's repository scope. The account repositories page uses the same intersection. runnerd does not persist the full repository authorization list; successful lookups are cached in memory for 30 seconds. Missing or rejected user tokens fail closed and require the user to sign in with GitHub again, while linked installations that are no longer accessible are ignored until installation sync removes them. Only accounts with `role: admin` can access management APIs. Bootstrap the first admin by running `runnerd --bootstrap-admin github:<github-user-id>` as a one-time setup step; it sets the admin account and exits without starting the server. OAuth sessions are stored as signed HttpOnly cookies.
+### OAuth Sign-in
 
-Sandbox service API URL and API key are normally configured from the ordinary-user account or organization Preferences page. Admins can configure a disabled-by-default platform fallback at `/admin/sandbox_service` for accounts without a complete scoped configuration. Its availability can cover all GitHub repository owners or selected GitHub users and organizations entered by login; runnerd resolves each entry through GitHub and stores the stable account identity, so selection does not depend on prior sign-in or installation sync. Selection matches the repository owner, not the workflow actor or organization membership. Scoped credentials always win; runnerd resolves a saved request snapshot, installation/custom inheritance, an eligible personal account, then the enabled and audience-eligible admin default. Every API key is encrypted with `auth.encryption_key`; runnerd does not read Sandbox service credentials from `runnerd.yaml`.
+`github.oauth` enables GitHub App OAuth login for the built-in console:
 
-Authenticated users can inspect Sandbox resources in the same account or organization scope. Sandbox Templates lists templates by supported region, while Sandbox Instances lists runner-created instances by region and optional template. The pages are available at `/account/sandbox-templates`, `/account/sandbox-instances`, and the matching `/organizations/{login}/...` routes; credentials remain server-side and are never returned by the catalog APIs.
+- Use the GitHub App's **Client ID** and **Client Secret**.
+- Set the App callback URL to `http://<host>:<port>/auth/github/callback`.
+- Set `auth.session_secret` (session signing) and `auth.encryption_key` (user secret encryption) to separate random values.
 
-`/webhooks/github` uses GitHub HMAC signature verification. The manual management API under `/runner_requests` requires a valid GitHub OAuth admin session cookie.
+First OAuth login creates a `role: user` account. Use `--bootstrap-admin <github-user-id>` to promote an account to admin.
 
-Runner state is persisted in a DB-backed store instead of per-request JSON directories. Control/stdout/stderr logs are kept as runner events and remain available from the admin API and UI.
-Schema creation is GORM-model driven on startup. Existing SQLite `runner_requests` tables use additive column/index migration instead of GORM table recreation so historical installation and Sandbox configuration fields remain intact; non-additive changes to that table require an explicit compatibility migration with preserved-data coverage. Other existing state tables run through a narrow legacy compatibility pass before `AutoMigrate`, so keep old-schema upgrade tests green when changing state records. Upgrading a database whose legacy `account_preferences` or `account_secrets` tables predate `scope_type`/`scope_id` intentionally drops and recreates those tables. Reconfigure the affected Sandbox Preferences and API keys, and have affected users sign in with GitHub again before syncing installations.
+### Webhook Events
 
-## Run
+In your GitHub App settings (**Settings → Developer settings → GitHub Apps → your app → General**), configure:
 
-```bash
-go run ./cmd/runnerd --config ./runnerd.yaml
+1. Set the **Webhook URL** to `https://<your-runnerd-host>/webhooks/github`.
+2. Under **Subscribe to events**, check:
+   - **Workflow jobs** (`workflow_job`) — **required**, triggers runner creation.
+   - **Workflow runs** (`workflow_run`) — optional, acts as a compensating signal for missed `workflow_job` events.
+3. Save changes.
+
+> **⚠️ Common pitfall:** If no events are subscribed, GitHub will not send any webhooks and jobs will stay queued forever. This is configured in the **GitHub App settings**, not in the repository's webhook settings.
+
+## Webhook & Workflow Setup
+
+1. Ensure the GitHub App webhook is configured as described in [Webhook Events](#webhook-events) above, with the `webhook_secret` matching `github.webhook_secret` in your config.
+2. In your workflow, use:
+
+```yaml
+runs-on: [self-hosted, <your-runner-label>]
 ```
 
-## Development
+runnerd handles `queued`, `in_progress`, and `completed` actions. For `workflow_run`, it lists all queued jobs in the run and enqueues any matching jobs not already seen.
 
-Install local tooling and UI dependencies once:
+## Runner Specs & Policies
 
-```bash
-task deps
-task ui-deps
-```
+Runner specs, runner groups, and repository policies are managed through the admin API and console — not through `runnerd.yaml`.
 
-Use a local config file for development so secrets and local sqlite state stay out of git:
+- **Runner Spec**: defines a runner label, sandbox template, and optional `runner_group`. Set `default_available: true` to make it available to all allowed repositories.
+- **Runner Group**: when a spec sets `runner_group`, runnerd creates an organization-level runner in that group; otherwise it creates a repository-level runner.
 
-```bash
-cp runnerd.yaml.example runnerd.local.yaml
-task dev
-```
+> **⚠️ Personal accounts:** `runner_group` requires the organization-level GitHub API. If the repository belongs to a personal account (not an organization), leave `runner_group` **empty** — otherwise runner registration will fail with a 404 error.
+- **Repository Policy**: grants a specific repository access to additional specs beyond the defaults.
 
-`task dev` starts the Vite UI dev server on the first available localhost port at or after `5173`, starts the smee webhook forwarder when `.smee-url` exists, and runs `runnerd` with the `development` build tag. The Go server still listens on the address from `runnerd.local.yaml`, commonly `:25500`, and proxies embedded UI assets to Vite. Open `http://127.0.0.1:25500/` for the ordinary-user PR/job view, `http://127.0.0.1:25500/github/pulls/{owner}/{repo}/{number}/jobs` for a stable GitHub pull request job-group route, `http://127.0.0.1:25500/repositories` for ordinary-user activity repositories, `http://127.0.0.1:25500/account/repositories` for GitHub App accounts and authorized repositories, `http://127.0.0.1:25500/account/preferences` for personal Sandbox service settings, `http://127.0.0.1:25500/account/sandbox-templates` or `/account/sandbox-instances` for the personal Sandbox catalog, `http://127.0.0.1:25500/admin/accounts` for account role management, `http://127.0.0.1:25500/admin/sandbox_service` for the platform fallback, or `http://127.0.0.1:25500/admin/` for the admin console while developing.
+Each spec's `template_id` should point to a Qiniu Sandbox template containing the GitHub runner image. Template access is checked against the repository owner's Sandbox service Preferences at sandbox creation time.
 
-Set `RUNNERD_CONFIG` to use another config file, or `RUNNERD_VITE_PORT` to require a specific Vite port.
+## Admin Console
 
-For local GitHub webhook forwarding, create a per-developer smee channel file:
+The built-in web UI provides:
 
-```bash
-echo 'https://smee.io/<your-channel>' > .smee-url
-```
+| Route | Description |
+| --- | --- |
+| `/admin/` | Dashboard with diagnostics, metrics, and recent failures |
+| `/admin/accounts` | Account management — list, search, and change roles |
+| `/admin/sandbox_service` | Sandbox service configuration |
 
-`task dev` will start the forwarder automatically. `task smee` is also available for standalone webhook forwarding and defaults to `http://127.0.0.1:25500/webhooks/github`. Set `SMEE_TARGET` if runnerd listens on another address.
+Ordinary-user routes include `/repositories`, PR job groups (`/github/pulls/{owner}/{repo}/{number}/jobs`), and account settings (`/account/preferences`, `/account/sandbox-templates`, `/account/sandbox-instances`), with matching `/organizations/{login}/...` routes.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| Job stays **queued** forever, no webhook in runnerd logs | GitHub App has no subscribed events | Go to GitHub App settings → Subscribe to **Workflow jobs** event |
+| `github registration token: status 404` | `runner_group` is set but the repo owner is a personal account | Clear `runner_group` in the runner spec to use repository-level registration |
+| `invalid signature` in logs | Webhook secret mismatch | Ensure `github.webhook_secret` matches the secret in GitHub App/repo webhook settings |
+| `runner start deferred ... at capacity` | Global or per-spec concurrency limit reached | Wait for running jobs to finish, or increase `max_concurrent_runners` / spec `max_concurrency` |
+| Sandbox creation fails | Sandbox service credentials not configured | Configure API credentials in account/org Preferences or admin fallback at `/admin/sandbox_service` |
+
+For detailed local debugging steps, see [docs/testing.md](docs/testing.md#8-troubleshooting-order).
 
 ## Docker
 
-The container image is file-config only. Mount `runnerd.yaml` and any referenced secret files into the container; environment variables such as `HTTP_ADDR` are not used for runtime config.
+The container image uses file-config only. Mount `runnerd.yaml` and any referenced secret files into the container:
 
 ```bash
 docker run --rm -p 25500:25500 \
@@ -113,45 +212,35 @@ docker run --rm -p 25500:25500 \
   ghcr.io/qiniu/ci-runner
 ```
 
-Open the ordinary-user console at `http://127.0.0.1:25500/` or the admin console at `http://127.0.0.1:25500/admin/`. The UI is built from `ui/` with the same React, Vite, Tailwind CSS, shadcn-style components, and theme tokens used by `kubevirt-console`. The console offers GitHub sign-in and uses a signed HttpOnly cookie for API calls. Ordinary users see a two-column repository/PR job view at `/`, stable GitHub-context job-group routes such as `/github/pulls/{owner}/{repo}/{number}/jobs`, local activity repositories at `/repositories`, GitHub App accounts plus on-demand authorized repositories at `/account/repositories`, Sandbox service settings at `/account/preferences` or `/organizations/{login}/preferences`, and scoped resource catalogs at `/account/sandbox-templates`, `/account/sandbox-instances`, and their organization equivalents. Admin users see the management console; provider resource catalogs are not admin configuration.
-
-The admin console lists local accounts and manages their roles, runner requests, runner specs, runner groups, runner policies, the global Sandbox service fallback, retry actions, audit history, runner-spec match tests, and diagnostics. Provider template/instance catalogs remain ordinary-user resources. Runner specs, groups, and repository policies are created through the admin API/UI rather than `runnerd.yaml`. runnerd creates repository runners by default; when a matched runner spec has a GitHub runner group, it creates an organization runner for the job repository owner and passes that group as `--runnergroup`.
-
-Create runner specs with meaningful names such as `ubuntu-24-04` or `ubuntu-24-04-large`; set each spec `template_id` to the Qiniu sandbox template that contains the GitHub runner image. Template access is checked when runnerd starts a sandbox with the repository owner's Sandbox service Preferences. Runner specs with `default_available: true` are globally available to allowed installed repositories. Use `github.allowed_repositories` to limit which repositories can use this runnerd instance, and use runner policies when a repository needs access to an additional/special spec.
-
-Runner requests are paginated by default: `GET /runner_requests` and the repository-authorized `GET /user/runner_requests` return the most recent 100 rows unless `limit` and `offset` are provided, cap pages at 500 rows, and include `X-Total-Count`, `X-Limit`, `X-Offset`, and `Link` response headers. The ordinary-user endpoint bounds offset pagination to the most recent 500 rows, rejecting pages that extend past that history window. List queries project only public runner-state fields instead of loading stored GitHub webhook payloads or Sandbox credentials. The browser loads only data used by the current route: the Jobs homepage loads and polls the newest 100 rows, stable job-group routes resolve against the 500-row history window, and the list can load those older jobs on demand. GitHub App metadata, preferences, catalog configuration, and audit data load only when their routes need them. The admin console adds status, repository, and runner-spec filters on top of the current page and links each managed request to the GitHub Actions job when GitHub provides a job URL.
-
-The Accounts page at `/admin/accounts` lists OAuth/bootstrap-created local accounts and their linked OAuth identities. Its summary cards report total accounts, administrators, users, and linked identities. `GET /admin/api/accounts` accepts `q`, `role=admin|user`, `limit`, and `offset`; statistics remain global while the list is searched, filtered, or paginated. The default page size is 20 and the maximum is 100. `PATCH /admin/api/accounts/{id}/role` is the page's only mutation and changes another account between `admin` and `user`; it cannot create or delete accounts or link or unlink identities. Self-role changes and changes that could leave the system without an administrator are rejected. Successful changes take effect immediately and create an `account.role.update` audit event.
-
-runnerd enforces both `worker.max_concurrent_runners` and per-spec `max_concurrency`. Requests above those limits remain in the DB as `queued` and are retried later; they are not dropped. Transient capacity signals such as Qiniu sandbox placement failures, HTTP 429, and GitHub secondary rate limits are treated as queue deferrals, so they keep waiting even after the normal retry counter reaches its configured cap. Other transient failures still use the configured retry backoff and eventually become `failed`; deterministic auth/config/template errors fail immediately.
-
-runnerd caches valid GitHub registration tokens per repository or organization, retries runner registration inside the sandbox, and best-effort removes the GitHub runner registration when a sandbox is stopped or recovered.
-
-The sandbox runner installs a pre-job hook that prints the Qiniu sandbox id, runner request id, and runner name in the GitHub Actions `Set up runner` log. Use that sandbox id to find the matching instance in the Qiniu sandbox console when debugging a job.
-
-The binary also imports `github.com/jimmicro/pprof`, so a local-only pprof/expvar service is started automatically and discovered through generated `.pprof` address files and dump scripts. The admin console exposes a diagnostics page that summarizes the discovered pprof endpoint, `/debug/vars`, DB state, GitHub auth mode, retry/lease metrics, and recent failures. The expvar metrics include ARC-style workflow job counts, conclusions, failures, queue/run duration totals and counts, runner registration/cleanup counters, GitHub API operation counters, low-cardinality HTTP route request counts and duration totals, and Fireactions-style profile current/busy/idle/pending/desired gauges.
-
-## Build
+## Build & Development
 
 ```bash
-task build
-task docker-build
-task template-build-prod
+task deps          # Install Go dependencies
+task ui-deps       # Install UI dependencies
+task build         # Build runnerd with embedded production UI
+task dev           # Start local dev (runnerd + Vite + smee)
+task lint          # Run linters
+task test          # Rebuild UI + run all tests (Go with race detection + Bun UI tests)
+task docker-check  # Verify Docker build
+task release-check # Verify release build
 ```
 
-`templates/github-runner-ubuntu-24.04` is the default GitHub runner image and includes the runner runtime, Docker support, helper tools, and `rclone`. Qiniu sandbox template builds use Taskfile targets that call `qshell sandbox template build` with a temporary copy of each template directory's `qshell.sandbox.toml`, so qshell-generated `template_id` values are not written back into tracked config. `templates/qbox-kodo-ubuntu-16.04` is an additional legacy Ubuntu 16.04 template for qbox/kodo-style jobs with the required old Go toolchains, apt packages, Docker support, and `rclone`. Its Docker base image is defined by `templates/qbox-kodo-ubuntu-16.04/base.Dockerfile` and can be rebuilt with `task qbox-kodo-base-build` before rebuilding the Qiniu sandbox template.
+For focused UI tests: `cd ui && bun run test`.
 
-Useful validation commands:
+### Sandbox Templates
 
-```bash
-task lint
-task test
-task docker-check
-task release-check
-```
+| Template | Description |
+| --- | --- |
+| `templates/github-runner-ubuntu-24.04` | Default GitHub runner image (runner runtime, Docker, helper tools, rclone) |
+| `templates/qbox-kodo-ubuntu-16.04` | Legacy Ubuntu 16.04 for qbox/kodo-style jobs |
 
-`task test` rebuilds the UI, runs the Bun UI tests, and then runs the Go suite with race detection and coverage. For focused UI tests, run `cd ui && bun run test`.
+Build templates with `task template-build-prod`. The qbox-kodo base image can be rebuilt separately with `task qbox-kodo-base-build`.
 
-Use `runs-on: [self-hosted, e2b]` in the target workflow. Configure a GitHub webhook for `workflow_job` events pointing at `POST /webhooks/github`; runnerd handles `queued`, `in_progress`, and `completed` actions. You can also include `workflow_run` events as a compensating signal; runnerd lists all queued jobs in the run and enqueues any matching jobs not already seen from `workflow_job`.
+## Documentation
 
-For a production-style readiness pass, use [docs/deployment-smoke.md](docs/deployment-smoke.md).
+| Document | Description |
+| --- | --- |
+| [docs/testing.md](docs/testing.md) | Local testing, GitHub App/OAuth setup, webhook forwarding, troubleshooting |
+| [docs/deployment-smoke.md](docs/deployment-smoke.md) | Production-style readiness checklist |
+| [docs/runner-architecture-comparison.md](docs/runner-architecture-comparison.md) | Architecture diagrams and comparison with ARC / Fireactions |
+| [docs/runner-implementation-review.md](docs/runner-implementation-review.md) | Implementation status and schema migration notes |

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,35 +2,111 @@
 
 [English](README.md)
 
-这是一个小型 Go 服务，用于在 Qiniu sandbox 实例中启动临时 GitHub Actions self-hosted runner。
+一个轻量级 Go 服务，在 [Qiniu Sandbox](https://www.qiniu.com/) 实例中运行临时的 [GitHub Actions self-hosted runner](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)。每个 workflow job 都会获得一个干净、隔离的沙箱环境，并在完成后自动销毁。
+
+## 目录
+
+- [特性](#特性)
+- [工作原理](#工作原理)
+- [快速开始](#快速开始)
+- [配置](#配置)
+  - [配置值混淆](#配置值混淆)
+- [GitHub App 设置](#github-app-设置)
+  - [所需权限](#所需权限)
+  - [OAuth 登录](#oauth-登录)
+  - [Webhook 事件订阅](#webhook-事件订阅)
+- [Webhook 与 Workflow 配置](#webhook-与-workflow-配置)
+- [Runner Spec 与 Policy](#runner-spec-与-policy)
+- [管理控制台](#管理控制台)
+- [常见问题排查](#常见问题排查)
+- [Docker](#docker)
+- [构建与开发](#构建与开发)
+- [文档](#文档)
+
+## 特性
+
+- **临时 Runner** — 每个 job 一个沙箱，完成后自动清理
+- **GitHub App 鉴权** — 推荐的生产鉴权方式，内置 Web 控制台支持 OAuth 登录
+- **多数据库支持** — SQLite（默认）、PostgreSQL 或 MySQL 存储运行时状态
+- **并发控制** — 全局 `max_concurrent_runners` 和 per-spec `max_concurrency`，基于队列的背压机制
+- **内置 Web UI** — 管理控制台（Runner Spec、分组、策略、账户、诊断）；普通用户控制台（Job 分组、日志、沙箱管理）
+- **配置混淆** — 敏感值可避免在配置文件中直接暴露明文
+- **重试与恢复** — 瞬时故障自动退避重试；容量信号延迟处理而非丢弃请求
+
+## 工作原理
+
+```
+GitHub webhook (workflow_job)
+        │
+        ▼
+   ┌─────────┐     创建沙箱             ┌──────────────────┐
+   │ runnerd  │ ──────────────────────►  │  Qiniu Sandbox   │
+   │ (服务端) │     注册 runner          │  (临时虚拟机)     │
+   │          │ ──────────────────────►  │                  │
+   └─────────┘                          │  GitHub Actions  │
+        │                               │  self-hosted     │
+        │  job 完成 / 超时               │  runner          │
+        │◄────────────────────────────── │                  │
+        │     停止并清理沙箱             └──────────────────┘
+        ▼
+   状态数据库 (sqlite / postgres / mysql)
+```
+
+1. GitHub 向 runnerd 发送 `workflow_job`（queued）webhook。
+2. runnerd 将 job labels 与 runner spec 和 policy 进行匹配。
+3. runnerd 创建 Qiniu Sandbox 实例，并在其中注册 self-hosted runner。
+4. GitHub Actions 将 job 分派到该 runner，job 在沙箱中执行。
+5. job 完成（或超时）后，runnerd 移除 runner 注册并停止沙箱。
+
+## 快速开始
+
+```bash
+# 1. 构建
+task build
+
+# 2. 从示例创建配置
+cp runnerd.yaml.example runnerd.yaml
+#    编辑 runnerd.yaml：设置数据库、GitHub App 凭据、沙箱参数
+
+# 3. 初始化首个管理员（一次性命令，执行后直接退出，不会启动服务）
+./bin/runnerd --bootstrap-admin github:<github-user-id> --config runnerd.yaml
+
+# 4. 启动 runnerd
+./bin/runnerd --config runnerd.yaml
+```
+
+5. 打开 `http://<host>:25500/`，使用 GitHub OAuth 登录。
+6. 在账户/组织 **Preferences** 中配置 **Sandbox Service** 凭据（或在 `/admin/sandbox_service` 配置管理员级兜底）。
+7. 在**管理控制台**中创建 **Runner Spec**，设置有意义的 label（如 `ubuntu-24-04`），填写 `template_id`，并启用 `default_available`。
+8. 配置 GitHub webhook → `POST http://<host>:25500/webhooks/github`。
+9. 在 workflow 中使用 `runs-on: [self-hosted, <your-runner-label>]`。
+
+本地开发请使用 `task dev` 配合 `runnerd.local.yaml`。详细的本地环境搭建（包括 GitHub App 创建和 webhook 转发）请参阅 [docs/zh/testing.md](docs/zh/testing.md)。
 
 ## 配置
 
-运行时配置以文件为主。`runnerd` 默认读取 `./runnerd.yaml`，也可以通过 `--config` 指定其他路径。
+`runnerd` 默认读取 `./runnerd.yaml`，也可通过 `--config` 指定路径。完整注释的参考配置见 [`runnerd.yaml.example`](runnerd.yaml.example)。
 
-从示例配置开始：
+| 配置段     | 说明                                                             |
+| ---------- | ---------------------------------------------------------------- |
+| `server`   | 监听地址、读/写/空闲超时                                         |
+| `database` | 后端类型（`sqlite` / `postgres` / `mysql`）和 DSN                |
+| `auth`     | Session secret、加密密钥、Session TTL                            |
+| `sandbox`  | 沙箱生命周期超时（创建、运行、停止）                             |
+| `github`   | Webhook secret、鉴权方式（App / PAT / basic）、OAuth、允许的仓库 |
+| `worker`   | Lease、重试和并发设置                                            |
 
-```bash
-cp runnerd.yaml.example runnerd.yaml
-```
+要点：
 
-配置文件覆盖：
-
-- 服务监听地址和超时；
-- sqlite、Postgres 或 MySQL 数据库后端和 DSN/path；
-- sandbox 生命周期超时；
-- GitHub webhook 设置，以及 GitHub App、PAT 或 basic auth；
-- 内置普通用户与管理员 console 的 GitHub App OAuth 登录；
-- worker lease、retry、concurrency 设置。
-
-相对路径的 sqlite `database.dsn` 和 `github.app.private_key_file` 会按 `runnerd.yaml` 所在目录解析。旧的 `database.url` 在 `database.dsn` 为空时仍作为 deprecated alias 兼容读取。
-本地和小型单节点部署建议使用 sqlite。状态存储支持 Postgres 和 MySQL，但不要在两个 runnerd 进程共用同一个数据库验证前，把 shared-database multi-instance 作为已支持能力对外说明。
-当前不支持 GitHub Enterprise Server；请配置 GitHub.com App installation。
-GitHub 鉴权方式必须三选一：`github.app`、`github.token` 或 `github.basic_auth`。使用 GitHub App auth 时，`github.app.installation_id` 是可选的；省略时，runnerd 会按每个 job repository 动态解析 installation，并缓存 installation transports，因此一个 GitHub App 可以服务多个已安装账号。
+- 相对路径的 `database.dsn` 和 `github.app.private_key_file` 按配置文件所在目录解析。
+- 本地和单节点部署建议使用 SQLite。支持 PostgreSQL 和 MySQL，但多实例共享数据库尚未验证。
+- **不支持** GitHub Enterprise Server，请使用 GitHub.com App。
+- GitHub 鉴权方式三选一：`github.app`、`github.token` 或 `github.basic_auth`。
+- 省略 `github.app.installation_id` 时，runnerd 按仓库动态解析 installation，一个 App 可服务多个账号。
 
 ### 配置值混淆
 
-敏感标量字段可以使用 `RUNNERD_ENC(v1:...)`，避免在 `runnerd.yaml` 中直接展示明文。先构建 runnerd，再以不回显的方式读取原值，并从 stdin 生成混淆值：
+敏感字段支持 `RUNNERD_ENC(v1:...)` 格式，避免配置文件中出现明文：
 
 ```bash
 read -r -s secret_value
@@ -38,73 +114,97 @@ printf '%s' "$secret_value" | ./bin/runnerd --obfuscate-config-value
 unset secret_value
 ```
 
-将输出替换原配置值即可；为保持兼容，明文仍然可用。支持混淆的字段包括 `database.dsn`/`database.url`、`auth.session_secret`、`auth.encryption_key`、`github.webhook_secret`、`github.token`、`github.basic_auth.password` 和 `github.oauth.client_secret`。这些运行时值通过默认文本格式、结构化日志、JSON 或 YAML 输出时也只显示 `******`；应用代码需要显式请求明文后才能使用。
+支持的字段：`database.dsn`、`auth.session_secret`、`auth.encryption_key`、`github.webhook_secret`、`github.token`、`github.basic_auth.password`、`github.oauth.client_secret`。这些值在日志和序列化输出中也会显示为 `******`。
 
-该功能用于避免直接查看配置或意外日志输出造成明文泄漏，不用于抵御能够检查或执行 runnerd 的主机用户，因为解码 key 内置在二进制中。仍应避免将配置提交到源码仓库，并在主机条件允许时限制访问。
+> **注意：** 此功能仅防止直接查看配置时的明文泄漏，解码 key 内置在二进制中，不能抵御主机级别的攻击者。
 
-### GitHub App 权限
+## GitHub App 设置
 
-使用 GitHub App 鉴权时，只需配置下表中的权限。Runner 管理权限取决于匹配到的 Runner Spec 是否设置了 `runner_group`。
+### 所需权限
 
-| 范围 | 权限 | 访问级别 | 必要用途 |
-| --- | --- | --- | --- |
-| Repository | Actions | Read-only | 查询 workflow job 和 run 状态、列出 queued jobs，并读取 job 或 run 日志；通过 GitHub App webhook 接收 `workflow_job` 和 `workflow_run` 事件时，也需要此权限。 |
-| Repository | Administration | Read and write | 匹配到的 Runner Spec **未配置 `runner_group`** 时，用于生成仓库级 runner 注册令牌、查询已注册 runner，并在任务结束后清理 runner。若不配置此权限，仓库级 runner 将注册失败，只能使用配置了 `runner_group` 的组织级 runner，且不再支持个人账户仓库。 |
-| Repository | Metadata | Read-only | 识别仓库及其所属账户，并获取登录用户与 GitHub App installation 均有权访问的仓库列表。 |
-| Repository | Pull requests | Read-only | 获取普通用户 PR job group 的 pull request 标题，包括私有仓库。若不配置此权限，job group 仍可使用，但标题会显示为不可用。 |
-| Organization | Self-hosted runners | Read and write | 匹配到的 Runner Spec **配置了 `runner_group`** 时，用于生成组织级 runner 注册令牌、将 runner 注册到指定 group，并在任务结束后查询和清理 runner。 |
+| 范围         | 权限                | 访问级别     | 用途                                                             |
+| ------------ | ------------------- | ------------ | ---------------------------------------------------------------- |
+| Repository   | Actions             | Read-only    | 查询 job/run 状态、列出排队 job、读取日志；接收 webhook 事件所需 |
+| Repository   | Administration      | Read & write | 仓库级 runner 注册（spec 未设置 `runner_group` 时）              |
+| Repository   | Metadata            | Read-only    | 识别仓库及其所属账户                                             |
+| Repository   | Pull requests       | Read-only    | 在 job 分组中显示 PR 标题                                        |
+| Organization | Self-hosted runners | Read & write | 组织级 runner 注册（spec 设置了 `runner_group` 时）              |
 
-如果希望普通用户 UI 显示 Install GitHub App 链接，请设置 `github.app.slug` 为 GitHub App URL slug。
-`github.allowed_repositories` 是可选 allowlist，支持 `owner/repo` 或 `owner/*`。为空表示允许所有能发送有效 webhook 且能匹配 runner labels/policies 的仓库。
+设置 `github.app.slug` 可在用户 UI 中显示"安装 GitHub App"链接。使用 `github.allowed_repositories`（支持 `owner/repo` 或 `owner/*` 模式）限制哪些仓库可以使用此 runnerd 实例。
 
-`github.oauth` 用于启用内置 console 的 GitHub App OAuth 登录。使用 GitHub App 的 Client ID 和 Client secret，设置单独的 `auth.session_secret` 用于签名 session，设置单独的 `auth.encryption_key` 用于加密用户 secret，并把 App callback URL 配成 runnerd origin 下的 `/auth/github/callback`。本地 account 保存 role，OAuth identity 按 provider 和 stable subject 匹配；GitHub 的 stable subject 是 numeric user ID，login 只作为展示元数据保存。首次 OAuth callback 会创建 `role: user` 的 account 并绑定 GitHub identity。普通用户安装配置的 GitHub App，runnerd 会记录返回的 installation id。普通用户的 Jobs 列表、详情、分组、日志和终端接口，都按用户的 GitHub App access token 与每个已绑定 installation 仓库范围的交集，精确校验 `(installation_id, repository_full_name)`。Account repositories 页面使用相同的交集。runnerd 不会持久化完整的仓库授权列表，只会在内存中缓存成功结果 30 秒。用户 token 缺失或被 GitHub 拒绝时会默认拒绝访问，并要求用户重新使用 GitHub 登录；已失去访问权的 installation 会被忽略，直到 installation sync 将其移除。只有 `role: admin` 的 account 可以访问管理 API。首个管理员通过 `runnerd --bootstrap-admin github:<github-user-id>` 一次性引导，该命令设置 admin 账户后直接退出，不会启动服务。OAuth session 存储为 signed HttpOnly cookie。
+### OAuth 登录
 
-Sandbox service API URL 和 API key 通常在普通用户的 account 或 organization Preferences 页面配置。管理员可以在 `/admin/sandbox_service` 配置一个默认关闭的平台回退，供缺少完整 scoped 配置的 account 使用；可用范围可以是全部 GitHub repository owners，或按 login 选择的 GitHub users/organizations。runnerd 会通过 GitHub 解析并保存稳定 account identity，因此选择不依赖此前登录或 installation 同步；匹配对象是 repository owner，不是 workflow actor 或 organization membership。Scoped credentials 始终优先，解析顺序为已保存的 request snapshot、installation custom/inherited 配置、符合条件的个人 account，以及已启用且 audience eligible 的 admin default。所有 API key 都使用 `auth.encryption_key` 加密；runnerd 不会从 `runnerd.yaml` 读取 Sandbox service 凭据。
+`github.oauth` 用于启用内置控制台的 GitHub App OAuth 登录：
 
-登录用户可以在同一 account 或 organization scope 下查看 Sandbox 资源。Sandbox Templates 按支持的区域列出模板，Sandbox Instances 按区域和可选模板筛选 runner 创建的实例。页面位于 `/account/sandbox-templates`、`/account/sandbox-instances` 及对应的 `/organizations/{login}/...` 路由；凭据只在服务端使用，目录 API 不会返回凭据。
+- 使用 GitHub App 的 **Client ID** 和 **Client Secret**。
+- 将 App callback URL 设置为 `http://<host>:<port>/auth/github/callback`。
+- 将 `auth.session_secret`（session 签名）和 `auth.encryption_key`（用户 secret 加密）设为不同的随机值。
 
-`/webhooks/github` 使用 GitHub HMAC signature verification。`/runner_requests` 下的手动管理 API 需要有效的 GitHub OAuth admin session cookie。
+首次 OAuth 登录会创建 `role: user` 的账户。使用 `--bootstrap-admin <github-user-id>` 将账户提升为管理员。
 
-Runner state 持久化到 DB-backed store，不再使用按请求拆分的 JSON 目录。Control/stdout/stderr logs 会作为 runner events 保存，并继续通过 admin API 和 UI 查看。
-Schema 创建由 GORM model 驱动。已有 SQLite `runner_requests` 表只执行 additive column/index migration，不再由 GORM 重建整张表，以保留历史 installation 和 Sandbox configuration 字段；这张表未来如需 non-additive 变更，必须增加显式 compatibility migration 和数据保全测试。其他旧状态表会先执行窄范围 legacy compatibility pass，再运行 `AutoMigrate`。修改 state records 时需要保持旧 schema upgrade tests 通过。如果旧数据库的 `account_preferences` 或 `account_secrets` 表早于 `scope_type`/`scope_id`，升级会有意删除并重建这些表。升级后需要重新配置受影响的 Sandbox Preferences 和 API keys，相关用户还需重新使用 GitHub 登录，才能继续同步 installations。
+### Webhook 事件订阅
 
-## 运行
+在 GitHub App 设置页面（**Settings → Developer settings → GitHub Apps → 你的 App → General**）中配置：
 
-```bash
-go run ./cmd/runnerd --config ./runnerd.yaml
+1. 将 **Webhook URL** 设置为 `https://<你的runnerd地址>/webhooks/github`。
+2. 在 **Subscribe to events** 中勾选：
+   - **Workflow jobs**（`workflow_job`）— **必需**，触发 runner 创建。
+   - **Workflow runs**（`workflow_run`）— 可选，作为 `workflow_job` 丢失时的补偿信号。
+3. 保存更改。
+
+> **⚠️ 常见坑：** 如果没有订阅任何事件，GitHub 不会发送任何 webhook，job 将永远卡在 queued 状态。此配置在 **GitHub App 设置页面**，不是仓库的 webhook 设置。
+
+## Webhook 与 Workflow 配置
+
+1. 确保已按上述 [Webhook 事件订阅](#webhook-事件订阅) 配置好 GitHub App webhook，且 `webhook_secret` 与配置文件中的 `github.webhook_secret` 一致。
+2. 在 workflow 中使用：
+
+```yaml
+runs-on: [self-hosted, <your-runner-label>]
 ```
 
-## 开发
+runnerd 处理 `queued`、`in_progress` 和 `completed` 动作。对于 `workflow_run` 事件，runnerd 会列出该 run 下所有排队 job，并将尚未入队的匹配 job 创建 runner request。
 
-首次安装本地工具和 UI 依赖：
+## Runner Spec 与 Policy
 
-```bash
-task deps
-task ui-deps
-```
+Runner spec、runner group 和 repository policy 通过管理 API 和控制台管理，**不在** `runnerd.yaml` 中配置。
 
-开发时使用本地配置文件，避免把 secret 和本地 sqlite 状态提交进仓库：
+- **Runner Spec**：定义 runner label、沙箱模板和可选的 `runner_group`。设置 `default_available: true` 使其对所有允许的仓库可用。
+- **Runner Group**：spec 设置了 `runner_group` 时，runnerd 创建组织级 runner；否则创建仓库级 runner。
 
-```bash
-cp runnerd.yaml.example runnerd.local.yaml
-task dev
-```
+> **⚠️ 个人账号注意：** `runner_group` 需要调用组织级 GitHub API。如果仓库属于个人账号（而非组织），必须将 `runner_group` 留**空**，否则 runner 注册会返回 404 错误。
 
-`task dev` 会从 `5173` 开始选择第一个可用 localhost 端口启动 Vite UI dev server；当 `.smee-url` 存在时启动 smee webhook forwarder；并用 `development` build tag 运行 `runnerd`。Go server 仍监听 `runnerd.local.yaml` 中的地址，通常是 `:25500`，并把嵌入式 UI 资源代理到 Vite。开发时可打开 `http://127.0.0.1:25500/` 查看普通用户 PR/job 视图，打开 `http://127.0.0.1:25500/github/pulls/{owner}/{repo}/{number}/jobs` 查看稳定的 GitHub pull request job-group 路由，打开 `http://127.0.0.1:25500/repositories` 查看普通用户 activity repositories，打开 `http://127.0.0.1:25500/account/repositories` 查看 GitHub App accounts 和 authorized repositories，打开 `http://127.0.0.1:25500/account/preferences` 配置个人 Sandbox service，打开 `http://127.0.0.1:25500/account/sandbox-templates` 或 `/account/sandbox-instances` 查看个人 Sandbox 目录，打开 `http://127.0.0.1:25500/admin/accounts` 管理账户角色，打开 `http://127.0.0.1:25500/admin/sandbox_service` 管理平台回退，或打开 `http://127.0.0.1:25500/admin/` 查看 admin console。
+- **Repository Policy**：为特定仓库授权访问默认之外的额外 spec。
 
-可设置 `RUNNERD_CONFIG` 使用其他配置文件，或设置 `RUNNERD_VITE_PORT` 要求固定 Vite 端口。
+每个 spec 的 `template_id` 应指向包含 GitHub runner 镜像的 Qiniu Sandbox 模板。创建沙箱时会使用仓库 owner 的 Sandbox service Preferences 检查模板访问权限。
 
-本地 GitHub webhook forwarding 可创建 per-developer smee channel 文件：
+## 管理控制台
 
-```bash
-echo 'https://smee.io/<your-channel>' > .smee-url
-```
+内置 Web UI 提供：
 
-`task dev` 会自动启动 forwarder。`task smee` 也可单独启动 webhook forwarding，默认转发到 `http://127.0.0.1:25500/webhooks/github`。如果 runnerd 监听其他地址，请设置 `SMEE_TARGET`。
+| 路由                     | 说明                           |
+| ------------------------ | ------------------------------ |
+| `/admin/`                | 仪表盘：诊断、指标、最近失败   |
+| `/admin/accounts`        | 账户管理：列表、搜索、角色变更 |
+| `/admin/sandbox_service` | Sandbox 服务配置               |
+
+普通用户路由包括 `/repositories`、PR job 分组（`/github/pulls/{owner}/{repo}/{number}/jobs`）、账户设置（`/account/preferences`、`/account/sandbox-templates`、`/account/sandbox-instances`），以及对应的 `/organizations/{login}/...` 路由。
+
+## 常见问题排查
+
+| 现象                                                 | 可能原因                                 | 解决方法                                                                           |
+| ---------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------- |
+| Job 一直卡在 **queued**，runnerd 日志无 webhook 记录 | GitHub App 未订阅事件                    | 进入 GitHub App 设置 → 勾选 **Workflow jobs** 事件                                 |
+| `github registration token: status 404`              | 设置了 `runner_group` 但仓库属于个人账号 | 清空 runner spec 中的 `runner_group`，改用仓库级注册                               |
+| 日志中出现 `invalid signature`                       | Webhook secret 不匹配                    | 确保 `github.webhook_secret` 与 GitHub App/仓库 webhook 设置中的 secret 一致       |
+| `runner start deferred ... at capacity`              | 全局或 spec 并发上限已满                 | 等待运行中的 job 完成，或调大 `max_concurrent_runners` / spec 的 `max_concurrency` |
+| 沙箱创建失败                                         | 未配置 Sandbox 服务凭据                  | 在账户/组织 Preferences 或 `/admin/sandbox_service` 管理面板中配置 API 凭据        |
+
+更多本地调试步骤请参阅 [docs/zh/testing.md](docs/zh/testing.md)。
 
 ## Docker
 
-容器镜像只使用文件配置。把 `runnerd.yaml` 和其中引用的 secret 文件挂载进容器；`HTTP_ADDR` 这类环境变量不会作为运行时配置使用。
+容器镜像仅使用文件配置。将 `runnerd.yaml` 和引用的密钥文件挂载到容器中：
 
 ```bash
 docker run --rm -p 25500:25500 \
@@ -113,45 +213,35 @@ docker run --rm -p 25500:25500 \
   ghcr.io/qiniu/ci-runner
 ```
 
-普通用户 console 地址是 `http://127.0.0.1:25500/`，admin console 地址是 `http://127.0.0.1:25500/admin/`。UI 从 `ui/` 构建，使用 React、Vite、Tailwind CSS、shadcn-style components，以及与 `kubevirt-console` 相同的 theme tokens。Console 提供 GitHub sign-in，并使用 signed HttpOnly cookie 调用 API。普通用户可以在 `/` 看到两列 repository/PR job 视图，通过 `/github/pulls/{owner}/{repo}/{number}/jobs` 这类稳定的 GitHub-context 路由查看 job group，在 `/repositories` 看到本地 activity repositories，在 `/account/repositories` 看到 GitHub App accounts 和按需加载的 authorized repositories，在 `/account/preferences` 或 `/organizations/{login}/preferences` 配置 Sandbox service，并在 `/account/sandbox-templates`、`/account/sandbox-instances` 及对应的 organization 路由查看 scoped resource catalogs。Admin 用户看到管理 console；provider resource catalogs 不属于 admin 配置。
-
-Admin console 列出本地 accounts 并管理其 roles，同时管理 runner requests、runner specs、runner groups、runner policies、全局 Sandbox service fallback、retry actions、audit history、runner-spec match tests 和 diagnostics。Provider template/instance catalogs 仍属于普通用户资源。Runner specs、groups 和 repository policies 通过 admin API/UI 创建，不是 `runnerd.yaml` 字段。runnerd 默认创建 repository runner；当匹配到的 runner spec 配置了 GitHub runner group 时，它会为 job repository owner 创建 organization runner，并把该 group 作为 `--runnergroup` 传入。
-
-创建 runner spec 时使用有意义的名称，例如 `ubuntu-24-04` 或 `ubuntu-24-04-large`；每个 spec 的 `template_id` 应指向包含 GitHub runner image 的 Qiniu sandbox template。runnerd 启动 sandbox 时会使用 repository owner 的 Sandbox service Preferences 检查 template 访问权限。`default_available: true` 的 runner spec 对所有允许的已安装仓库默认可用。使用 `github.allowed_repositories` 限制哪些仓库可以使用该 runnerd 实例；当某个仓库需要额外或特殊 spec 时，使用 runner policies 授权。
-
-Runner requests 默认分页：`GET /runner_requests` 和经过 repository 授权过滤的 `GET /user/runner_requests` 在未提供 `limit` 和 `offset` 时返回最近 100 行，单页最多 500 行，并返回 `X-Total-Count`、`X-Limit`、`X-Offset` 和 `Link` headers。普通用户接口把 offset 分页限制在最近 500 行，超出该历史窗口的页面会被拒绝。列表查询只读取公开 runner state 所需字段，不再加载已保存的 GitHub webhook payload 或 Sandbox credentials。浏览器只加载当前路由实际使用的数据：首页加载并轮询最近 100 行，稳定 job-group 路由在 500 行历史窗口内解析，列表可按需加载这些更早的 jobs；GitHub App metadata、Preferences、catalog 配置和 audit data 只在对应路由需要时加载。Admin console 会在当前页上叠加 status、repository 和 runner-spec filters，并在 GitHub 提供 job URL 时把每个 managed request 链接到 GitHub Actions job。
-
-`/admin/accounts` 的 Accounts 页面列出通过 OAuth/bootstrap 创建的本地 accounts 及其关联 OAuth identities。顶部统计卡展示账户总数、管理员、普通用户和已绑定 identity 数量；搜索、角色筛选或分页不会改变全局统计。`GET /admin/api/accounts` 接受 `q`、`role=admin|user`、`limit` 和 `offset`，默认每页 20 条、最多 100 条。`PATCH /admin/api/accounts/{id}/role` 是页面唯一的修改操作，只能把其他 account 的 role 在 `admin` 和 `user` 之间切换；不能创建或删除 account，也不能绑定或解绑 identity。系统会拒绝修改自身角色，以及可能导致系统没有管理员的变更。成功修改会立即生效，并写入 `account.role.update` 审计事件。
-
-runnerd 同时执行 `worker.max_concurrent_runners` 和 per-spec `max_concurrency`。超过这些限制的请求会以 `queued` 状态留在数据库中，并在之后重试；不会被丢弃。Qiniu sandbox placement failures、HTTP 429、GitHub secondary rate limits 等瞬时 capacity 信号会作为 queue deferrals 处理，因此即使普通 retry counter 达到配置上限，仍会继续等待。其他 transient failures 使用配置的 retry backoff，最终可能变成 `failed`；确定性的 auth/config/template 错误会立即失败。
-
-runnerd 会按 repository 或 organization 缓存有效的 GitHub registration token，在 sandbox 内重试 runner registration，并在 sandbox stopped 或 recovery 时 best-effort 移除 GitHub runner registration。
-
-sandbox runner 会安装 pre-job hook，在 GitHub Actions `Set up runner` log 中打印 Qiniu sandbox id、runner request id 和 runner name。调试 job 时可用该 sandbox id 在 Qiniu sandbox console 中查找对应实例。
-
-二进制还会导入 `github.com/jimmicro/pprof`，因此会自动启动 local-only pprof/expvar service，并通过生成的 `.pprof` address files 和 dump scripts 发现。Admin console 提供 diagnostics 页面，汇总发现的 pprof endpoint、`/debug/vars`、DB state、GitHub auth mode、retry/lease metrics 和 recent failures。expvar metrics 包括 ARC-style workflow job counts、conclusions、failures、queue/run duration totals and counts、runner registration/cleanup counters、GitHub API operation counters、低基数 HTTP route request counts 和 duration totals，以及 Fireactions-style profile current/busy/idle/pending/desired gauges。
-
-## 构建
+## 构建与开发
 
 ```bash
-task build
-task docker-build
-task template-build-prod
+task deps          # 安装 Go 依赖
+task ui-deps       # 安装 UI 依赖
+task build         # 构建 runnerd（内嵌生产 UI）
+task dev           # 启动本地开发环境（runnerd + Vite + smee）
+task lint          # 运行代码检查
+task test          # 重建 UI + 运行全部测试（Go race detection + Bun UI tests）
+task docker-check  # 验证 Docker 构建
+task release-check # 验证发布构建
 ```
 
-`templates/github-runner-ubuntu-24.04` 是默认 GitHub runner image，包含 runner runtime、Docker support、helper tools 和 `rclone`。Qiniu sandbox template 构建使用 Taskfile target 调用 `qshell sandbox template build`，并使用各模板目录下 `qshell.sandbox.toml` 的临时副本，避免 qshell 生成的 `template_id` 写回已跟踪配置。`templates/qbox-kodo-ubuntu-16.04` 是额外的 legacy Ubuntu 16.04 template，用于仍需要旧 Go toolchains、apt packages、Docker support 和 `rclone` 的 qbox/kodo-style jobs。它的 Docker base image 定义在 `templates/qbox-kodo-ubuntu-16.04/base.Dockerfile`，可先运行 `task qbox-kodo-base-build` 重建，再重建 Qiniu sandbox template。
+单独运行 UI 测试：`cd ui && bun run test`。
 
-常用验证命令：
+### 沙箱模板
 
-```bash
-task lint
-task test
-task docker-check
-task release-check
-```
+| 模板                                   | 说明                                                               |
+| -------------------------------------- | ------------------------------------------------------------------ |
+| `templates/github-runner-ubuntu-24.04` | 默认 GitHub runner 镜像（runner 运行时、Docker、辅助工具、rclone） |
+| `templates/qbox-kodo-ubuntu-16.04`     | 旧版 Ubuntu 16.04，用于 qbox/kodo 风格的 job                       |
 
-`task test` 会重新构建 UI、运行 Bun UI tests，然后执行带 race detection 和 coverage 的 Go test suite。只运行 UI tests 时，可使用 `cd ui && bun run test`。
+使用 `task template-build-prod` 构建模板。qbox-kodo 基础镜像可通过 `task qbox-kodo-base-build` 单独重建。
 
-目标 workflow 使用 `runs-on: [self-hosted, e2b]`。配置 GitHub webhook，把 `workflow_job` events 发送到 `POST /webhooks/github`；runnerd 处理 `queued`、`in_progress` 和 `completed` actions。也可以加入 `workflow_run` events 作为补偿信号；runnerd 会列出该 run 下所有 queued jobs，并为尚未通过 `workflow_job` 入队的 matching jobs 创建 runner request。
+## 文档
 
-生产风格 readiness pass 请使用 [docs/zh/deployment-smoke.md](docs/zh/deployment-smoke.md)。
+| 文档                                                                                   | 说明                                                    |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| [docs/zh/testing.md](docs/zh/testing.md)                                               | 本地测试、GitHub App/OAuth 设置、webhook 转发、故障排查 |
+| [docs/zh/deployment-smoke.md](docs/zh/deployment-smoke.md)                             | 生产环境就绪检查清单                                    |
+| [docs/zh/runner-architecture-comparison.md](docs/zh/runner-architecture-comparison.md) | 架构图及与 ARC / Fireactions 的对比                     |
+| [docs/zh/runner-implementation-review.md](docs/zh/runner-implementation-review.md)     | 实现状态与 schema 迁移说明                              |

--- a/docs/deployment-smoke.md
+++ b/docs/deployment-smoke.md
@@ -9,7 +9,7 @@ Use this checklist before treating a runnerd deployment as ready for real GitHub
 - A runnerd deployment reachable over HTTPS for GitHub webhooks and console sign-in.
 - A `runnerd.yaml` with `database`, `auth`, `github`, and `worker` sections configured.
 - A GitHub.com App installed on the target repository or organization.
-- The GitHub App has the [required repository and organization permissions](../README.md#github-app-permissions) for the runner modes used by this deployment.
+- The GitHub App has the [required repository and organization permissions](../README.md#required-permissions) for the runner modes used by this deployment.
 - A GitHub App OAuth callback URL pointing at `/auth/github/callback` on the runnerd origin.
 - A GitHub App webhook or repository webhook delivering `workflow_job` events to `POST /webhooks/github`.
 - Sandbox service API URL and API key configured in the target account/organization Preferences page, or an enabled admin fallback at `/admin/sandbox_service`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -93,7 +93,7 @@ RUNNERD_SQLITE_SNAPSHOT=/path/to/runnerd-export.db \
 
 GitHub App is recommended. PAT token and basic auth are also supported, mainly for local verification or existing credential scenarios.
 
-Configure the [required GitHub App permissions](../README.md#github-app-permissions) before continuing. The steps below cover local setup details.
+Configure the [required GitHub App permissions](../README.md#required-permissions) before continuing. The steps below cover local setup details.
 
 Suggested setup:
 
@@ -103,7 +103,7 @@ Suggested setup:
    - Homepage URL: use the repository URL or local project docs URL
    - Setup URL: runnerd's `/github-app/setup`, for example `http://127.0.0.1:25500/github-app/setup`
    - Webhook: if runnerd receives repository webhooks itself, you can leave the App webhook disabled; this is different from the `workflow_job` webhook
-3. Under `Permissions`, apply the settings in the [required permissions table](../README.md#github-app-permissions).
+3. Under `Permissions`, apply the settings in the [required permissions table](../README.md#required-permissions).
 4. Where can this GitHub App be installed:
    - For local verification, usually choose `Only on this account`
 5. After creating the App, generate a private key on the App page, download the `.pem`, and save it locally, for example `./secrets/github-app.pem`
@@ -229,7 +229,7 @@ Ordinary-user page:
 http://127.0.0.1:25500/
 ```
 
-The page redirects to GitHub OAuth login. The first login creates a local account with `role=user` and links the GitHub OAuth identity. The first admin must be explicitly bootstrapped at startup:
+The page redirects to GitHub OAuth login. The first login creates a local account with `role=user` and links the GitHub OAuth identity. The first admin must be bootstrapped as a separate one-time step before starting the server; the command sets the admin role and exits without starting runnerd:
 
 ```bash
 go run ./cmd/runnerd --config ./runnerd.yaml --bootstrap-admin github:<your-github-user-id>
@@ -463,7 +463,7 @@ Common issues:
 - `runner start deferred because global concurrency is at capacity` or `runner start deferred because profile is at capacity`: the request remains queued until global or per-spec capacity is available.
 - GitHub job stays queued: workflow `runs-on` labels must include `self-hosted` and `e2b`, and must match runner spec labels.
 - sandbox creation fails: confirm the account/organization Preferences or enabled admin default has a complete Sandbox service config matching the template and local environment; the Runner detail shows which source was selected.
-- registration token fails: check the [GitHub App permission table](../README.md#github-app-permissions). Specs without `runner_group` require repository `Administration`; specs with `runner_group` require organization `Self-hosted runners`.
+- registration token fails: check the [GitHub App permission table](../README.md#required-permissions). Specs without `runner_group` require repository `Administration`; specs with `runner_group` require organization `Self-hosted runners`.
 
 ## 9. How To Read GitHub Actions Logs
 

--- a/docs/zh/deployment-smoke.md
+++ b/docs/zh/deployment-smoke.md
@@ -9,7 +9,7 @@
 - 一个可通过 HTTPS 接收 GitHub webhooks 和 console 登录的 runnerd 部署。
 - `runnerd.yaml` 已配置 `database`、`auth`、`github` 和 `worker` sections。
 - 目标 repository 或 organization 已安装 GitHub.com App。
-- GitHub App 已配置当前部署所用 runner 模式需要的[仓库级和组织级权限](../../README.zh.md#github-app-权限)。
+- GitHub App 已配置当前部署所用 runner 模式需要的[仓库级和组织级权限](../../README.zh.md#所需权限)。
 - GitHub App OAuth callback URL 指向 runnerd origin 下的 `/auth/github/callback`。
 - GitHub App webhook 或 repository webhook 将 `workflow_job` events 发送到 `POST /webhooks/github`。
 - 目标 account/organization Preferences 已配置 Sandbox service API URL 和 API key，或 `/admin/sandbox_service` 已启用 admin fallback。

--- a/docs/zh/testing.md
+++ b/docs/zh/testing.md
@@ -91,7 +91,7 @@ RUNNERD_SQLITE_SNAPSHOT=/path/to/runnerd-export.db \
 
 推荐使用 GitHub App。PAT token 和 basic auth 也支持，主要用于本地验证或已有凭据场景。
 
-继续前，请先配置[必要的 GitHub App 权限](../../README.zh.md#github-app-权限)。以下步骤只说明本地设置细节。
+继续前，请先配置[必要的 GitHub App 权限](../../README.zh.md#所需权限)。以下步骤只说明本地设置细节。
 
 建议流程：
 
@@ -101,7 +101,7 @@ RUNNERD_SQLITE_SNAPSHOT=/path/to/runnerd-export.db \
    - Homepage URL：先填仓库地址或本地项目文档地址
    - Setup URL：填 runnerd 的 `/github-app/setup` 地址，例如 `http://127.0.0.1:25500/github-app/setup`
    - Webhook：如果 runnerd 自己收 webhook，可以先不开 App webhook，这里和 `workflow_job` webhook 不是一回事
-3. 在 `Permissions` 中应用[必要权限表](../../README.zh.md#github-app-权限)中的设置。
+3. 在 `Permissions` 中应用[必要权限表](../../README.zh.md#所需权限)中的设置。
 4. Where can this GitHub App be installed：
    - 本地验证一般选 `Only on this account`
 5. 创建后，在 App 页面生成 private key，下载 `.pem` 文件，保存到本地，例如 `./secrets/github-app.pem`
@@ -227,7 +227,7 @@ curl -fsS http://127.0.0.1:25500/healthz
 http://127.0.0.1:25500/
 ```
 
-页面会跳转到 GitHub OAuth 登录。首次登录会在数据库中创建 `role=user` 的本地 account，并把 GitHub OAuth identity 绑定到该 account；首个管理员需要在启动时显式 bootstrap：
+页面会跳转到 GitHub OAuth 登录。首次登录会在数据库中创建 `role=user` 的本地 account，并把 GitHub OAuth identity 绑定到该 account；首个管理员需要在启动服务之前单独执行一次 bootstrap 命令；该命令会设置管理员角色后直接退出，不会启动 runnerd：
 
 ```bash
 go run ./cmd/runnerd --config ./runnerd.yaml --bootstrap-admin github:<your-github-user-id>
@@ -461,7 +461,7 @@ curl -fsS -b "$COOKIE_JAR" \
 - `runner start deferred because global concurrency is at capacity` 或 `runner start deferred because profile is at capacity`：request 会保持 queued，直到全局或 per-spec 容量可用。
 - GitHub job 一直 queued：workflow 的 `runs-on` labels 必须包含 `self-hosted` 和 `e2b`，并与 runner spec 的 labels 保持一致。
 - sandbox 创建失败：确认账户/组织 Preferences 或已启用的 admin default 具有与 template 和本地环境匹配的完整 Sandbox service 配置；Runner detail 会显示实际选择的来源。
-- registration token 失败：检查 [GitHub App 权限表](../../README.zh.md#github-app-权限)。未配置 `runner_group` 的 spec 需要 repository `Administration`；配置了 `runner_group` 的 spec 需要 organization `Self-hosted runners`。
+- registration token 失败：检查 [GitHub App 权限表](../../README.zh.md#所需权限)。未配置 `runner_group` 的 spec 需要 repository `Administration`；配置了 `runner_group` 的 spec 需要 organization `Self-hosted runners`。
 
 ## 9. GitHub Actions 日志怎么看
 


### PR DESCRIPTION
Closes #45

## 问题

当前 README 存在以下问题：
- 缺少项目概览，只有一行描述就直接跳到配置
- 没有目录导航，150+ 行难以定位
- 配置部分是一堵文字墙，GitHub App 权限、OAuth、Runner Spec、Admin Console、Worker 行为、pprof 全混在一起
- 实现细节过多（分页 header、expvar metrics、pprof 发现机制等）
- 缺少 Quick Start，用户不知道最小启动步骤

## 改动

- 添加目录（TOC）方便导航
- 添加 **Features** 特性概览
- 添加 **How It Works** 工作原理（含 ASCII 架构图）
- 添加 **Quick Start** 快速开始（最小启动步骤）
- 将配置整理为摘要表格 + 要点说明
- 将 GitHub App 设置（权限表 + OAuth）独立成节
- 添加 Webhook & Workflow 配置说明
- 添加 Runner Spec 与 Policy 说明
- 添加 Admin Console 路由表
- 整理 Build & Development 命令表
- 添加文档索引表，链接到 docs/
- 将实现细节（pprof、expvar、分页 header、pre-job hook、token 缓存）移至 docs/（这些内容在 docs/ 中已有覆盖）
- 保持 README.md 和 README.zh.md 结构对齐