### PR TITLE
fix(ui): prevent production chunk cycle

### DIFF
--- a/ui/src/vite-manual-chunks.test.js
+++ b/ui/src/vite-manual-chunks.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+
+import viteConfig from "../vite.config"
+
+describe("Vite manual chunks", () => {
+  test("keeps React ecosystem packages out of the React core chunk", () => {
+    const manualChunks = viteConfig.build?.rollupOptions?.output?.manualChunks
+
+    expect(typeof manualChunks).toBe("function")
+    expect(manualChunks("/app/node_modules/react/index.js")).toBe("vendor-react")
+    expect(manualChunks("/app/node_modules/react-dom/client.js")).toBe("vendor-react")
+    expect(manualChunks("/app/node_modules/scheduler/index.js")).toBe("vendor-react")
+    expect(manualChunks("/app/node_modules/react-remove-scroll/dist/es2015/index.js")).toBeUndefined()
+    expect(manualChunks("/app/node_modules/react-redux/dist/react-redux.mjs")).toBeUndefined()
+    expect(manualChunks("/app/node_modules/react-joyride/dist/index.mjs")).toBeUndefined()
+  })
+})

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -33,9 +33,9 @@ export default defineConfig({
       output: {
         manualChunks(id) {
           if (
-            id.includes("node_modules/react") ||
-            id.includes("node_modules/react-dom") ||
-            id.includes("node_modules/scheduler")
+            id.includes("node_modules/react/") ||
+            id.includes("node_modules/react-dom/") ||
+            id.includes("node_modules/scheduler/")
           ) {
             return "vendor-react"
           }


### PR DESCRIPTION
## Summary

- restrict the React vendor chunk to React core packages
- keep React ecosystem dependencies out of the forced core chunk
- add regression coverage for manual chunk classification

## Root cause

The production build grouped packages such as react-remove-scroll into vendor-react while Radix packages were forced into vendor-radix. This produced a circular ES module initialization path between the two chunks and stopped React before it mounted, leaving the deployed homepage blank.

## Impact

Production bundles no longer create the vendor-react to vendor-radix cycle that caused the homepage to fail during module initialization.

## Verification

- task lint
- task test: 119 UI tests and all Go race and coverage tests passed
- production build completed without the circular chunk warning
- the built homepage rendered in a real browser with no console errors or warnings