### PR TITLE
perf(ui): cache and compress production assets

### DIFF
--- a/docs/deployment-smoke.md
+++ b/docs/deployment-smoke.md
@@ -28,6 +28,20 @@ curl -fsS https://<runnerd-host>/healthz
 
 Expected result: HTTP 200 with `status: ok`.
 
+Verify the production UI cache and compression headers using the current hashed JavaScript or CSS path from `index.html`:
+
+```bash
+curl -sS -D - -o /dev/null https://<runnerd-host>/
+curl -sS --compressed -D - -o /dev/null https://<runnerd-host>/assets/<current-hashed-asset>.js
+```
+
+Expected result:
+
+- The HTML shell returns `Cache-Control: no-store`.
+- Content-hashed files under `/assets/` return `Cache-Control: public, max-age=31536000, immutable`.
+- Large JavaScript and CSS responses return `Content-Encoding: gzip` when the request accepts gzip, plus `Vary: Accept-Encoding`.
+- Unversioned static files use a short browser cache instead of the immutable policy.
+
 Log in through the admin console:
 
 ```text

--- a/docs/zh/deployment-smoke.md
+++ b/docs/zh/deployment-smoke.md
@@ -28,6 +28,20 @@ curl -fsS https://<runnerd-host>/healthz
 
 预期结果：HTTP 200，响应包含 `status: ok`。
 
+从 `index.html` 找到当前带哈希的 JavaScript 或 CSS 路径，验证生产 UI 的缓存和压缩响应头：
+
+```bash
+curl -sS -D - -o /dev/null https://<runnerd-host>/
+curl -sS --compressed -D - -o /dev/null https://<runnerd-host>/assets/<current-hashed-asset>.js
+```
+
+预期结果：
+
+- HTML shell 返回 `Cache-Control: no-store`。
+- `/assets/` 下带内容哈希的文件返回 `Cache-Control: public, max-age=31536000, immutable`。
+- 请求接受 gzip 时，大型 JavaScript 和 CSS 响应返回 `Content-Encoding: gzip`，同时包含 `Vary: Accept-Encoding`。
+- 未版本化的静态文件使用短期浏览器缓存，而不是 immutable 策略。
+
 通过 admin console 登录：
 
 ```text

--- a/internal/server/ui_assets_production.go
+++ b/internal/server/ui_assets_production.go
@@ -3,18 +3,36 @@
 package server
 
 import (
+	"bytes"
+	"compress/gzip"
 	"embed"
 	"mime"
 	"net/http"
 	"path"
+	"strconv"
+	"strings"
+	"sync"
 )
 
 const uiAssetsDevelopment = false
 
+const (
+	immutableUIAssetCacheControl = "public, max-age=31536000, immutable"
+	shortUIAssetCacheControl     = "public, max-age=3600"
+	minimumGzipUIAssetSize       = 1024
+)
+
 //go:embed ui/*
 var uiAssets embed.FS
 
