### PR TITLE
fix(ui): harden auth session loading

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner"
 import { AppSidebar } from "@/components/app-sidebar"
 import { AccountsSection } from "@/components/accounts-section"
 import { AuditSection, DiagnosticsSection, MatchSection, OverviewSection } from "@/components/admin-sections"
-import { AccessDeniedPage, NotFoundPage, SessionLoadingPage, SignInPage } from "@/components/auth-pages"
+import { AccessDeniedPage, NotFoundPage, SessionErrorPage, SessionLoadingPage, SignInPage } from "@/components/auth-pages"
 import { LandingPage } from "@/components/landing-page"
 import { RunnerJobDetail } from "@/components/runner-job-detail"
 import { RunnerGroupsSection } from "@/components/runner-groups-section"
@@ -49,6 +49,7 @@ import {
   adminDataResources,
   adminPollingResources,
   appRouteAccess,
+  authRouteViewState,
   shouldPollAdminSection,
   shouldPollUserRoute,
   userDataResources,
@@ -57,6 +58,7 @@ import {
   userRunnerRequestLimit,
   userRunnerRequestsPath,
   type AdminDataResource,
+  type AuthSessionCheckStatus,
 } from "@/app-load-policy"
 import { useRunnerCatalog } from "@/hooks/use-runner-catalog"
 import {
@@ -121,7 +123,7 @@ function updateAdminResource(
 
 function App() {
   const [authSession, setAuthSession] = useState<AuthSession>({ authenticated: false, oauth_enabled: false })
-  const [authSessionLoaded, setAuthSessionLoaded] = useState(false)
+  const [authSessionStatus, setAuthSessionStatus] = useState<AuthSessionCheckStatus>("checking")
   const [locationPath, setLocationPath] = useState(() => window.location.pathname)
   const [locationSearch, setLocationSearch] = useState(() => window.location.search)
   const [section, setSectionState] = useState<AdminSection>(() => sectionFromPath())
@@ -566,18 +568,21 @@ function App() {
     parseLabels,
   })
 
-  useEffect(() => {
-    void (async () => {
-      try {
-        const response = await fetch("/auth/session", { credentials: "same-origin" })
-        if (response.ok) setAuthSession((await response.json()) as AuthSession)
-      } catch {
-        setAuthSession({ authenticated: false, oauth_enabled: false })
-      } finally {
-        setAuthSessionLoaded(true)
-      }
-    })()
+  const loadAuthSession = useCallback(async () => {
+    setAuthSessionStatus("checking")
+    try {
+      const response = await fetch("/auth/session", { credentials: "same-origin" })
+      if (!response.ok) throw new Error(`session check failed with status ${response.status}`)
+      setAuthSession((await response.json()) as AuthSession)
+      setAuthSessionStatus("ready")
+    } catch {
+      setAuthSessionStatus("error")
+    }
   }, [])
+
+  useEffect(() => {
+    void loadAuthSession()
+  }, [loadAuthSession])
 
   useEffect(() => {
     const handlePopState = () => {
@@ -805,11 +810,17 @@ function App() {
     return <NotFoundPage />
   }
 
-  if (!authSessionLoaded) {
+  const authViewState = authRouteViewState(authSessionStatus, authSession.authenticated)
+
+  if (authViewState === "loading") {
     return <SessionLoadingPage />
   }
 
-  if (!authSession.authenticated) {
+  if (authViewState === "error") {
+    return <SessionErrorPage onRetry={() => void loadAuthSession()} />
+  }
+
+  if (authViewState === "sign-in") {
     return (
       <SignInPage
         oauthEnabled={authSession.oauth_enabled}

--- a/ui/src/app-load-policy.test.js
+++ b/ui/src/app-load-policy.test.js
@@ -96,4 +96,11 @@ describe("app load policy", () => {
       "/auth/github/login?return_to=%2Fjobs%2Fjob-1%3Ftab%3Dlogs",
     )
   })
+
+  test("does not treat an unchecked session as signed out", () => {
+    expect(appPolicy.authRouteViewState?.("checking", false)).toBe("loading")
+    expect(appPolicy.authRouteViewState?.("ready", true)).toBe("authenticated")
+    expect(appPolicy.authRouteViewState?.("ready", false)).toBe("sign-in")
+    expect(appPolicy.authRouteViewState?.("error", false)).toBe("error")
+  })
 })

--- a/ui/src/app-load-policy.ts
+++ b/ui/src/app-load-policy.ts
@@ -12,6 +12,8 @@ export type AdminDataResource =
 
 export type UserDataResource = "github_app" | "runner_requests" | "preferences"
 export type AppRouteAccess = "public" | "user" | "admin" | "not-found"
+export type AuthSessionCheckStatus = "checking" | "ready" | "error"
+export type AuthRouteViewState = "loading" | "authenticated" | "sign-in" | "error"
 
 const adminResourcesBySection: Record<AdminSection, readonly AdminDataResource[]> = {
   overview: ["runner_requests", "runner_specs", "runner_policies"],
@@ -67,6 +69,15 @@ export function appRouteAccess(path: string): AppRouteAccess {
   if (isAdminRoute(path)) return "admin"
   if (isUserRoute(path)) return "user"
   return "not-found"
+}
+
+export function authRouteViewState(
+  status: AuthSessionCheckStatus,
+  authenticated: boolean,
+): AuthRouteViewState {
+  if (status === "checking") return "loading"
+  if (status === "error") return "error"
+  return authenticated ? "authenticated" : "sign-in"
 }
 
 export function signInURL(path: string, search = ""): string {

--- a/ui/src/components/auth-pages.test.js
+++ b/ui/src/components/auth-pages.test.js
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test"
 import { createElement } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 
-import { AccessDeniedPage, NotFoundPage, SessionLoadingPage, SignInPage } from "./auth-pages"
+import * as authPages from "./auth-pages"
+
+const { AccessDeniedPage, NotFoundPage, SessionLoadingPage, SignInPage } = authPages
 
 describe("authentication route pages", () => {
   test("preserves the protected destination through GitHub sign-in", () => {
@@ -52,5 +54,19 @@ describe("authentication route pages", () => {
   test("renders distinct loading and not-found states", () => {
     expect(renderToStaticMarkup(createElement(SessionLoadingPage))).toContain("Checking your session")
     expect(renderToStaticMarkup(createElement(NotFoundPage))).toContain("Page not found")
+  })
+
+  test("offers retry when the session check fails", () => {
+    expect(typeof authPages.SessionErrorPage).toBe("function")
+    if (!authPages.SessionErrorPage) return
+
+    const html = renderToStaticMarkup(
+      createElement(authPages.SessionErrorPage, {
+        onRetry: () => {},
+      }),
+    )
+
+    expect(html).toContain("Unable to check your session")
+    expect(html).toContain("Try again")
   })
 })

--- a/ui/src/components/auth-pages.tsx
+++ b/ui/src/components/auth-pages.tsx
@@ -92,6 +92,24 @@ export function SessionLoadingPage() {
   )
 }
 
+export function SessionErrorPage({ onRetry }: { onRetry: () => void }) {
+  return (
+    <RouteMessagePage
+      eyebrow="Secure route"
+      title="Unable to check your session"
+      description="Runnerd could not confirm your GitHub access. Try again before signing in."
+    >
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex h-11 items-center justify-center rounded-md bg-[#00aae7] px-5 text-sm font-semibold text-[#041018] transition-colors hover:bg-[#27c5f5] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#00aae7]"
+      >
+        Try again
+      </button>
+    </RouteMessagePage>
+  )
+}
+
 function RouteMessagePage({
   eyebrow,
   icon,


### PR DESCRIPTION
## Summary

- model the initial authentication check as explicit `checking`, `ready`, and `error` states
- keep protected routes on a neutral session-loading page until `/auth/session` completes
- show a retryable error page when session verification fails
- cover authenticated, signed-out, loading, and error route states with focused UI tests

## Root cause

The UI originally initialized authentication as signed out before the asynchronous session request completed. On refresh, that allowed the sign-in view to render briefly before the valid session response restored the protected page. The current loading gate prevents that flash; this change makes the state machine explicit and keeps request failures distinct from a confirmed anonymous session.

## User impact

Signed-in users can refresh protected routes without seeing the sign-in page. If runnerd cannot verify the session, users get a clear retry action instead of being incorrectly treated as signed out.

## Validation

- `cd ui && bun test` — 79 tests passed
- `cd ui && bun run lint`
- `task build`
- refreshed `/repositories` with a valid session in the built-in browser; observed the session-loading page followed by the authenticated route, with no sign-in view or console errors

Fixes #40
