### PR TITLE
docs(readme): 补充应用市场部署链接和图文使用指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="./README.zh.md">中文</a> ·
   <a href="#quick-start">Quick Start</a> ·
-  <a href="https://app-6a6b0d723d3a24e095531129.app.qiniucc.com/">Deploy on Qiniu</a> ·
+  <a href="https://app-6a6b0d723d3a24e095531129.app.qiniucc.com/">Deploy to Qiniu LAS</a> ·
   <a href="https://github.com/qiniu/ci-runner/issues/59">Deployment Guide</a> ·
   <a href="#documentation">Documentation</a> ·
   <a href="#license">License</a> ·

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 <p align="center">
   <a href="./README.zh.md">中文</a> ·
   <a href="#quick-start">Quick Start</a> ·
+  <a href="https://app-6a6b0d723d3a24e095531129.app.qiniucc.com/">Deploy on Qiniu</a> ·
+  <a href="https://github.com/qiniu/ci-runner/issues/59">Deployment Guide</a> ·
   <a href="#documentation">Documentation</a> ·
   <a href="#license">License</a> ·
   <a href="#community--contributing">Community &amp; Contributing</a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="./README.md">English</a> ·
   <a href="#快速开始">快速开始</a> ·
-  <a href="https://app-6a6b0d723d3a24e095531129.app.qiniucc.com/">七牛云一键部署</a> ·
+  <a href="https://app-6a6b0d723d3a24e095531129.app.qiniucc.com/">一键部署到七牛云 LAS</a> ·
   <a href="https://github.com/qiniu/ci-runner/issues/59">部署使用指南</a> ·
   <a href="#文档">文档</a> ·
   <a href="#许可证">许可证</a> ·

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,6 +7,8 @@
 <p align="center">
   <a href="./README.md">English</a> ·
   <a href="#快速开始">快速开始</a> ·
+  <a href="https://app-6a6b0d723d3a24e095531129.app.qiniucc.com/">七牛云一键部署</a> ·
+  <a href="https://github.com/qiniu/ci-runner/issues/59">部署使用指南</a> ·
   <a href="#文档">文档</a> ·
   <a href="#许可证">许可证</a> ·
   <a href="#社区与贡献">社区与贡献</a>


### PR DESCRIPTION
## 变更内容

在 README.md 和 README.zh.md 顶部导航栏中补充两个链接：

- **七牛云一键部署**：https://app-6a6b0d723d3a24e095531129.app.qiniucc.com/
- **部署使用指南（图文版）**：https://github.com/qiniu/ci-runner/issues/59

## 关联 Issue

Closes #60