-func (s *Server) serveUIAsset(w http.ResponseWriter, _ *http.Request, name string) bool {
+type cachedGzipUIAsset struct {
+	once sync.Once
+	data []byte
+}
+
+var gzipUIAssetCache sync.Map
+
+func (s *Server) serveUIAsset(w http.ResponseWriter, r *http.Request, name string) bool {
 	data, err := uiAssets.ReadFile("ui" + name)
 	if err != nil {
 		if path.Ext(name) != "" {
@@ -34,9 +52,75 @@ func (s *Server) serveUIAsset(w http.ResponseWriter, _ *http.Request, name strin
 			w.Header().Set("Content-Type", contentType)
 		}
 	}
-	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Cache-Control", uiAssetCacheControl(name))
+	if shouldCompressUIAsset(name, data) {
+		w.Header().Add("Vary", "Accept-Encoding")
+		if acceptsGzip(r.Header.Get("Accept-Encoding")) {
+			w.Header().Set("Content-Encoding", "gzip")
+			_, _ = w.Write(gzipUIAsset(name, data))
+			return true
+		}
+	}
 	_, _ = w.Write(data)
 	return true
+}
+
+func gzipUIAsset(name string, data []byte) []byte {
+	value, _ := gzipUIAssetCache.LoadOrStore(name, &cachedGzipUIAsset{})
+	cached := value.(*cachedGzipUIAsset)
+	cached.once.Do(func() {
+		var compressed bytes.Buffer
+		writer := gzip.NewWriter(&compressed)
+		_, _ = writer.Write(data)
+		_ = writer.Close()
+		cached.data = compressed.Bytes()
+	})
+	return cached.data
+}
+
+func uiAssetCacheControl(name string) string {
+	if name == "/index.html" {
+		return "no-store"
+	}
+	if strings.HasPrefix(name, "/assets/") {
+		return immutableUIAssetCacheControl
+	}
+	return shortUIAssetCacheControl
+}
+
+func shouldCompressUIAsset(name string, data []byte) bool {
+	if len(data) < minimumGzipUIAssetSize {
+		return false
+	}
+	switch strings.ToLower(path.Ext(name)) {
+	case ".css", ".html", ".js", ".json", ".mjs", ".svg":
+		return true
+	default:
+		return false
+	}
+}
+
+func acceptsGzip(header string) bool {
+	for _, value := range strings.Split(header, ",") {
+		parts := strings.Split(value, ";")
+		if !strings.EqualFold(strings.TrimSpace(parts[0]), "gzip") {
+			continue
+		}
+		quality := 1.0
+		for _, parameter := range parts[1:] {
+			keyValue := strings.SplitN(parameter, "=", 2)
+			if len(keyValue) != 2 || !strings.EqualFold(strings.TrimSpace(keyValue[0]), "q") {
+				continue
+			}
+			parsed, err := strconv.ParseFloat(strings.TrimSpace(keyValue[1]), 64)
+			if err != nil {
+				return false
+			}
+			quality = parsed
+		}
+		return quality > 0
+	}
+	return false
 }
 
 func fallbackContentType(ext string) string {

--- a/internal/server/ui_assets_production_test.go
+++ b/internal/server/ui_assets_production_test.go
@@ -2,7 +2,16 @@
 
 package server
 
-import "testing"
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
 
 func TestFallbackContentTypeForWebAssets(t *testing.T) {
 	tests := map[string]string{
@@ -22,4 +31,171 @@ func TestFallbackContentTypeForWebAssets(t *testing.T) {
 	if got := fallbackContentType(".txt"); got != "" {
 		t.Fatalf("fallbackContentType for unknown extension = %q, want empty", got)
 	}
+}
+
+func TestServeUIAssetUsesRouteSpecificCachePolicy(t *testing.T) {
+	hashedAsset := firstEmbeddedUIAssetWithSuffix(t, ".js")
+	tests := []struct {
+		name         string
+		requestPath  string
+		assetName    string
+		cacheControl string
+	}{
+		{
+			name:         "html shell",
+			requestPath:  "/",
+			assetName:    "/index.html",
+			cacheControl: "no-store",
+		},
+		{
+			name:         "spa fallback",
+			requestPath:  "/github/pulls/qiniu/ci-runner/39/jobs",
+			assetName:    "/github/pulls/qiniu/ci-runner/39/jobs",
+			cacheControl: "no-store",
+		},
+		{
+			name:         "content hashed asset",
+			requestPath:  hashedAsset,
+			assetName:    hashedAsset,
+			cacheControl: "public, max-age=31536000, immutable",
+		},
+		{
+			name:         "unversioned static asset",
+			requestPath:  "/favicon.svg",
+			assetName:    "/favicon.svg",
+			cacheControl: "public, max-age=3600",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.requestPath, nil)
+			rec := httptest.NewRecorder()
+
+			if served := (&Server{}).serveUIAsset(rec, req, tt.assetName); !served {
+				t.Fatalf("serveUIAsset(%q) = false, want true", tt.assetName)
+			}
+			if got := rec.Header().Get("Cache-Control"); got != tt.cacheControl {
+				t.Fatalf("Cache-Control = %q, want %q", got, tt.cacheControl)
+			}
+		})
+	}
+}
+
+func TestServeUIAssetCompressesLargeTextAssetsWhenGzipIsAccepted(t *testing.T) {
+	assetName := firstEmbeddedUIAssetWithSuffix(t, ".js")
+	want, err := uiAssets.ReadFile("ui" + assetName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, assetName, nil)
+	req.Header.Set("Accept-Encoding", "br, gzip")
+	rec := httptest.NewRecorder()
+
+	if served := (&Server{}).serveUIAsset(rec, req, assetName); !served {
+		t.Fatalf("serveUIAsset(%q) = false, want true", assetName)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	if got := rec.Header().Values("Vary"); !containsHeaderToken(got, "Accept-Encoding") {
+		t.Fatalf("Vary = %q, want Accept-Encoding", got)
+	}
+	reader, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("decompressed response does not match embedded asset")
+	}
+}
+
+func TestServeUIAssetDoesNotCompressWhenGzipIsRejected(t *testing.T) {
+	assetName := firstEmbeddedUIAssetWithSuffix(t, ".js")
+	want, err := uiAssets.ReadFile("ui" + assetName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, assetName, nil)
+	req.Header.Set("Accept-Encoding", "br, gzip;q=0")
+	rec := httptest.NewRecorder()
+
+	if served := (&Server{}).serveUIAsset(rec, req, assetName); !served {
+		t.Fatalf("serveUIAsset(%q) = false, want true", assetName)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("Content-Encoding = %q, want empty", got)
+	}
+	if got := rec.Header().Values("Vary"); !containsHeaderToken(got, "Accept-Encoding") {
+		t.Fatalf("Vary = %q, want Accept-Encoding", got)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), want) {
+		t.Fatal("identity response does not match embedded asset")
+	}
+}
+
+func TestGzipUIAssetReusesOneResultAcrossConcurrentRequests(t *testing.T) {
+	data := bytes.Repeat([]byte("immutable-ui-asset"), 1024)
+	const requestCount = 16
+	start := make(chan struct{})
+	results := make(chan []byte, requestCount)
+	var wg sync.WaitGroup
+	for range requestCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			results <- gzipUIAsset("/assets/cache-test.js", data)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var first []byte
+	for result := range results {
+		if len(result) == 0 {
+			t.Fatal("gzipUIAsset returned an empty result")
+		}
+		if first == nil {
+			first = result
+			continue
+		}
+		if &result[0] != &first[0] {
+			t.Fatal("gzipUIAsset did not reuse the cached compressed bytes")
+		}
+	}
+}
+
+func firstEmbeddedUIAssetWithSuffix(t *testing.T, suffix string) string {
+	t.Helper()
+	entries, err := uiAssets.ReadDir("ui/assets")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), suffix) {
+			return "/assets/" + entry.Name()
+		}
+	}
+	t.Fatalf("no embedded UI asset with suffix %q", suffix)
+	return ""
+}
+
+func containsHeaderToken(values []string, token string) bool {
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), token) {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- add route-specific cache headers for the production UI
- cache content-hashed assets for one year with `immutable`
- keep the HTML shell uncached and give unversioned assets a short cache
- gzip large text assets and reuse one concurrency-safe compressed result per embedded asset
- document production cache and compression smoke checks

## Root cause

Production UI responses used `Cache-Control: no-store` for every embedded asset, so browsers repeatedly downloaded unchanged content-hashed JavaScript and CSS. Compressing each response dynamically would also add repeated CPU and latency, so compressed bytes are now generated once per process and shared safely across concurrent requests.

## Impact

Repeat visits can reuse immutable content-hashed assets, while deployments still pick up a new HTML shell and newly hashed filenames. Large text assets transfer fewer bytes without recompressing them on every request. No database or data migration is required.

## Validation

- `task lint`
- `task test`
- `git diff --check`
