### PR TITLE
feat(runners): add managed default runner specs

### DIFF
--- a/.agents/rules/project-architecture.md
+++ b/.agents/rules/project-architecture.md
@@ -41,7 +41,7 @@
 - Runtime state can use sqlite, Postgres, or MySQL.
 - Do not document multi-instance support until two runnerd processes have been verified against the same database.
 - State schema is defined mostly by GORM tags in `internal/state/records.go`.
-- Startup migration runs a narrow legacy compatibility pass in `internal/state/db.go`, then GORM `AutoMigrate`. Existing SQLite `runner_requests` tables use additive missing-column/index migration instead of generic table recreation so ALTER-added historical fields remain intact.
+- Startup migration runs a narrow legacy compatibility pass in `internal/state/db.go`, then GORM `AutoMigrate`. Existing SQLite `runner_requests` and `runner_profiles` tables use additive missing-column/index migration instead of generic table recreation so ALTER-added runner-request fields and legacy runner-profile rows and indexes remain intact.
 - GORM foreign-key creation is intentionally disabled. Legacy compatibility may remove old constraints or reset incompatible legacy scope tables; keep every such action narrow and covered by old-schema tests. Pre-scope account preference/secret rows are intentionally erased, requiring Sandbox reconfiguration and GitHub reauthentication before installation sync.
 - Keep old-schema upgrade tests when changing state records, GORM tags, indexes, required columns, or relationship constraints.
 - Do not reintroduce legacy `users` migration behavior unless the user explicitly asks for that compatibility path.

--- a/.agents/rules/testing-and-verification.md
+++ b/.agents/rules/testing-and-verification.md
@@ -36,7 +36,7 @@ go test ./...
 task test
 ```
 
-Old-schema upgrade coverage is required when adding required columns, changing uniqueness semantics, or altering relationship constraints. Fresh sqlite creation is not enough. Existing SQLite `runner_requests` migration is additive-only; non-additive changes require an explicit compatibility helper instead of generic table recreation. Assert preserved Installation ID, Sandbox snapshot fields, and `updated_at` values where migration promises preservation, and explicit data reset where the compatibility contract requires reconfiguration. For production snapshots, compare total rows plus populated `github_installation_id`, `sandbox_api_url`, `sandbox_api_key_encrypted`, and `sandbox_config_source` counts across two consecutive starts.
+Old-schema upgrade coverage is required when adding required columns, changing uniqueness semantics, or altering relationship constraints. Fresh sqlite creation is not enough. Existing SQLite `runner_requests` and `runner_profiles` migrations are additive-only; non-additive changes require an explicit compatibility helper instead of generic table recreation. Assert preserved Installation ID, Sandbox snapshot fields, and `updated_at` values where migration promises preservation; preserve runner-profile rows and existing indexes while adding all missing model fields; and assert explicit data reset where the compatibility contract requires reconfiguration. For production snapshots, compare total rows plus populated `github_installation_id`, `sandbox_api_url`, `sandbox_api_key_encrypted`, and `sandbox_config_source` counts across two consecutive starts.
 
 Use the state-only snapshot gate when a production export is available:
 

--- a/.agents/skills/runnerd-state-schema/SKILL.md
+++ b/.agents/skills/runnerd-state-schema/SKILL.md
@@ -21,7 +21,7 @@ Keep runnerd's database schema model-driven through GORM while preserving known 
 
 ## Rules
 
-- Prefer GORM tags and `AutoMigrate` for normal schema source of truth. Existing SQLite `runner_requests` tables are additive-only: create missing model columns and indexes without generic table recreation.
+- Prefer GORM tags and `AutoMigrate` for normal schema source of truth. Existing SQLite `runner_requests` and `runner_profiles` tables are additive-only: create missing model columns and indexes without generic table recreation.
 - Use handwritten SQL only for genuine GORM gaps.
 - Keep every legacy compatibility action narrow and explicit. This includes column additions, obsolete constraint removal, and destructive reset of legacy tables that cannot represent the current scope model. Document required operator reconfiguration and user reauthentication.
 - GORM foreign-key creation is disabled intentionally. Preserve the foreign-keyless schema convention unless a separately tested migration changes it.
@@ -44,9 +44,9 @@ sed -n '1,220p' internal/state/db.go
 rg -n "Migrate|Legacy|default_available|runner_group_name|AutoMigrate" internal/state
 ```
 
-3. For schema edits, update the model tags first. Change `migrateLegacySchemaColumns` only when old databases cannot safely migrate through `AutoMigrate` alone. Keep existing SQLite `runner_requests` changes additive; any non-additive change requires a narrow explicit compatibility migration. Cover column additions, constraint removal, or legacy-table reset with an old-schema fixture that proves the required cleanup and asserts preservation or intentional data loss according to the compatibility contract.
+3. For schema edits, update the model tags first. Change `migrateLegacySchemaColumns` only when old databases cannot safely migrate through `AutoMigrate` alone. Keep existing SQLite `runner_requests` and `runner_profiles` changes additive; any non-additive change requires a narrow explicit compatibility migration. Cover column additions, constraint removal, or legacy-table reset with an old-schema fixture that proves the required cleanup and asserts preservation or intentional data loss according to the compatibility contract.
 
-4. Add or update tests before relying on the fix. Include old sqlite upgrade coverage for required columns, unique indexes with existing rows, and relationship changes. Assert preservation of `github_installation_id`, Sandbox snapshot fields, and `updated_at` for existing runner requests.
+4. Add or update tests before relying on the fix. Include old sqlite upgrade coverage for required columns, unique indexes with existing rows, and relationship changes. Assert preservation of `github_installation_id`, Sandbox snapshot fields, and `updated_at` for existing runner requests; preserve runner-profile rows and existing indexes while adding every missing model field.
 
 5. Run:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,21 @@ Use this guide for future Codex or agent work in this repository.
 - Current admin browser routes include `/admin/`, `/admin/accounts`, and `/admin/sandbox_service`; keep admin routes and role-gated APIs explicit when changing shared `ui/` code.
 - `/admin/accounts` lists OAuth/bootstrap-created accounts and linked identities. Its only mutation changes another account's `admin`/`user` role atomically with an audit event; self-role changes and changes that could leave no administrator are rejected.
 - Runtime state can use sqlite, Postgres, or MySQL. Do not document multi-instance support until two runnerd processes have been verified against the same database.
-- State schema is defined mostly by GORM tags in `internal/state/records.go`; startup migration runs a narrow legacy compatibility pass and then `AutoMigrate` in `internal/state/db.go`. Existing SQLite `runner_requests` tables are the exception: migrate them additively by creating missing columns and indexes because generic table recreation can erase ALTER-added historical values. GORM foreign-key creation is disabled intentionally, so preserve the foreign-keyless schema convention unless a separately tested migration changes it. Legacy account preference/secret tables without scope columns are intentionally reset; operator docs must warn about Sandbox reconfiguration and GitHub reauthentication before installation sync.
+- State schema is defined mostly by GORM tags in `internal/state/records.go`; startup migration runs a narrow legacy compatibility pass and then `AutoMigrate` in `internal/state/db.go`. Existing SQLite `runner_requests` and `runner_profiles` tables are the exceptions: migrate their missing model columns and indexes additively because generic table recreation can erase ALTER-added runner-request values or legacy runner-profile rows and custom indexes. GORM foreign-key creation is disabled intentionally, so preserve the foreign-keyless schema convention unless a separately tested migration changes it. Legacy account preference/secret tables without scope columns are intentionally reset; operator docs must warn about Sandbox reconfiguration and GitHub reauthentication before installation sync.
 - Runner specs, runner groups, and repository policies are admin API/UI data, not `runnerd.yaml` fields.
+- Runner Spec matching must preserve
+  `required_labels ⊆ job_labels ⊆ labels`. Managed Ubuntu defaults require
+  both `qiniu` and the exact OS label; never broaden them to accept partial
+  label sets or unsupported extra labels.
+- runnerd owns the managed catalog's labels, required labels, stable public
+  template name, priority, and default availability. Operators own
+  `enabled`, `max_concurrency`, and `min_idle`. Custom specs remain
+  operator-owned, retain explicit `template_id`, edit/delete behavior, and no
+  save-time Sandbox validation.
+- Resolve a managed spec's stable public template name against the
+  account/organization scoped Sandbox endpoint immediately before runner
+  registration. Never persist one region's default-template ID in a managed
+  spec.
 - The recommended production GitHub auth path is GitHub App auth for runner operations plus GitHub App OAuth sign-in for ordinary users and administrators. Local account roles authorize management APIs. Token and basic auth still exist as compatibility modes, but their long-term product status is undecided.
 
 ## Common Commands

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ cp runnerd.yaml.example runnerd.yaml
 
 5. Open `http://<host>:25500/` and sign in with GitHub OAuth. The public product landing page links to the current GitHub documentation and the protected Jobs console at `/jobs`. On the first authenticated visit to `/jobs`, a six-step product tour introduces Jobs, Repositories, Settings, and Sandbox setup; it can be replayed from the account menu.
 6. Open **Repositories** to review **Runner readiness** for the account or organization. Ready sources are shown without configuration controls. If Sandbox setup is missing and you can manage that scope, use **Configure Sandbox** to open the exact account or organization **Preferences** page and configure **Sandbox Service** credentials. Settings lists only your account and organizations where you are an active member; outside collaborators receive a read-only readiness prompt and cannot browse that organization's Sandbox catalogs. Administrators can provide a fallback at `/admin/sandbox_service`.
-7. After the public-template two-region release gate is complete, confirm the five managed Qiniu Runner Specs in the **Admin Console**. Until then, create a custom spec with a meaningful label and an explicit `template_id`.
+7. Confirm the five managed Qiniu Runner Specs in the **Admin Console**. Their public templates have passed the two-region release gate; operators can still disable individual managed specs or adjust their concurrency and idle capacity.
 8. Configure a GitHub webhook → `POST http://<host>:25500/webhooks/github`.
-9. After that release gate, use `runs-on: [qiniu, ubuntu-24.04]` for a managed default; otherwise use the labels required by your custom spec.
+9. Use `runs-on: [qiniu, ubuntu-24.04]` for a managed default, or use the labels required by your custom spec.
 
 For local development, use `task dev` with `runnerd.local.yaml`. See [docs/testing.md](docs/testing.md) for detailed local setup including GitHub App creation and webhook forwarding.
 
@@ -156,8 +156,7 @@ In your GitHub App settings (**Settings → Developer settings → GitHub Apps �
 ## Webhook & Workflow Setup
 
 1. Ensure the GitHub App webhook is configured as described in [Webhook Events](#webhook-events) above, with the `webhook_secret` matching `github.webhook_secret` in your config.
-2. After the [public-template release gate](docs/default-runner-templates.md)
-   reports both regions verified, use:
+2. Use a verified managed label pair, for example:
 
 ```yaml
 runs-on: [qiniu, ubuntu-24.04]

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ cp runnerd.yaml.example runnerd.yaml
 ./bin/runnerd --config runnerd.yaml
 ```
 
-5. Open `http://<host>:25500/`. The public product landing page links to the current GitHub documentation and the protected Jobs console at `/jobs`. On the first authenticated visit to `/jobs`, a six-step product tour introduces Jobs, Repositories, Settings, and Sandbox setup; it can be replayed from the account menu.
-6. Open **Repositories** to review **Runner readiness** for the account or organization. Ready sources are shown without configuration controls. If Sandbox setup is missing and you can manage that scope, use **Configure Sandbox** to open the exact account or organization Settings page. Settings lists only your account and organizations where you are an active member; outside collaborators receive a read-only readiness prompt and cannot browse that organization's Sandbox catalogs.
-7. In the **Admin Console**, create a **Runner Spec** with a meaningful label (e.g. `ubuntu-24-04`), set its `template_id`, and enable `default_available`.
+5. Open `http://<host>:25500/` and sign in with GitHub OAuth. The public product landing page links to the current GitHub documentation and the protected Jobs console at `/jobs`. On the first authenticated visit to `/jobs`, a six-step product tour introduces Jobs, Repositories, Settings, and Sandbox setup; it can be replayed from the account menu.
+6. Open **Repositories** to review **Runner readiness** for the account or organization. Ready sources are shown without configuration controls. If Sandbox setup is missing and you can manage that scope, use **Configure Sandbox** to open the exact account or organization **Preferences** page and configure **Sandbox Service** credentials. Settings lists only your account and organizations where you are an active member; outside collaborators receive a read-only readiness prompt and cannot browse that organization's Sandbox catalogs. Administrators can provide a fallback at `/admin/sandbox_service`.
+7. After the public-template two-region release gate is complete, confirm the five managed Qiniu Runner Specs in the **Admin Console**. Until then, create a custom spec with a meaningful label and an explicit `template_id`.
 8. Configure a GitHub webhook → `POST http://<host>:25500/webhooks/github`.
-9. Use `runs-on: [self-hosted, <your-runner-label>]` in your workflow.
+9. After that release gate, use `runs-on: [qiniu, ubuntu-24.04]` for a managed default; otherwise use the labels required by your custom spec.
 
 For local development, use `task dev` with `runnerd.local.yaml`. See [docs/testing.md](docs/testing.md) for detailed local setup including GitHub App creation and webhook forwarding.
 
@@ -97,7 +97,7 @@ Key notes:
 
 - Relative `database.dsn` and `github.app.private_key_file` paths resolve from the config file's directory.
 - Use SQLite for local and single-node deployments. PostgreSQL and MySQL are supported but multi-instance operation on a shared database has not been verified.
-- Existing SQLite `runner_requests` tables add missing model columns and indexes on startup without table recreation. Creating the list-ordering indexes does not rewrite runner rows, but it can add brief startup I/O and lock contention on a large database; see [docs/testing.md](docs/testing.md) for the migration and query-plan checks.
+- Existing SQLite `runner_requests` and `runner_profiles` tables add missing model columns and indexes on startup without table recreation. This preserves historical runner values plus legacy profile rows and indexes. Creating missing indexes does not rewrite rows, but it can add brief startup I/O and lock contention on a large database; see [docs/testing.md](docs/testing.md) for migration and query-plan checks.
 - GitHub Enterprise Server is **not** supported; use a GitHub.com App.
 - Configure exactly one GitHub auth method: `github.app`, `github.token`, or `github.basic_auth`.
 - When `github.app.installation_id` is omitted, runnerd resolves the installation dynamically per repository, allowing one App to serve multiple accounts.
@@ -156,11 +156,15 @@ In your GitHub App settings (**Settings → Developer settings → GitHub Apps �
 ## Webhook & Workflow Setup
 
 1. Ensure the GitHub App webhook is configured as described in [Webhook Events](#webhook-events) above, with the `webhook_secret` matching `github.webhook_secret` in your config.
-2. In your workflow, use:
+2. After the [public-template release gate](docs/default-runner-templates.md)
+   reports both regions verified, use:
 
 ```yaml
-runs-on: [self-hosted, <your-runner-label>]
+runs-on: [qiniu, ubuntu-24.04]
 ```
+
+The `qiniu` label is mandatory for managed defaults. A custom spec can define
+its own advertised and required labels instead.
 
 runnerd handles `queued`, `in_progress`, and `completed` actions. For `workflow_run`, it lists all queued jobs in the run and enqueues any matching jobs not already seen.
 
@@ -168,13 +172,37 @@ runnerd handles `queued`, `in_progress`, and `completed` actions. For `workflow_
 
 Runner specs, runner groups, and repository policies are managed through the admin API and console — not through `runnerd.yaml`.
 
-- **Runner Spec**: defines a runner label, sandbox template, and optional `runner_group`. Set `default_available: true` to make it available to all allowed repositories.
+- **Managed Runner Spec**: runnerd reconciles five built-in specs for
+  `ubuntu-slim`, `ubuntu-22.04`, `ubuntu-24.04`, preview `ubuntu-26.04`, and
+  `ubuntu-latest`. Their catalog labels, required labels, public template name,
+  priority, and availability are managed by runnerd. Operators retain
+  `enabled`, `max_concurrency`, and `min_idle`.
+- **Custom Runner Spec**: an operator-owned spec with an explicit
+  `template_id`, advertised labels, and optional required labels and
+  `runner_group`. Saving it does not call Sandbox to validate the template.
 - **Runner Group**: when a spec sets `runner_group`, runnerd creates an organization-level runner in that group; otherwise it creates a repository-level runner.
 
 > **⚠️ Personal accounts:** `runner_group` requires the organization-level GitHub API. If the repository belongs to a personal account (not an organization), leave `runner_group` **empty** — otherwise runner registration will fail with a 404 error.
 - **Repository Policy**: grants a specific repository access to additional specs beyond the defaults.
 
-Each spec's `template_id` should point to a Qiniu Sandbox template containing the GitHub runner image. Template access is checked against the repository owner's effective Sandbox service shown under **Repositories → Runner readiness** at sandbox creation time.
+Matching always enforces `required_labels ⊆ job_labels ⊆ labels`. Managed
+Ubuntu specs therefore require both `qiniu` and the exact OS label: neither
+`[ubuntu-24.04]` nor `[qiniu]` is sufficient. Removing `qiniu` from a workflow
+prevents managed-default routing; an operator can also disable an individual
+managed spec in Admin without changing its reconciled catalog identity.
+
+Managed specs store a stable public template name. Immediately before runner
+creation, runnerd resolves that name against the repository owner's scoped
+Sandbox endpoint, so different regions can return different template IDs.
+Custom specs continue to send their stored `template_id` directly.
+`ubuntu-latest` maps to Ubuntu 24.04 in the current catalog revision; changing
+that mapping requires a reviewed catalog update and new regional smoke
+evidence.
+
+See [Public Runner Templates](docs/default-runner-templates.md) for supported
+workflow labels, publication status, and regional verification.
+
+For custom specs, `template_id` should point to a Qiniu Sandbox template containing the GitHub runner image. Template access is checked against the repository owner's effective Sandbox service shown under **Repositories → Runner readiness** at sandbox creation time.
 
 ## Admin Console
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -74,9 +74,9 @@ cp runnerd.yaml.example runnerd.yaml
 
 5. 打开 `http://<host>:25500/`，使用 GitHub OAuth 登录。公开产品首页提供当前 GitHub 文档入口，以及指向 `/jobs` 受保护的 Jobs 控制台入口。用户首次登录访问 `/jobs` 时，会看到介绍 Jobs、Repositories、Settings 和 Sandbox 设置的六步引导；之后可从账户菜单重播。
 6. 打开 **Repositories** 查看账户或组织的 **Runner readiness**。有效来源只显示状态，不提供配置控件；缺少 Sandbox 且用户可管理该 scope 时，通过 **Configure Sandbox** 进入精确的账户或组织 **Preferences** 页面并配置 **Sandbox Service** 凭据。Settings 只列出个人账户和用户属于 active member 的组织；outside collaborator 只能看到 readiness 只读提示，不能浏览该组织的 Sandbox 资源目录。管理员可以在 `/admin/sandbox_service` 配置兜底。
-7. 公共模板完成双区域 release gate 后，在**管理控制台**中确认 5 个 Qiniu managed Runner Specs；在此之前，请创建带有明确 label 和显式 `template_id` 的自定义 spec。
+7. 在**管理控制台**中确认 5 个 Qiniu managed Runner Specs。它们的公共模板已通过双区域 release gate；operator 仍可禁用单个 managed spec，或调整并发与 idle capacity。
 8. 配置 GitHub webhook → `POST http://<host>:25500/webhooks/github`。
-9. 完成 release gate 后，可在 workflow 中配置 `runs-on: [qiniu, ubuntu-24.04]`；否则应配置自定义 spec 要求的 labels。
+9. 在 workflow 中配置 `runs-on: [qiniu, ubuntu-24.04]` 使用 managed default，或配置自定义 spec 要求的 labels。
 
 本地开发请使用 `task dev` 配合 `runnerd.local.yaml`。详细的本地环境搭建（包括 GitHub App 创建和 webhook 转发）请参阅 [docs/zh/testing.md](docs/zh/testing.md)。
 
@@ -156,8 +156,7 @@ unset secret_value
 ## Webhook 与 Workflow 配置
 
 1. 确保已按上述 [Webhook 事件订阅](#webhook-事件订阅) 配置好 GitHub App webhook，且 `webhook_secret` 与配置文件中的 `github.webhook_secret` 一致。
-2. [公共模板 release gate](docs/zh/default-runner-templates.md)确认两个区域都完成
-   验证后，在 workflow 中使用：
+2. 使用已验证的 managed label 组合，例如：
 
 ```yaml
 runs-on: [qiniu, ubuntu-24.04]

--- a/README.zh.md
+++ b/README.zh.md
@@ -72,11 +72,11 @@ cp runnerd.yaml.example runnerd.yaml
 ./bin/runnerd --config runnerd.yaml
 ```
 
-5. 打开 `http://<host>:25500/`。公开产品首页提供当前 GitHub 文档入口，以及指向 `/jobs` 受保护的 Jobs 控制台入口。用户首次登录访问 `/jobs` 时，会看到介绍 Jobs、Repositories、Settings 和 Sandbox 设置的六步引导；之后可从账户菜单重播。
-6. 打开 **Repositories** 查看账户或组织的 **Runner readiness**。有效来源只显示状态，不提供配置控件；缺少 Sandbox 且用户可管理该 scope 时，通过 **Configure Sandbox** 进入精确的账户或组织 Settings 页面。Settings 只列出个人账户和用户属于 active member 的组织；outside collaborator 只能看到 readiness 只读提示，不能浏览该组织的 Sandbox 资源目录。
-7. 在**管理控制台**中创建 **Runner Spec**，设置有意义的 label（如 `ubuntu-24-04`），填写 `template_id`，并启用 `default_available`。
+5. 打开 `http://<host>:25500/`，使用 GitHub OAuth 登录。公开产品首页提供当前 GitHub 文档入口，以及指向 `/jobs` 受保护的 Jobs 控制台入口。用户首次登录访问 `/jobs` 时，会看到介绍 Jobs、Repositories、Settings 和 Sandbox 设置的六步引导；之后可从账户菜单重播。
+6. 打开 **Repositories** 查看账户或组织的 **Runner readiness**。有效来源只显示状态，不提供配置控件；缺少 Sandbox 且用户可管理该 scope 时，通过 **Configure Sandbox** 进入精确的账户或组织 **Preferences** 页面并配置 **Sandbox Service** 凭据。Settings 只列出个人账户和用户属于 active member 的组织；outside collaborator 只能看到 readiness 只读提示，不能浏览该组织的 Sandbox 资源目录。管理员可以在 `/admin/sandbox_service` 配置兜底。
+7. 公共模板完成双区域 release gate 后，在**管理控制台**中确认 5 个 Qiniu managed Runner Specs；在此之前，请创建带有明确 label 和显式 `template_id` 的自定义 spec。
 8. 配置 GitHub webhook → `POST http://<host>:25500/webhooks/github`。
-9. 在 workflow 中使用 `runs-on: [self-hosted, <your-runner-label>]`。
+9. 完成 release gate 后，可在 workflow 中配置 `runs-on: [qiniu, ubuntu-24.04]`；否则应配置自定义 spec 要求的 labels。
 
 本地开发请使用 `task dev` 配合 `runnerd.local.yaml`。详细的本地环境搭建（包括 GitHub App 创建和 webhook 转发）请参阅 [docs/zh/testing.md](docs/zh/testing.md)。
 
@@ -97,7 +97,7 @@ cp runnerd.yaml.example runnerd.yaml
 
 - 相对路径的 `database.dsn` 和 `github.app.private_key_file` 按配置文件所在目录解析。
 - 本地和单节点部署建议使用 SQLite。支持 PostgreSQL 和 MySQL，但多实例共享数据库尚未验证。
-- 已有 SQLite `runner_requests` 表会在启动时补建缺失的 model columns 和 indexes，不会重建整张表。创建列表排序索引不会重写 runner rows，但大数据库可能出现短暂的启动 I/O 和锁等待；迁移与查询计划检查见 [docs/zh/testing.md](docs/zh/testing.md)。
+- 已有 SQLite `runner_requests` 和 `runner_profiles` 表会在启动时补建缺失的 model columns 和 indexes，不会重建整张表，从而保留历史 runner 字段以及旧 profile rows 和 indexes。创建缺失索引不会重写 rows，但大数据库可能出现短暂的启动 I/O 和锁等待；迁移与查询计划检查见 [docs/zh/testing.md](docs/zh/testing.md)。
 - **不支持** GitHub Enterprise Server，请使用 GitHub.com App。
 - GitHub 鉴权方式三选一：`github.app`、`github.token` 或 `github.basic_auth`。
 - 省略 `github.app.installation_id` 时，runnerd 按仓库动态解析 installation，一个 App 可服务多个账号。
@@ -156,11 +156,15 @@ unset secret_value
 ## Webhook 与 Workflow 配置
 
 1. 确保已按上述 [Webhook 事件订阅](#webhook-事件订阅) 配置好 GitHub App webhook，且 `webhook_secret` 与配置文件中的 `github.webhook_secret` 一致。
-2. 在 workflow 中使用：
+2. [公共模板 release gate](docs/zh/default-runner-templates.md)确认两个区域都完成
+   验证后，在 workflow 中使用：
 
 ```yaml
-runs-on: [self-hosted, <your-runner-label>]
+runs-on: [qiniu, ubuntu-24.04]
 ```
+
+使用 managed defaults 时必须包含 `qiniu` label。自定义 spec 可以定义自己的
+advertised labels 和 required labels。
 
 runnerd 处理 `queued`、`in_progress` 和 `completed` 动作。对于 `workflow_run` 事件，runnerd 会列出该 run 下所有排队 job，并将尚未入队的匹配 job 创建 runner request。
 
@@ -168,14 +172,35 @@ runnerd 处理 `queued`、`in_progress` 和 `completed` 动作。对于 `workflo
 
 Runner spec、runner group 和 repository policy 通过管理 API 和控制台管理，**不在** `runnerd.yaml` 中配置。
 
-- **Runner Spec**：定义 runner label、沙箱模板和可选的 `runner_group`。设置 `default_available: true` 使其对所有允许的仓库可用。
+- **Managed Runner Spec**：runnerd 会协调 `ubuntu-slim`、`ubuntu-22.04`、
+  `ubuntu-24.04`、预览版 `ubuntu-26.04` 和 `ubuntu-latest` 这 5 个内置
+  specs。catalog labels、required labels、公共模板名称、priority 和
+  availability 由 runnerd 管理；operator 仍可控制 `enabled`、
+  `max_concurrency` 和 `min_idle`。
+- **自定义 Runner Spec**：由 operator 管理，保存显式 `template_id`、
+  advertised labels、可选 required labels 和 `runner_group`。保存时不会调用
+  Sandbox 验证模板。
 - **Runner Group**：spec 设置了 `runner_group` 时，runnerd 创建组织级 runner；否则创建仓库级 runner。
 
 > **⚠️ 个人账号注意：** `runner_group` 需要调用组织级 GitHub API。如果仓库属于个人账号（而非组织），必须将 `runner_group` 留**空**，否则 runner 注册会返回 404 错误。
 
 - **Repository Policy**：为特定仓库授权访问默认之外的额外 spec。
 
-每个 spec 的 `template_id` 应指向包含 GitHub runner 镜像的 Qiniu Sandbox 模板。创建沙箱时会使用 **Repositories → Runner readiness** 中显示的仓库 owner 有效 Sandbox service 检查模板访问权限。
+匹配始终遵守 `required_labels ⊆ job_labels ⊆ labels`。因此，managed Ubuntu
+spec 同时要求 `qiniu` 和准确的操作系统 label；`[ubuntu-24.04]` 或 `[qiniu]`
+都不能单独匹配。workflow 移除 `qiniu` 后不会选择 managed defaults；operator
+也可以在 Admin 中单独禁用某个 managed spec，而不改变 runnerd 协调的 catalog
+identity。
+
+Managed spec 保存稳定的公共模板名称。runnerd 会在创建 Runner 前，使用
+repository owner 对应的 scoped Sandbox endpoint 解析该名称，因此不同区域可以
+返回不同的 template ID。自定义 spec 仍直接使用保存的 `template_id`。当前
+catalog revision 中，`ubuntu-latest` 映射到 Ubuntu 24.04；修改映射前必须评审
+catalog 更新并取得新的区域 smoke 证据。
+
+支持的 workflow labels、发布状态和区域验证流程见[公共 Runner 模板](docs/zh/default-runner-templates.md)。
+
+对于自定义 spec，`template_id` 应指向包含 GitHub runner 镜像的 Qiniu Sandbox 模板。创建沙箱时会使用 **Repositories → Runner readiness** 中显示的仓库 owner 有效 Sandbox service 检查模板访问权限。
 
 ## 管理控制台
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,10 +10,6 @@ This file tracks active project work. Completed behavior should move into `READM
 - Verify DB lease behavior with two runnerd processes sharing the same database before documenting multi-instance support.
 - Decide whether expvar diagnostics need a Prometheus/export adapter or histogram-style latency views for deployment observability.
 - After the `ui-production-smoke` check has reported on `main`, enable it as a required status check in branch protection; the repository currently has no required status checks.
-- Complete the remaining Issue #38 release gate: the four physical templates
-  are published and verified in `cn-yangzhou-1` and `us-south-1`; verify all
-  five logical workflow labels through the managed Runner Spec rollout, then
-  close the issue.
 - Decide production credential ownership, approval, and rotation before adding
   a manual `workflow_dispatch` that publishes public Sandbox templates.
 - Keep old-schema upgrade coverage whenever state records or GORM tags change; the current migration path is a narrow legacy compatibility pass followed by `AutoMigrate`, with additive-only handling for existing SQLite `runner_requests` and `runner_profiles`, not a full handwritten migration history.

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@ This file tracks active project work. Completed behavior should move into `READM
   close the issue.
 - Decide production credential ownership, approval, and rotation before adding
   a manual `workflow_dispatch` that publishes public Sandbox templates.
-- Keep old-schema upgrade coverage whenever state records or GORM tags change; the current migration path is a narrow legacy compatibility pass followed by `AutoMigrate`, with additive-only handling for existing SQLite `runner_requests`, not a full handwritten migration history.
+- Keep old-schema upgrade coverage whenever state records or GORM tags change; the current migration path is a narrow legacy compatibility pass followed by `AutoMigrate`, with additive-only handling for existing SQLite `runner_requests` and `runner_profiles`, not a full handwritten migration history.
 
 ## Maintenance
 

--- a/cmd/runnerd/main.go
+++ b/cmd/runnerd/main.go
@@ -17,9 +17,15 @@ import (
 	"github.com/qiniu/ci-runner/internal/config"
 	"github.com/qiniu/ci-runner/internal/github"
 	"github.com/qiniu/ci-runner/internal/redact"
+	"github.com/qiniu/ci-runner/internal/runnercatalog"
 	"github.com/qiniu/ci-runner/internal/server"
 	"github.com/qiniu/ci-runner/internal/state"
 )
+
+type startupStateStore interface {
+	Ensure() error
+	ReconcileManagedProfiles([]state.RunnerProfile) ([]state.ManagedProfileConflict, error)
+}
 
 func main() {
 	configPath := flag.String("config", "runnerd.yaml", "path to runnerd config file")
@@ -43,8 +49,8 @@ func main() {
 		DatabaseDSN:    cfg.StateDatabaseDSN.Value(),
 		MigrateOnStart: true,
 	})
-	if err := store.Ensure(); err != nil {
-		logger.Error("ensure state store", "error", err)
+	if err := initializeStateStore(store, logger); err != nil {
+		logger.Error("initialize state store", "error", err)
 		os.Exit(1)
 	}
 	if *bootstrapAdmin != "" {
@@ -126,6 +132,24 @@ func (g *recoveryGate) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	g.next.ServeHTTP(w, r)
+}
+
+func initializeStateStore(store startupStateStore, logger *slog.Logger) error {
+	if err := store.Ensure(); err != nil {
+		return fmt.Errorf("ensure state store: %w", err)
+	}
+	conflicts, err := store.ReconcileManagedProfiles(runnercatalog.DefaultProfiles())
+	if err != nil {
+		return fmt.Errorf("reconcile managed runner specs: %w", err)
+	}
+	for _, conflict := range conflicts {
+		logger.Warn(
+			"managed runner spec name collision",
+			"name", conflict.Name,
+			"existing_managed_by", conflict.ExistingManagedBy,
+		)
+	}
+	return nil
 }
 
 func runObfuscateConfigValue(input io.Reader, output, errorOutput io.Writer) bool {

--- a/cmd/runnerd/main_test.go
+++ b/cmd/runnerd/main_test.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/qiniu/ci-runner/internal/config"
+	"github.com/qiniu/ci-runner/internal/runnercatalog"
 	"github.com/qiniu/ci-runner/internal/state"
 	"gopkg.in/yaml.v3"
 )
@@ -40,6 +44,81 @@ func TestRecoveryGateAllowsOnlyHealthUntilReady(t *testing.T) {
 	if ready.Code != http.StatusNoContent {
 		t.Fatalf("ready status = %d, want %d", ready.Code, http.StatusNoContent)
 	}
+}
+
+type startupStoreStub struct {
+	ensureErr    error
+	reconcileErr error
+	conflicts    []state.ManagedProfileConflict
+	calls        []string
+	profiles     []state.RunnerProfile
+}
+
+func (s *startupStoreStub) Ensure() error {
+	s.calls = append(s.calls, "ensure")
+	return s.ensureErr
+}
+
+func (s *startupStoreStub) ReconcileManagedProfiles(profiles []state.RunnerProfile) ([]state.ManagedProfileConflict, error) {
+	s.calls = append(s.calls, "reconcile")
+	s.profiles = profiles
+	return s.conflicts, s.reconcileErr
+}
+
+func TestInitializeStateStoreReconcilesDefaultsAfterEnsureAndWarnsOnCollisions(t *testing.T) {
+	store := &startupStoreStub{
+		conflicts: []state.ManagedProfileConflict{
+			{Name: "qiniu-ubuntu-24.04", ExistingManagedBy: ""},
+			{Name: "qiniu-ubuntu-latest", ExistingManagedBy: "another/catalog"},
+		},
+	}
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+
+	if err := initializeStateStore(store, logger); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(store.calls, []string{"ensure", "reconcile"}) {
+		t.Fatalf("calls = %#v, want Ensure before reconciliation", store.calls)
+	}
+	if !reflect.DeepEqual(store.profiles, runnercatalog.DefaultProfiles()) {
+		t.Fatalf("reconciled profiles = %#v, want product defaults", store.profiles)
+	}
+	for _, want := range []string{
+		`"level":"WARN"`,
+		`"name":"qiniu-ubuntu-24.04"`,
+		`"existing_managed_by":""`,
+		`"name":"qiniu-ubuntu-latest"`,
+		`"existing_managed_by":"another/catalog"`,
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("logs = %q, missing %q", logs.String(), want)
+		}
+	}
+}
+
+func TestInitializeStateStoreReturnsDatabaseErrors(t *testing.T) {
+	t.Run("ensure", func(t *testing.T) {
+		store := &startupStoreStub{ensureErr: errors.New("open database")}
+		err := initializeStateStore(store, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+		if err == nil || !strings.Contains(err.Error(), "ensure state store") {
+			t.Fatalf("error = %v, want ensure state store failure", err)
+		}
+		if !reflect.DeepEqual(store.calls, []string{"ensure"}) {
+			t.Fatalf("calls = %#v, reconciliation must not run after Ensure failure", store.calls)
+		}
+	})
+
+	t.Run("reconcile", func(t *testing.T) {
+		store := &startupStoreStub{reconcileErr: errors.New("write database")}
+		err := initializeStateStore(store, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+		if err == nil || !strings.Contains(err.Error(), "reconcile managed runner specs") {
+			t.Fatalf("error = %v, want reconciliation failure", err)
+		}
+		if !reflect.DeepEqual(store.calls, []string{"ensure", "reconcile"}) {
+			t.Fatalf("calls = %#v", store.calls)
+		}
+	})
 }
 
 func TestWriteObfuscatedConfigValueReadsSecretFromStdin(t *testing.T) {

--- a/docs/default-runner-templates.md
+++ b/docs/default-runner-templates.md
@@ -10,15 +10,17 @@ fifth image.
 The four physical templates were published, catalog-checked, and release-smoke
 verified in both supported Sandbox regions on 2026-08-03. The regional IDs and
 evidence are retained in [Issue #38](https://github.com/qiniu/ci-runner/issues/38#issuecomment-5164811404).
-The separate managed Runner Spec rollout is still required before the five
-workflow labels are operational. See
+The managed Runner Spec rollout was end-to-end verified on 2026-08-04 CST by
+[GitHub Actions run 30858489153](https://github.com/miclle/qiniu-ci-runner-test/actions/runs/30858489153):
+all five logical labels completed successfully, all five runner requests
+reached `completed`, every Sandbox was cleaned, and no self-hosted runner
+registration remained. See
 [`templates/README.md`](../templates/README.md) for pinned upstream provenance,
 the compatibility contract, and per-image differences.
 
 ## Workflow labels
 
-After the managed Runner Spec rollout is verified, use the exact pair for the
-requested environment:
+Use the exact pair for the requested environment:
 
 ```yaml
 jobs:

--- a/docs/deployment-smoke.md
+++ b/docs/deployment-smoke.md
@@ -13,7 +13,10 @@ Use this checklist before treating a runnerd deployment as ready for real GitHub
 - A GitHub App OAuth callback URL pointing at `/auth/github/callback` on the runnerd origin.
 - A GitHub App webhook or repository webhook delivering `workflow_job` events to `POST /webhooks/github`.
 - Sandbox service API URL and API key configured in the target account/organization Preferences page, or an enabled admin fallback at `/admin/sandbox_service`.
-- At least one Qiniu sandbox template that contains `/opt/actions-runner/config.sh` and `/opt/actions-runner/run.sh`.
+- All four public Qiniu templates built, published, catalog-checked, and
+  smoke-tested in both supported regions according to
+  [Public Runner Templates](default-runner-templates.md). Do not deploy the
+  enabled managed defaults before this gate passes.
 - An admin account bootstrapped by running `runnerd --bootstrap-admin github:<github-user-id>` (sets the admin and exits; run before starting the service).
 
 Do not use real secrets in this document or commit deployment-local files such as `runnerd.local.yaml`, `.smee-url`, sqlite databases, private keys, or cookie jars.
@@ -119,27 +122,53 @@ Before creating runner specs, verify Sandbox credential precedence:
 - Removing an audience entry blocks new fallback resolution without changing an already-snapshotted runner request.
 - Disabling the admin default makes an otherwise unconfigured account fail with `sandbox service not configured`.
 
-Create or confirm a runner spec:
+On startup, confirm runnerd reconciles exactly five managed specs without a
+custom-name conflict:
 
 ```bash
-curl -fsS -X POST https://<runnerd-host>/runner_specs \
-  -b "$COOKIE_JAR" \
-  -H 'content-type: application/json' \
-  -d '{"name":"ubuntu-24-04","labels":["self-hosted","e2b"],"template_id":"<template-id>","max_concurrency":1,"enabled":true,"default_available":true}' | jq
+curl -fsS -b "$COOKIE_JAR" https://<runnerd-host>/runner_specs |
+  jq '[.[] | select(.managed_by == "qiniu/ci-runner") |
+      {name, required_labels, default_template_name, enabled}]'
 ```
 
-If the spec should be restricted, set `default_available: false` and create a runner policy or runner group for the target repository.
+Expected names are `qiniu-ubuntu-slim`, `qiniu-ubuntu-22.04`,
+`qiniu-ubuntu-24.04`, `qiniu-ubuntu-26.04`, and `qiniu-ubuntu-latest`.
+Confirm startup logs contain no managed-profile name collision. In each
+configured Sandbox region, run `task template-defaults-check` and retain the
+four IDs; runnerd must resolve the same stable name through that scoped
+endpoint rather than persist one region's ID.
 
-Run a match test:
+Run positive and negative match tests:
 
 ```bash
 curl -fsS -X POST https://<runnerd-host>/runner_specs/match \
   -b "$COOKIE_JAR" \
   -H 'content-type: application/json' \
-  -d '{"repository_full_name":"<owner>/<repo>","labels":["self-hosted","e2b"]}' | jq
+  -d '{"repository_full_name":"<owner>/<repo>","labels":["qiniu","ubuntu-24.04"]}' | jq
+
+curl -fsS -X POST https://<runnerd-host>/runner_specs/match \
+  -b "$COOKIE_JAR" \
+  -H 'content-type: application/json' \
+  -d '{"repository_full_name":"<owner>/<repo>","labels":["ubuntu-24.04"]}' | jq
+
+curl -fsS -X POST https://<runnerd-host>/runner_specs/match \
+  -b "$COOKIE_JAR" \
+  -H 'content-type: application/json' \
+  -d '{"repository_full_name":"<owner>/<repo>","labels":["qiniu"]}' | jq
 ```
 
-Expected result: the response includes the intended runner spec.
+Expected result: only the first request selects `qiniu-ubuntu-24.04`.
+
+Create one custom regression spec with an explicit template ID and operator
+labels. Confirm saving it does not contact Sandbox, running it uses the stored
+ID, and it can still be edited and deleted:
+
+```bash
+curl -fsS -X POST https://<runnerd-host>/runner_specs \
+  -b "$COOKIE_JAR" \
+  -H 'content-type: application/json' \
+  -d '{"name":"deployment-custom","labels":["self-hosted","deployment-custom"],"required_labels":["deployment-custom"],"template_id":"<private-template-id>","max_concurrency":1,"enabled":true,"default_available":true}' | jq
+```
 
 ## 4. Webhook Delivery
 
@@ -154,7 +183,7 @@ Expected result:
 
 ## 5. Workflow Pickup
 
-Use a minimal workflow:
+Trigger one job for every logical managed label:
 
 ```yaml
 name: runnerd-smoke
@@ -163,8 +192,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  smoke:
-    runs-on: [self-hosted, e2b]
+  slim:
+    runs-on: [qiniu, ubuntu-slim]
+    steps:
+      - run: uname -a
+  ubuntu_22:
+    runs-on: [qiniu, ubuntu-22.04]
+    steps:
+      - run: uname -a
+  ubuntu_24:
+    runs-on: [qiniu, ubuntu-24.04]
+    steps:
+      - run: uname -a
+  ubuntu_26_preview:
+    runs-on: [qiniu, ubuntu-26.04]
+    steps:
+      - run: uname -a
+  latest:
+    runs-on: [qiniu, ubuntu-latest]
     steps:
       - run: |
           uname -a
@@ -177,7 +222,11 @@ Trigger it manually.
 Expected result:
 
 - A runner request appears as `queued`, then `creating`, then `running`.
-- The GitHub Actions job leaves the queued state and runs on an `e2b-*` runner.
+- All five GitHub Actions jobs leave the queued state and run on ephemeral
+  managed runners. The two 24.04 logical labels resolve the 24.04 physical
+  template through the scoped region catalog.
+- Each job starts the requested OS; the 26.04 job is recorded as preview
+  acceptance.
 - The job's `Set up runner` log includes the Qiniu sandbox id, runner request id, and runner name.
 - After the job finishes, the runner request becomes `completed`.
 
@@ -206,16 +255,25 @@ After the workflow completes, verify:
 
 ## 8. Failure Drill
 
-Run one controlled failure while the deployment is still under observation:
+Run controlled routing and operator-control checks while the deployment is
+still under observation:
 
-- Use labels that do not match any runner spec, or
-- temporarily disable the matched runner spec, or
-- lower the spec concurrency and trigger two jobs.
+- Trigger `[ubuntu-24.04]` and `[qiniu]`; both must remain unmatched.
+- Disable `qiniu-ubuntu-24.04` in Admin, restart runnerd, and confirm it remains
+  disabled. Re-enable it and confirm scheduling resumes.
+- Lower a managed spec's concurrency and trigger two jobs.
+- Run the `deployment-custom` spec, confirm its explicit template ID is used,
+  then delete it and confirm managed-spec delete still returns conflict.
 
 Expected result depends on the scenario:
 
 - unmatched labels or disabled specs are recorded as admission failures;
+- reconciliation preserves the operator-controlled disabled state across
+  restart;
 - concurrency pressure leaves later requests queued rather than dropped;
 - retryable placement or rate-limit failures populate `next_retry_at` and remain eligible for later processing.
+
+If routing or template health regresses, disable all five managed specs first.
+Do not delete public templates or custom specs during rollback.
 
 Record any deployment-specific notes outside the repository if they include private hosts, account names, channel URLs, secrets, or cookie data.

--- a/docs/deployment-smoke.md
+++ b/docs/deployment-smoke.md
@@ -230,6 +230,14 @@ Expected result:
 - The job's `Set up runner` log includes the Qiniu sandbox id, runner request id, and runner name.
 - After the job finishes, the runner request becomes `completed`.
 
+Reference evidence: on 2026-08-04 CST,
+[run 30858489153](https://github.com/miclle/qiniu-ci-runner-test/actions/runs/30858489153)
+accepted signed GitHub `workflow_run` and `workflow_job` deliveries and completed
+all five jobs. The five requests reached `completed`, each runner process exited
+cleanly, each Sandbox was cleaned, and the repository had zero self-hosted
+runners afterward. This reference run does not replace verification that the
+deployment's own webhook secret matches its configured GitHub webhook.
+
 ## 6. Restart Recovery
 
 Add a step that runs long enough to restart runnerd while the job is active. Restart only the runnerd service; do not stop the sandbox directly.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -63,11 +63,19 @@ Sandbox service API URL and API Key are not configured in `runnerd.yaml`. After 
 
 The first-use product tour stores only a version, status, and `tour_seen` marker in the existing account-scoped `account_preferences` table under `onboarding/product-tour`; it never stores the Sandbox API Key. A missing or outdated version is returned as `pending` with `tour_seen=false`. Finishing the overlay writes `pending` with `tour_seen=true`, so it does not auto-start again while required setup remains visible. `completed` is written when the signed-in account resolves any effective Sandbox source: custom, inherited, or an eligible admin default. An explicit first-run skip writes `skipped` to dismiss the overlay without hiding required setup. Replaying the tour from the account menu does not reset or replace the persisted state.
 
-Runner spec, runner group, and repository policy are not `runnerd.yaml` fields. Create them from the admin page or admin API after the service starts. Use meaningful spec names such as `ubuntu-24-04`; set `template_id` to the matching Qiniu sandbox template ID. Template access is checked when runnerd starts a sandbox with the account or organization Sandbox service config.
+Runner spec, runner group, and repository policy are not `runnerd.yaml` fields.
+At startup, runnerd reconciles five managed Qiniu Ubuntu specs. It owns their
+labels, required labels, stable public template names, priority, and default
+availability while preserving operator-controlled `enabled`,
+`max_concurrency`, and `min_idle`. Custom specs remain admin API/UI data: give
+them an explicit `template_id`, advertised labels, and optional required
+labels. Custom template access is intentionally not validated at save time.
+It is checked when runnerd starts a sandbox with the account or organization
+Sandbox service config.
 
 `database.backend` supports `sqlite`, `postgres`, and `mysql`. Prefer sqlite for local development. Before documenting shared-database multi-instance deployment as supported, verify lease behavior with two runnerd processes sharing the same database.
 
-The state schema is mainly defined by GORM tags in `internal/state/records.go`. On startup, an existing SQLite `runner_requests` table is migrated additively by creating missing model columns and indexes; it is deliberately excluded from generic SQLite `AutoMigrate` table recreation because historical ALTER-added columns must remain intact. Admin newest-first lists depend on `idx_runner_requests_queued_id` over `(queued_at DESC, id ASC)`. Repository-authorized lists query each installation separately through `idx_runner_requests_github_installation_queued_id` over `(github_installation_id, queued_at DESC, id ASC)`, then merge the bounded results. Creating either missing index does not rewrite rows, but benchmark startup I/O and lock time on a disposable production-sized copy. A future non-additive `runner_requests` change requires a narrow explicit migration and a preserved-data regression fixture. Other tables run through a narrow legacy compatibility pass for older columns, obsolete OAuth constraints, and incompatible legacy scope tables, then run GORM `AutoMigrate`. Legacy `account_preferences` and `account_secrets` tables without `scope_type`/`scope_id` are dropped and recreated rather than data-migrated. Reconfigure their saved Sandbox Preferences and API keys after that upgrade; stored GitHub OAuth tokens are also cleared, so affected users must sign in with GitHub again before syncing installations. When changing state records, indexes, or migration helpers, run at least:
+The state schema is mainly defined by GORM tags in `internal/state/records.go`. On startup, existing SQLite `runner_requests` and `runner_profiles` tables are migrated additively by creating every missing model column and index; they are deliberately excluded from generic SQLite `AutoMigrate` table recreation. This keeps historical ALTER-added runner-request values and preserves legacy runner-profile rows and custom indexes while adding managed-catalog fields. Admin newest-first lists depend on `idx_runner_requests_queued_id` over `(queued_at DESC, id ASC)`. Repository-authorized lists query each installation separately through `idx_runner_requests_github_installation_queued_id` over `(github_installation_id, queued_at DESC, id ASC)`, then merge the bounded results. Creating a missing index does not rewrite rows, but benchmark startup I/O and lock time on a disposable production-sized copy. A future non-additive change to either additive-only table requires a narrow explicit migration and a preserved-data regression fixture. Other tables run through a narrow legacy compatibility pass for older columns, obsolete OAuth constraints, and incompatible legacy scope tables, then run GORM `AutoMigrate`. Legacy `account_preferences` and `account_secrets` tables without `scope_type`/`scope_id` are dropped and recreated rather than data-migrated. Reconfigure their saved Sandbox Preferences and API keys after that upgrade; stored GitHub OAuth tokens are also cleared, so affected users must sign in with GitHub again before syncing installations. When changing state records, indexes, or migration helpers, run at least:
 
 ```bash
 go test ./internal/state -count=1
@@ -340,13 +348,25 @@ browser-unsafe module execution order.
 
 `task test` rebuilds the UI, runs the same Bun suite, and then runs Go tests with race detection and coverage. The Bun suite covers helpers and server-rendered component output; use a real browser to verify navigation, dialogs, avatar loading/fallback, and access transitions after a role change. For onboarding changes, also verify the automatic `/jobs` start, all six targets, the transition to `/account/preferences`, the persistent setup task after the overlay closes, explicit skip persistence, and replay without a state change.
 
-Create a default runner spec first:
+Confirm the reconciled managed specs:
+
+```bash
+curl -fsS -b "$COOKIE_JAR" \
+  http://127.0.0.1:25500/runner_specs |
+  jq '.[] | select(.managed_by == "qiniu/ci-runner") |
+      {name, required_labels, default_template_name, enabled}'
+```
+
+The result should contain exactly `qiniu-ubuntu-slim`,
+`qiniu-ubuntu-22.04`, `qiniu-ubuntu-24.04`, `qiniu-ubuntu-26.04`, and
+`qiniu-ubuntu-latest`. Create a custom spec separately when testing the
+backward-compatible explicit-template path:
 
 ```bash
 curl -fsS -X POST http://127.0.0.1:25500/runner_specs \
   -b "$COOKIE_JAR" \
   -H 'content-type: application/json' \
-  -d '{"name":"ubuntu-24-04","labels":["self-hosted","e2b"],"template_id":"<template id>","max_concurrency":100,"enabled":true,"default_available":true}' | jq
+  -d '{"name":"custom-ubuntu","labels":["self-hosted","custom-ubuntu"],"required_labels":["custom-ubuntu"],"template_id":"<template id>","max_concurrency":1,"enabled":true,"default_available":true}' | jq
 ```
 
 Manually create a runner:
@@ -355,7 +375,7 @@ Manually create a runner:
 curl -fsS -X POST http://127.0.0.1:25500/runner_requests \
   -b "$COOKIE_JAR" \
   -H 'content-type: application/json' \
-  -d '{"id":"manual-001","repository_full_name":"<owner>/<repo>","runner_spec_name":"ubuntu-24-04"}' | jq
+  -d '{"id":"manual-001","repository_full_name":"<owner>/<repo>","runner_spec_name":"qiniu-ubuntu-24.04"}' | jq
 ```
 
 Check state:
@@ -467,14 +487,14 @@ After saving, GitHub sends a ping. The service handles `workflow_job.queued` / `
 Add this to the target repository:
 
 ```yaml
-name: e2b-runner-smoke
+name: qiniu-runner-smoke
 
 on:
   workflow_dispatch:
 
 jobs:
   smoke:
-    runs-on: [self-hosted, e2b]
+    runs-on: [qiniu, ubuntu-24.04]
     steps:
       - name: Print runner info
         run: |
@@ -488,7 +508,7 @@ After triggering `workflow_dispatch`, the expected flow is:
 1. GitHub creates a `workflow_job.queued` webhook.
 2. This service verifies the signature and writes a `queued` runner request into the state database.
 3. The service creates a sandbox, obtains a GitHub registration token, and starts an ephemeral runner inside the sandbox.
-4. The GitHub job is picked up by the `self-hosted,e2b` runner.
+4. The GitHub job is picked up by the managed `qiniu,ubuntu-24.04` runner.
 5. After the runner process exits, the service cleans up the sandbox.
 
 If `Workflow runs` events are also configured, `workflow_run.requested` / `workflow_run.in_progress` are only compensating signals. runnerd queries queued jobs in the run and creates runner requests for matching jobs that have not already been enqueued through `workflow_job`. This compensating action does not immediately make the GitHub Actions UI show the job as running. The UI remains queued / waiting for runner until the ephemeral runner inside the sandbox registers successfully and GitHub assigns it to that job.
@@ -518,7 +538,12 @@ Common issues:
 
 - `invalid signature`: GitHub webhook secret and `github.webhook_secret` do not match.
 - `runner start deferred because global concurrency is at capacity` or `runner start deferred because profile is at capacity`: the request remains queued until global or per-spec capacity is available.
-- GitHub job stays queued: workflow `runs-on` labels must include `self-hosted` and `e2b`, and must match runner spec labels.
+- GitHub job stays queued: a managed default requires both `qiniu` and the
+  exact OS label. `[ubuntu-24.04]`, `[qiniu]`, and unsupported extra labels do
+  not match. For a custom spec, use its advertised and required labels.
+- `template_resolution` admission failure: confirm the repository owner's
+  scoped Sandbox endpoint exposes exactly one public default template with the
+  managed stable name in `ready` or `uploaded` state.
 - sandbox creation fails: confirm the account/organization Preferences or enabled admin default has a complete Sandbox service config matching the template and local environment; the Runner detail shows which source was selected.
 - registration token fails: check the [GitHub App permission table](../README.md#required-permissions). Specs without `runner_group` require repository `Administration`; specs with `runner_group` require organization `Self-hosted runners`.
 

--- a/docs/zh/default-runner-templates.md
+++ b/docs/zh/default-runner-templates.md
@@ -10,15 +10,16 @@ Ubuntu Slim、Ubuntu 22.04、Ubuntu 24.04，以及处于预览阶段的 Ubuntu 2
 4 个物理模板已于 2026-08-03 在两个受支持的 Sandbox 区域完成发布、catalog
 检查和 release smoke 验证；区域 ID 和证据保存在
 [Issue #38](https://github.com/qiniu/ci-runner/issues/38#issuecomment-5164811404)。
-5 个 workflow label 仍需完成独立的 managed Runner Spec rollout 后才能投入
-使用。
+Managed Runner Spec rollout 已于 2026-08-04（CST）通过
+[GitHub Actions run 30858489153](https://github.com/miclle/qiniu-ci-runner-test/actions/runs/30858489153)
+完成端到端验证：5 个逻辑 labels 全部成功，5 条 Runner requests 均进入
+`completed`，所有 Sandbox 均已清理，且未残留 self-hosted Runner registration。
 上游版本来源、兼容性契约和各镜像差异见
 [`templates/README.md`](../../templates/README.md)。
 
 ## Workflow labels
 
-完成 managed Runner Spec rollout 验证后，请根据所需环境使用准确的 label
-组合：
+请根据所需环境使用准确的 label 组合：
 
 ```yaml
 jobs:

--- a/docs/zh/deployment-smoke.md
+++ b/docs/zh/deployment-smoke.md
@@ -225,6 +225,13 @@ jobs:
 - Job 的 `Set up runner` log 包含 Qiniu sandbox id、runner request id 和 runner name。
 - Job 结束后，runner request 变为 `completed`。
 
+参考证据：2026-08-04（CST），
+[run 30858489153](https://github.com/miclle/qiniu-ci-runner-test/actions/runs/30858489153)
+接收了带有效签名的 GitHub `workflow_run` 和 `workflow_job` deliveries，并让
+5 个 jobs 全部完成。5 条 requests 均进入 `completed`，Runner processes 均正常
+退出，Sandbox 均完成清理，repository 最终没有残留 self-hosted Runners。该参考
+run 不能替代对实际部署的 webhook secret 与 GitHub webhook 配置是否一致的验证。
+
 ## 6. Restart Recovery
 
 在 workflow 中增加一个持续时间足够长的步骤，并在 job 运行期间重启 runnerd。只重启 runnerd 服务，不要直接停止沙箱。

--- a/docs/zh/deployment-smoke.md
+++ b/docs/zh/deployment-smoke.md
@@ -13,7 +13,9 @@
 - GitHub App OAuth callback URL 指向 runnerd origin 下的 `/auth/github/callback`。
 - GitHub App webhook 或 repository webhook 将 `workflow_job` events 发送到 `POST /webhooks/github`。
 - 目标 account/organization Preferences 已配置 Sandbox service API URL 和 API key，或 `/admin/sandbox_service` 已启用 admin fallback。
-- 至少一个 Qiniu sandbox template 包含 `/opt/actions-runner/config.sh` 和 `/opt/actions-runner/run.sh`。
+- 已按[公共 Runner 模板](default-runner-templates.md)完成 4 个公共 Qiniu 模板的
+  双区域构建、发布、catalog 检查和 smoke 验证。该门禁通过前，不要部署默认
+  启用的 managed specs。
 - 已通过 `runnerd --bootstrap-admin github:<github-user-id>` 引导 admin account（该命令设置 admin 后直接退出，需在启动服务前执行）。
 
 不要在本文档中写入真实 secret，也不要提交部署本地文件，例如 `runnerd.local.yaml`、`.smee-url`、sqlite databases、private keys 或 cookie jars。
@@ -118,27 +120,51 @@ curl -fsS -b "$COOKIE_JAR" https://<runnerd-host>/diagnostics/vars | jq
 - 移除 audience entry 会阻止新的 fallback resolution，但不会改变已 snapshot 的 runner request。
 - 禁用 admin default 后，原本未配置的 account 会得到 `sandbox service not configured`。
 
-创建或确认 runner spec：
+启动后确认 runnerd 协调了且仅协调了 5 个 managed specs，并且没有自定义名称
+冲突：
 
 ```bash
-curl -fsS -X POST https://<runnerd-host>/runner_specs \
-  -b "$COOKIE_JAR" \
-  -H 'content-type: application/json' \
-  -d '{"name":"ubuntu-24-04","labels":["self-hosted","e2b"],"template_id":"<template-id>","max_concurrency":1,"enabled":true,"default_available":true}' | jq
+curl -fsS -b "$COOKIE_JAR" https://<runnerd-host>/runner_specs |
+  jq '[.[] | select(.managed_by == "qiniu/ci-runner") |
+      {name, required_labels, default_template_name, enabled}]'
 ```
 
-如果 spec 需要限制访问，将 `default_available` 设为 `false`，并为目标仓库创建 runner policy 或 runner group。
+预期名称为 `qiniu-ubuntu-slim`、`qiniu-ubuntu-22.04`、
+`qiniu-ubuntu-24.04`、`qiniu-ubuntu-26.04` 和 `qiniu-ubuntu-latest`。
+确认启动日志中不存在 managed-profile name collision。在每个已配置的 Sandbox
+区域运行 `task template-defaults-check` 并保存 4 个 ID；runnerd 必须通过该
+scoped endpoint 解析相同稳定名称，不能保存某一区域的 ID。
 
-运行 match test：
+运行正向和负向 match tests：
 
 ```bash
 curl -fsS -X POST https://<runnerd-host>/runner_specs/match \
   -b "$COOKIE_JAR" \
   -H 'content-type: application/json' \
-  -d '{"repository_full_name":"<owner>/<repo>","labels":["self-hosted","e2b"]}' | jq
+  -d '{"repository_full_name":"<owner>/<repo>","labels":["qiniu","ubuntu-24.04"]}' | jq
+
+curl -fsS -X POST https://<runnerd-host>/runner_specs/match \
+  -b "$COOKIE_JAR" \
+  -H 'content-type: application/json' \
+  -d '{"repository_full_name":"<owner>/<repo>","labels":["ubuntu-24.04"]}' | jq
+
+curl -fsS -X POST https://<runnerd-host>/runner_specs/match \
+  -b "$COOKIE_JAR" \
+  -H 'content-type: application/json' \
+  -d '{"repository_full_name":"<owner>/<repo>","labels":["qiniu"]}' | jq
 ```
 
-预期结果：响应包含预期 runner spec。
+预期结果：只有第 1 个请求选择 `qiniu-ubuntu-24.04`。
+
+创建一个带显式 template ID 和 operator labels 的自定义回归 spec。确认保存时
+不会访问 Sandbox，运行时使用保存的 ID，并且仍可编辑和删除：
+
+```bash
+curl -fsS -X POST https://<runnerd-host>/runner_specs \
+  -b "$COOKIE_JAR" \
+  -H 'content-type: application/json' \
+  -d '{"name":"deployment-custom","labels":["self-hosted","deployment-custom"],"required_labels":["deployment-custom"],"template_id":"<private-template-id>","max_concurrency":1,"enabled":true,"default_available":true}' | jq
+```
 
 ## 4. Webhook Delivery
 
@@ -153,7 +179,7 @@ curl -fsS -X POST https://<runnerd-host>/runner_specs/match \
 
 ## 5. Workflow Pickup
 
-使用最小 workflow：
+为每个 managed 逻辑 label 触发 1 个 job：
 
 ```yaml
 name: runnerd-smoke
@@ -162,8 +188,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  smoke:
-    runs-on: [self-hosted, e2b]
+  slim:
+    runs-on: [qiniu, ubuntu-slim]
+    steps:
+      - run: uname -a
+  ubuntu_22:
+    runs-on: [qiniu, ubuntu-22.04]
+    steps:
+      - run: uname -a
+  ubuntu_24:
+    runs-on: [qiniu, ubuntu-24.04]
+    steps:
+      - run: uname -a
+  ubuntu_26_preview:
+    runs-on: [qiniu, ubuntu-26.04]
+    steps:
+      - run: uname -a
+  latest:
+    runs-on: [qiniu, ubuntu-latest]
     steps:
       - run: |
           uname -a
@@ -176,7 +218,10 @@ jobs:
 预期结果：
 
 - Runner request 依次显示为 `queued`、`creating`、`running`。
-- GitHub Actions job 离开 queued 状态，并运行在 `e2b-*` runner 上。
+- 5 个 GitHub Actions jobs 都离开 queued 状态，并运行在临时 managed runners
+  上。两个 24.04 逻辑 labels 都通过 scoped region catalog 解析到 24.04 物理
+  模板。
+- 每个 job 都启动请求的操作系统；26.04 job 记录为预览验收。
 - Job 的 `Set up runner` log 包含 Qiniu sandbox id、runner request id 和 runner name。
 - Job 结束后，runner request 变为 `completed`。
 
@@ -205,16 +250,23 @@ Workflow 完成后确认：
 
 ## 8. Failure Drill
 
-部署仍在观察期时，运行一个受控失败：
+部署仍在观察期时，执行受控路由与 operator-control 检查：
 
-- 使用不匹配任何 runner spec 的 labels，或
-- 临时禁用匹配的 runner spec，或
-- 降低 spec concurrency 并触发两个 jobs。
+- 触发 `[ubuntu-24.04]` 和 `[qiniu]`；两者都必须保持 unmatched。
+- 在 Admin 中禁用 `qiniu-ubuntu-24.04`，重启 runnerd，并确认它仍保持禁用；
+  重新启用后确认恢复调度。
+- 降低某个 managed spec 的 concurrency，并触发两个 jobs。
+- 运行 `deployment-custom` spec，确认使用显式 template ID；随后删除它，并
+  确认删除 managed spec 仍返回 conflict。
 
 预期结果取决于场景：
 
 - unmatched labels 或 disabled specs 会记录为 admission failures；
+- reconciliation 会在重启后保留 operator 控制的 disabled 状态；
 - concurrency pressure 会让后续 requests 保持 queued，而不是被丢弃；
 - retryable placement 或 rate-limit failures 会填充 `next_retry_at`，并保持后续可处理。
+
+如果路由或模板健康状态回退，先禁用全部 5 个 managed specs。回滚时不要删除
+公共模板或自定义 specs。
 
 如果部署说明包含 private hosts、account names、channel URLs、secrets 或 cookie data，请记录在仓库外部。

--- a/docs/zh/testing.md
+++ b/docs/zh/testing.md
@@ -61,11 +61,17 @@ Sandbox service API URL 和 API Key 不在 `runnerd.yaml` 中配置。登录后�
 
 首次使用产品引导只会在现有账户级 `account_preferences` 表的 `onboarding/product-tour` 下保存版本号、状态和 `tour_seen` 标记，不会保存 Sandbox API Key。记录缺失或版本过旧时返回 `pending` 且 `tour_seen=false`。走完引导浮层后写入 `pending` 且 `tour_seen=true`，因此不会再次自动弹出，但必需的设置仍会保留。当前登录账户能解析到 custom、inherited 或符合条件的 admin default 任一有效 Sandbox 来源后即写入 `completed`。首次引导中显式跳过会写入 `skipped` 并关闭浮层，但不会隐藏必需设置。从账户菜单重播引导不会重置或覆盖已保存状态。
 
-Runner spec、runner group 和 repository policy 不在 `runnerd.yaml` 中配置；服务启动后通过后台页面或 admin API 创建。spec 名称建议使用有意义的名字，例如 `ubuntu-24-04`，`template_id` 填对应的 Qiniu sandbox template ID。template 是否可访问会在 runnerd 使用对应账户或组织的 Sandbox service 配置启动 sandbox 时确认。
+Runner spec、runner group 和 repository policy 不在 `runnerd.yaml` 中配置。
+runnerd 启动时会协调 5 个 Qiniu Ubuntu managed specs。其 labels、required
+labels、稳定公共模板名称、priority 和 default availability 由 runnerd 管理，
+operator 控制的 `enabled`、`max_concurrency` 和 `min_idle` 会被保留。自定义
+spec 仍通过 Admin API/UI 管理，需要显式 `template_id`、advertised labels 和
+可选 required labels。保存自定义 spec 时不会验证模板访问权限；runnerd 使用
+对应账户或组织的 Sandbox service 配置启动 sandbox 时才会检查。
 
 `database.backend` 支持 `sqlite`、`postgres` 和 `mysql`。本地开发优先使用 sqlite；共享数据库的多实例部署需要先用两个 runnerd 进程验证 lease 行为，再作为正式运行方式记录。
 
-状态表结构主要由 `internal/state/records.go` 里的 GORM tag 定义。服务启动时，已有 SQLite `runner_requests` 表只通过创建缺失的 model columns 和 indexes 做 additive migration；它会跳过通用 SQLite `AutoMigrate` 表重建，避免历史上通过 ALTER 添加的字段丢失。Admin newest-first 列表依赖 `(queued_at DESC, id ASC)` 上的 `idx_runner_requests_queued_id`。Repository-authorized 列表通过 `(github_installation_id, queued_at DESC, id ASC)` 上的 `idx_runner_requests_github_installation_queued_id` 分别查询每个 installation，再合并有界结果。创建任一缺失索引都不会重写 rows，但应先在 disposable production-sized copy 上测量启动 I/O 和锁等待。未来如需对 `runner_requests` 做 non-additive 变更，必须增加窄范围显式 migration 和数据保全回归 fixture。其他表会先针对旧 columns、obsolete OAuth constraints 和不兼容的 legacy scope tables 执行窄范围 compatibility pass，再运行 GORM `AutoMigrate`。缺少 `scope_type`/`scope_id` 的旧 `account_preferences` 和 `account_secrets` 表会被删除并重建，而不是迁移原数据。升级后必须重新配置其中保存的 Sandbox Preferences 和 API keys；已保存的 GitHub OAuth tokens 也会被清除，相关用户需重新使用 GitHub 登录后才能同步 installations。修改 state record、索引或迁移 helper 时，至少先跑：
+状态表结构主要由 `internal/state/records.go` 里的 GORM tag 定义。服务启动时，已有 SQLite `runner_requests` 和 `runner_profiles` 表只通过创建全部缺失的 model columns 和 indexes 做 additive migration；它们会跳过通用 SQLite `AutoMigrate` 表重建，从而保留历史上通过 ALTER 添加的 runner-request 字段，以及旧 runner-profile rows 和自定义 indexes，并补齐 managed-catalog 字段。Admin newest-first 列表依赖 `(queued_at DESC, id ASC)` 上的 `idx_runner_requests_queued_id`。Repository-authorized 列表通过 `(github_installation_id, queued_at DESC, id ASC)` 上的 `idx_runner_requests_github_installation_queued_id` 分别查询每个 installation，再合并有界结果。创建缺失索引不会重写 rows，但应先在 disposable production-sized copy 上测量启动 I/O 和锁等待。未来如需对任一 additive-only 表做 non-additive 变更，必须增加窄范围显式 migration 和数据保全回归 fixture。其他表会先针对旧 columns、obsolete OAuth constraints 和不兼容的 legacy scope tables 执行窄范围 compatibility pass，再运行 GORM `AutoMigrate`。缺少 `scope_type`/`scope_id` 的旧 `account_preferences` 和 `account_secrets` 表会被删除并重建，而不是迁移原数据。升级后必须重新配置其中保存的 Sandbox Preferences 和 API keys；已保存的 GitHub OAuth tokens 也会被清除，相关用户需重新使用 GitHub 登录后才能同步 installations。修改 state record、索引或迁移 helper 时，至少先跑：
 
 ```bash
 go test ./internal/state -count=1
@@ -336,13 +342,24 @@ allowlist 这两类 warning；它们表示 manual chunk 可能生成浏览器不
 
 `task test` 会重新构建 UI、运行同一套 Bun tests，然后执行带 race detection 和 coverage 的 Go tests。Bun suite 覆盖 helper 和 server-rendered component output；导航、dialog、头像加载/回退，以及角色变更后的权限切换仍需在真实浏览器中验证。修改 onboarding 时还要验证：`/jobs` 自动启动、六个目标、跳转到 `/account/preferences`、遮罩关闭后持续显示设置任务、显式跳过的持久化，以及重播不修改状态。
 
-先创建一个默认 runner spec：
+确认 runnerd 已协调 managed specs：
+
+```bash
+curl -fsS -b "$COOKIE_JAR" \
+  http://127.0.0.1:25500/runner_specs |
+  jq '.[] | select(.managed_by == "qiniu/ci-runner") |
+      {name, required_labels, default_template_name, enabled}'
+```
+
+结果应恰好包含 `qiniu-ubuntu-slim`、`qiniu-ubuntu-22.04`、
+`qiniu-ubuntu-24.04`、`qiniu-ubuntu-26.04` 和 `qiniu-ubuntu-latest`。验证向后
+兼容的显式模板路径时，请另外创建自定义 spec：
 
 ```bash
 curl -fsS -X POST http://127.0.0.1:25500/runner_specs \
   -b "$COOKIE_JAR" \
   -H 'content-type: application/json' \
-  -d '{"name":"ubuntu-24-04","labels":["self-hosted","e2b"],"template_id":"<template id>","max_concurrency":100,"enabled":true,"default_available":true}' | jq
+  -d '{"name":"custom-ubuntu","labels":["self-hosted","custom-ubuntu"],"required_labels":["custom-ubuntu"],"template_id":"<template id>","max_concurrency":1,"enabled":true,"default_available":true}' | jq
 ```
 
 手动创建一个 runner：
@@ -351,7 +368,7 @@ curl -fsS -X POST http://127.0.0.1:25500/runner_specs \
 curl -fsS -X POST http://127.0.0.1:25500/runner_requests \
   -b "$COOKIE_JAR" \
   -H 'content-type: application/json' \
-  -d '{"id":"manual-001","repository_full_name":"<owner>/<repo>","runner_spec_name":"ubuntu-24-04"}' | jq
+  -d '{"id":"manual-001","repository_full_name":"<owner>/<repo>","runner_spec_name":"qiniu-ubuntu-24.04"}' | jq
 ```
 
 查看状态：
@@ -463,14 +480,14 @@ Settings -> Webhooks -> Add webhook
 在目标仓库添加：
 
 ```yaml
-name: e2b-runner-smoke
+name: qiniu-runner-smoke
 
 on:
   workflow_dispatch:
 
 jobs:
   smoke:
-    runs-on: [self-hosted, e2b]
+    runs-on: [qiniu, ubuntu-24.04]
     steps:
       - name: Print runner info
         run: |
@@ -484,7 +501,7 @@ jobs:
 1. GitHub 创建一个 `workflow_job.queued` webhook。
 2. 本服务校验签名并在状态库里写入一条 `queued` runner request。
 3. 服务创建 sandbox，获取 GitHub registration token，并在 sandbox 内启动 ephemeral runner。
-4. GitHub job 被 `self-hosted,e2b` runner 接走执行。
+4. GitHub job 被 managed `qiniu,ubuntu-24.04` runner 接走执行。
 5. runner 进程退出后，服务清理对应 sandbox。
 
 如果同时配置了 `Workflow runs` 事件，`workflow_run.requested` / `workflow_run.in_progress` 只作为补偿信号：runnerd 会查询该 run 下仍处于 `queued` 的 jobs，并为尚未通过 `workflow_job` 入队的 job 补建 runner request。这个补偿动作本身不会让 GitHub Actions UI 立刻显示 job 正在运行；UI 会继续显示 queued / waiting for runner，直到 sandbox 内的 ephemeral runner 注册成功并被 GitHub 分配到该 job 后才会变成 in progress / running。
@@ -514,7 +531,12 @@ curl -fsS -b "$COOKIE_JAR" \
 
 - `invalid signature`：GitHub webhook secret 和 `github.webhook_secret` 不一致。
 - `runner start deferred because global concurrency is at capacity` 或 `runner start deferred because profile is at capacity`：request 会保持 queued，直到全局或 per-spec 容量可用。
-- GitHub job 一直 queued：workflow 的 `runs-on` labels 必须包含 `self-hosted` 和 `e2b`，并与 runner spec 的 labels 保持一致。
+- GitHub job 一直 queued：managed default 必须同时包含 `qiniu` 和准确的操作
+  系统 label。`[ubuntu-24.04]`、`[qiniu]` 和不受支持的额外 labels 都不会匹配；
+  自定义 spec 则使用它自己的 advertised labels 和 required labels。
+- 出现 `template_resolution` admission failure：确认 repository owner 对应的
+  scoped Sandbox endpoint 中，managed stable name 恰好对应 1 个公共的
+  `ready` 或 `uploaded` 模板。
 - sandbox 创建失败：确认账户/组织 Preferences 或已启用的 admin default 具有与 template 和本地环境匹配的完整 Sandbox service 配置；Runner detail 会显示实际选择的来源。
 - registration token 失败：检查 [GitHub App 权限表](../../README.zh.md#所需权限)。未配置 `runner_group` 的 spec 需要 repository `Administration`；配置了 `runner_group` 的 spec 需要 organization `Self-hosted runners`。
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/jimmicro/pprof v1.1.0
-	github.com/qiniu/go-sdk/v7 v7.26.13-0.20260515114350-0068302da18a
+	github.com/qiniu/go-sdk/v7 v7.26.18
 	golang.org/x/sync v0.21.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQ
 github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/qiniu/go-sdk/v7 v7.26.13-0.20260515114350-0068302da18a h1:5ajNU7jyuC9wJCr5viOy0RjREcpRlLgPtTq/fpvBjvE=
-github.com/qiniu/go-sdk/v7 v7.26.13-0.20260515114350-0068302da18a/go.mod h1:ri7fGwbio0pRDFr8EK5TUpx0DbnpIMJ2bMSDxGWfCbk=
+github.com/qiniu/go-sdk/v7 v7.26.18 h1:74rUItkJGFwD7wV6vUSXLfR23r8NqbAyjFj3goiFeN0=
+github.com/qiniu/go-sdk/v7 v7.26.18/go.mod h1:pTwVR1B+8SXcPLhDzBUasiKFTD9F7jRglRDR553BW3k=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/internal/runnercatalog/defaults.go
+++ b/internal/runnercatalog/defaults.go
@@ -1,0 +1,36 @@
+package runnercatalog
+
+import "github.com/qiniu/ci-runner/internal/state"
+
+const (
+	// ManagerName identifies runner specs owned by the built-in catalog.
+	ManagerName = "qiniu/ci-runner"
+	// CurrentRevision is the schema revision of the built-in catalog rows.
+	CurrentRevision = 1
+)
+
+// DefaultProfiles returns the managed runner specs reconciled at startup.
+func DefaultProfiles() []state.RunnerProfile {
+	return []state.RunnerProfile{
+		defaultProfile("qiniu-ubuntu-slim", "ubuntu-slim", "github-runner-ubuntu-slim"),
+		defaultProfile("qiniu-ubuntu-22.04", "ubuntu-22.04", "github-runner-ubuntu-22-04"),
+		defaultProfile("qiniu-ubuntu-24.04", "ubuntu-24.04", "github-runner-ubuntu-24-04"),
+		defaultProfile("qiniu-ubuntu-26.04", "ubuntu-26.04", "github-runner-ubuntu-26-04"),
+		defaultProfile("qiniu-ubuntu-latest", "ubuntu-latest", "github-runner-ubuntu-24-04"),
+	}
+}
+
+func defaultProfile(name, osLabel, templateName string) state.RunnerProfile {
+	return state.RunnerProfile{
+		Name:                name,
+		Labels:              []string{"self-hosted", "linux", "x64", "qiniu", osLabel},
+		RequiredLabels:      []string{"qiniu", osLabel},
+		DefaultTemplateName: templateName,
+		MaxConcurrency:      10,
+		Priority:            100,
+		Enabled:             true,
+		DefaultAvailable:    true,
+		ManagedBy:           ManagerName,
+		CatalogRevision:     CurrentRevision,
+	}
+}

--- a/internal/runnercatalog/defaults_test.go
+++ b/internal/runnercatalog/defaults_test.go
@@ -1,0 +1,162 @@
+package runnercatalog
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/qiniu/ci-runner/internal/state"
+)
+
+func TestDefaultProfilesMatchTargetCatalog(t *testing.T) {
+	want := []state.RunnerProfile{
+		{
+			Name:                "qiniu-ubuntu-slim",
+			Labels:              []string{"self-hosted", "linux", "x64", "qiniu", "ubuntu-slim"},
+			RequiredLabels:      []string{"qiniu", "ubuntu-slim"},
+			DefaultTemplateName: "github-runner-ubuntu-slim",
+			MaxConcurrency:      10,
+			Priority:            100,
+			Enabled:             true,
+			DefaultAvailable:    true,
+			ManagedBy:           "qiniu/ci-runner",
+			CatalogRevision:     1,
+		},
+		{
+			Name:                "qiniu-ubuntu-22.04",
+			Labels:              []string{"self-hosted", "linux", "x64", "qiniu", "ubuntu-22.04"},
+			RequiredLabels:      []string{"qiniu", "ubuntu-22.04"},
+			DefaultTemplateName: "github-runner-ubuntu-22-04",
+			MaxConcurrency:      10,
+			Priority:            100,
+			Enabled:             true,
+			DefaultAvailable:    true,
+			ManagedBy:           "qiniu/ci-runner",
+			CatalogRevision:     1,
+		},
+		{
+			Name:                "qiniu-ubuntu-24.04",
+			Labels:              []string{"self-hosted", "linux", "x64", "qiniu", "ubuntu-24.04"},
+			RequiredLabels:      []string{"qiniu", "ubuntu-24.04"},
+			DefaultTemplateName: "github-runner-ubuntu-24-04",
+			MaxConcurrency:      10,
+			Priority:            100,
+			Enabled:             true,
+			DefaultAvailable:    true,
+			ManagedBy:           "qiniu/ci-runner",
+			CatalogRevision:     1,
+		},
+		{
+			Name:                "qiniu-ubuntu-26.04",
+			Labels:              []string{"self-hosted", "linux", "x64", "qiniu", "ubuntu-26.04"},
+			RequiredLabels:      []string{"qiniu", "ubuntu-26.04"},
+			DefaultTemplateName: "github-runner-ubuntu-26-04",
+			MaxConcurrency:      10,
+			Priority:            100,
+			Enabled:             true,
+			DefaultAvailable:    true,
+			ManagedBy:           "qiniu/ci-runner",
+			CatalogRevision:     1,
+		},
+		{
+			Name:                "qiniu-ubuntu-latest",
+			Labels:              []string{"self-hosted", "linux", "x64", "qiniu", "ubuntu-latest"},
+			RequiredLabels:      []string{"qiniu", "ubuntu-latest"},
+			DefaultTemplateName: "github-runner-ubuntu-24-04",
+			MaxConcurrency:      10,
+			Priority:            100,
+			Enabled:             true,
+			DefaultAvailable:    true,
+			ManagedBy:           "qiniu/ci-runner",
+			CatalogRevision:     1,
+		},
+	}
+
+	got := DefaultProfiles()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DefaultProfiles() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDefaultProfilesHaveUniqueRoutingKeys(t *testing.T) {
+	profiles := DefaultProfiles()
+	names := make(map[string]struct{}, len(profiles))
+	requiredLabelPairs := make(map[string]struct{}, len(profiles))
+	revision := 0
+	for _, profile := range profiles {
+		if _, exists := names[profile.Name]; exists {
+			t.Fatalf("duplicate profile name %q", profile.Name)
+		}
+		names[profile.Name] = struct{}{}
+
+		if len(profile.RequiredLabels) != 2 {
+			t.Fatalf("%s required labels = %#v, want one unique pair", profile.Name, profile.RequiredLabels)
+		}
+		pair := profile.RequiredLabels[0] + "\x00" + profile.RequiredLabels[1]
+		if _, exists := requiredLabelPairs[pair]; exists {
+			t.Fatalf("duplicate required-label pair %#v", profile.RequiredLabels)
+		}
+		requiredLabelPairs[pair] = struct{}{}
+
+		if profile.DefaultTemplateName == "" {
+			t.Fatalf("%s has empty default template name", profile.Name)
+		}
+		if profile.ManagedBy != "qiniu/ci-runner" {
+			t.Fatalf("%s ManagedBy = %q", profile.Name, profile.ManagedBy)
+		}
+		if profile.CatalogRevision <= 0 {
+			t.Fatalf("%s CatalogRevision = %d, want positive", profile.Name, profile.CatalogRevision)
+		}
+		if revision == 0 {
+			revision = profile.CatalogRevision
+		} else if profile.CatalogRevision != revision {
+			t.Fatalf("%s CatalogRevision = %d, want shared revision %d", profile.Name, profile.CatalogRevision, revision)
+		}
+	}
+}
+
+func TestDefaultProfilesReferenceTrackedPublicTemplates(t *testing.T) {
+	templateDirectories := map[string]string{
+		"ubuntu-slim":  "github-runner-ubuntu-slim",
+		"ubuntu-22.04": "github-runner-ubuntu-22.04",
+		"ubuntu-24.04": "github-runner-ubuntu-24.04",
+		"ubuntu-26.04": "github-runner-ubuntu-26.04",
+	}
+	profilesByLabel := make(map[string]state.RunnerProfile)
+	for _, profile := range DefaultProfiles() {
+		if len(profile.RequiredLabels) != 2 {
+			continue
+		}
+		profilesByLabel[profile.RequiredLabels[1]] = profile
+	}
+
+	for label, directory := range templateDirectories {
+		profile, ok := profilesByLabel[label]
+		if !ok {
+			t.Fatalf("missing managed profile for public template label %q", label)
+		}
+		configPath := filepath.Join("..", "..", "templates", directory, "qshell.sandbox.toml")
+		config, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("read public template config %s: %v", configPath, err)
+		}
+		nameDeclaration := `name = "` + profile.DefaultTemplateName + `"`
+		if !strings.Contains(string(config), nameDeclaration) {
+			t.Fatalf("%s does not declare managed template name %q", configPath, profile.DefaultTemplateName)
+		}
+	}
+
+	latest, ok := profilesByLabel["ubuntu-latest"]
+	if !ok {
+		t.Fatal("missing managed profile for ubuntu-latest")
+	}
+	if latest.DefaultTemplateName != profilesByLabel["ubuntu-24.04"].DefaultTemplateName {
+		t.Fatalf(
+			"ubuntu-latest template = %q, want ubuntu-24.04 template %q",
+			latest.DefaultTemplateName,
+			profilesByLabel["ubuntu-24.04"].DefaultTemplateName,
+		)
+	}
+}

--- a/internal/sandboxrunner/runner.go
+++ b/internal/sandboxrunner/runner.go
@@ -118,6 +118,8 @@ type E2BService struct {
 	client *qnsandbox.Client
 }
 
+const runnerBootstrapUser = "root"
+
 //go:embed scripts/start-github-runner.sh
 var startRunnerScriptTemplate string
 
@@ -258,6 +260,7 @@ func (s *E2BService) StartRunner(ctx context.Context, input StartInput) (StartRe
 	cmd := "chmod +x /tmp/start-github-runner.sh && /tmp/start-github-runner.sh"
 	handle, err := sb.Commands().Start(
 		commandCtx, cmd,
+		qnsandbox.WithCommandUser(runnerBootstrapUser),
 		qnsandbox.WithTag("github-runner"),
 		qnsandbox.WithOnStdout(input.OnStdout),
 		qnsandbox.WithOnStderr(input.OnStderr),

--- a/internal/sandboxrunner/runner.go
+++ b/internal/sandboxrunner/runner.go
@@ -59,6 +59,7 @@ type ExitResult struct {
 type CatalogTemplate struct {
 	TemplateID  string    `json:"template_id"`
 	Aliases     []string  `json:"aliases"`
+	Names       []string  `json:"names"`
 	BuildStatus string    `json:"build_status"`
 	CPUCount    int32     `json:"cpu_count"`
 	MemoryMB    int32     `json:"memory_mb"`
@@ -83,6 +84,11 @@ type CatalogSandbox struct {
 type Catalog interface {
 	ListTemplates(ctx context.Context) ([]CatalogTemplate, error)
 	ListRunnerSandboxes(ctx context.Context) ([]CatalogSandbox, error)
+}
+
+// DefaultTemplateCatalog lists public templates available on the scoped Sandbox endpoint.
+type DefaultTemplateCatalog interface {
+	ListDefaultTemplates(ctx context.Context) ([]CatalogTemplate, error)
 }
 
 type TerminalSession interface {
@@ -158,6 +164,29 @@ func (s *E2BService) ListTemplates(ctx context.Context) ([]CatalogTemplate, erro
 		result = append(result, CatalogTemplate{
 			TemplateID:  item.TemplateID,
 			Aliases:     item.Aliases,
+			BuildStatus: string(item.BuildStatus),
+			CPUCount:    item.CPUCount,
+			MemoryMB:    item.MemoryMB,
+			DiskSizeMB:  item.DiskSizeMB,
+			Public:      item.Public,
+			SpawnCount:  item.SpawnCount,
+			UpdatedAt:   item.UpdatedAt,
+		})
+	}
+	return result, nil
+}
+
+// ListDefaultTemplates lists the public template catalog from the scoped Sandbox endpoint.
+func (s *E2BService) ListDefaultTemplates(ctx context.Context) ([]CatalogTemplate, error) {
+	items, err := s.client.ListDefaultTemplates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]CatalogTemplate, 0, len(items))
+	for _, item := range items {
+		result = append(result, CatalogTemplate{
+			TemplateID:  item.TemplateID,
+			Names:       item.Names,
 			BuildStatus: string(item.BuildStatus),
 			CPUCount:    item.CPUCount,
 			MemoryMB:    item.MemoryMB,

--- a/internal/sandboxrunner/runner_api_test.go
+++ b/internal/sandboxrunner/runner_api_test.go
@@ -181,3 +181,39 @@ func TestNewE2BService_EmptyAPIKey(t *testing.T) {
 		t.Fatal("expected non-nil service")
 	}
 }
+
+func TestE2BServiceListDefaultTemplates(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/default-templates" {
+			t.Fatalf("request path = %q, want %q", r.URL.Path, "/default-templates")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"templateID":"tpl-public-runner","names":["github-runner-ubuntu-24-04"],"buildStatus":"ready","cpuCount":2,"memoryMB":4096,"diskSizeMB":20480,"public":true,"spawnCount":3,"updatedAt":"2024-01-01T00:00:00Z"}]`))
+	}))
+	defer ts.Close()
+
+	svc := newTestService(t, ts)
+	items, err := svc.ListDefaultTemplates(context.Background())
+	if err != nil {
+		t.Fatalf("ListDefaultTemplates: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one template, got %d", len(items))
+	}
+	got := items[0]
+	if got.TemplateID != "tpl-public-runner" {
+		t.Errorf("TemplateID = %q, want %q", got.TemplateID, "tpl-public-runner")
+	}
+	if len(got.Names) != 1 || got.Names[0] != "github-runner-ubuntu-24-04" {
+		t.Errorf("Names = %#v, want [github-runner-ubuntu-24-04]", got.Names)
+	}
+	if got.BuildStatus != "ready" {
+		t.Errorf("BuildStatus = %q, want %q", got.BuildStatus, "ready")
+	}
+	if !got.Public {
+		t.Error("Public = false, want true")
+	}
+}

--- a/internal/sandboxrunner/runner_test.go
+++ b/internal/sandboxrunner/runner_test.go
@@ -76,6 +76,12 @@ func TestStartScriptEncodesRunnerArguments(t *testing.T) {
 	}
 }
 
+func TestRunnerBootstrapRequiresRootUser(t *testing.T) {
+	if runnerBootstrapUser != "root" {
+		t.Fatalf("runner bootstrap user = %q, want root", runnerBootstrapUser)
+	}
+}
+
 func TestStartScriptRunsCleanupAfterRunnerExit(t *testing.T) {
 	script := startScript(StartInput{
 		RepositoryURL:     "https://github.com/o/r",

--- a/internal/sandboxrunner/runner_test.go
+++ b/internal/sandboxrunner/runner_test.go
@@ -131,12 +131,16 @@ func TestStartScriptUsesHostedRunnerFilesystemContract(t *testing.T) {
 	runnerHome := filepath.Join(fixture, "home", "runner")
 	hookRoot := filepath.Join(fixture, "hooks")
 	logPath := filepath.Join(fixture, "runner.log")
+	environmentPath := filepath.Join(fixture, "environment")
 	if err := os.MkdirAll(actionsRunnerRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(environmentPath, []byte("ImageVersion=\"$TEMPLATE_VERSION\"\nIMAGE_VERSION=\"$TEMPLATE_VERSION\"\nCUSTOM_RUNNER_ENV=\"$HOME/from-environment\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	writeExecutable(t, filepath.Join(actionsRunnerRoot, "config.sh"), `#!/usr/bin/env bash
 set -euo pipefail
-printf 'config HOME=%s PWD=%s TOOL_CACHE=%s AGENT_TOOLS=%s\n' "$HOME" "$PWD" "$RUNNER_TOOL_CACHE" "$AGENT_TOOLSDIRECTORY" >>"$RUNNER_TEST_LOG"
+printf 'config HOME=%s PWD=%s TOOL_CACHE=%s AGENT_TOOLS=%s IMAGE_VERSION=%s CUSTOM_RUNNER_ENV=%s\n' "$HOME" "$PWD" "$RUNNER_TOOL_CACHE" "$AGENT_TOOLSDIRECTORY" "${IMAGE_VERSION:-}" "${CUSTOM_RUNNER_ENV:-}" >>"$RUNNER_TEST_LOG"
 `)
 	writeExecutable(t, filepath.Join(actionsRunnerRoot, "run.sh"), `#!/usr/bin/env bash
 set -euo pipefail
@@ -163,6 +167,7 @@ printf 'run HOME=%s PWD=%s RUNASROOT=%s\n' "$HOME" "$PWD" "${RUNNER_ALLOW_RUNASR
 		"RUNNER_HOME="+runnerHome,
 		"RUNNER_HOOK_ROOT="+hookRoot,
 		"RUNNER_TEST_LOG="+logPath,
+		"RUNNER_ENVIRONMENT_FILE="+environmentPath,
 		"ENSURE_DOCKER=/bin/true",
 	)
 	if err != nil {
@@ -176,6 +181,7 @@ printf 'run HOME=%s PWD=%s RUNASROOT=%s\n' "$HOME" "$PWD" "${RUNNER_ALLOW_RUNASR
 	for _, want := range []string{
 		"config HOME=" + runnerHome + " PWD=" + workdir,
 		"TOOL_CACHE=/opt/hostedtoolcache AGENT_TOOLS=/opt/hostedtoolcache",
+		"IMAGE_VERSION= CUSTOM_RUNNER_ENV=" + runnerHome + "/from-environment",
 		"run HOME=" + runnerHome + " PWD=" + workdir + " RUNASROOT=",
 	} {
 		if !strings.Contains(log, want) {

--- a/internal/sandboxrunner/scripts/start-github-runner.sh
+++ b/internal/sandboxrunner/scripts/start-github-runner.sh
@@ -7,6 +7,7 @@ workdir="${RUNNER_WORKDIR:-/home/runner/actions-runner}"
 runner_job_work="${RUNNER_JOB_WORK:-/home/runner/work}"
 hook_root="${RUNNER_HOOK_ROOT:-/home/runner/_runnerd-hooks}"
 ensure_docker="${ENSURE_DOCKER:-/usr/local/bin/ensure-docker}"
+runner_environment_file="${RUNNER_ENVIRONMENT_FILE:-/etc/environment}"
 export HOME="${RUNNER_HOME:-/home/runner}"
 export XDG_CONFIG_HOME="${HOME}/.config"
 export GOPATH="${GOPATH:-/opt/go}"
@@ -14,11 +15,15 @@ export GOBIN="${GOBIN:-/usr/local/bin}"
 export RUNNER_TOOL_CACHE="${RUNNER_TOOL_CACHE:-/opt/hostedtoolcache}"
 export AGENT_TOOLSDIRECTORY="${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}"
 export PATH="/usr/local/go/bin:/usr/local/bin:${GOPATH}/bin:${PATH}"
-if [ -r /etc/environment ]; then
+if [ -r "$runner_environment_file" ]; then
   set -a
   # runner-images writes shell-compatible KEY="value" entries here.
-  # shellcheck disable=SC1091
-  . /etc/environment
+  # The environment can contain references to build-only variables. Keep
+  # nounset disabled while loading it so those entries do not abort startup.
+  set +u
+  # shellcheck disable=SC1090
+  . "$runner_environment_file"
+  set -u
   set +a
 fi
 
@@ -33,6 +38,7 @@ if [ "$(id -u)" -eq 0 ] && id -u "$runner_user" >/dev/null 2>&1 && [ "${RUNNERD_
     RUNNER_JOB_WORK="$runner_job_work" \
     RUNNER_HOOK_ROOT="$hook_root" \
     ENSURE_DOCKER="$ensure_docker" \
+    RUNNER_ENVIRONMENT_FILE="$runner_environment_file" \
     HOME="$HOME" \
     bash "$0"
 fi

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -75,9 +75,10 @@ type manualCreateRequest struct {
 	Labels             []string `json:"labels"`
 }
 
-type upsertProfileRequest struct {
+type createProfileRequest struct {
 	Name             string   `json:"name"`
 	Labels           []string `json:"labels"`
+	RequiredLabels   []string `json:"required_labels"`
 	TemplateID       string   `json:"template_id"`
 	RunnerGroup      string   `json:"runner_group"`
 	MaxConcurrency   int      `json:"max_concurrency"`
@@ -86,6 +87,20 @@ type upsertProfileRequest struct {
 	Enabled          *bool    `json:"enabled"`
 	DefaultAvailable *bool    `json:"default_available"`
 }
+
+type patchProfileRequest struct {
+	Labels           *[]string `json:"labels"`
+	RequiredLabels   *[]string `json:"required_labels"`
+	TemplateID       *string   `json:"template_id"`
+	RunnerGroup      *string   `json:"runner_group"`
+	MaxConcurrency   *int      `json:"max_concurrency"`
+	MinIdle          *int      `json:"min_idle"`
+	Priority         *int      `json:"priority"`
+	Enabled          *bool     `json:"enabled"`
+	DefaultAvailable *bool     `json:"default_available"`
+}
+
+const managedRunnerSpecErrorCode = "managed_runner_spec"
 
 type upsertRepositoryPolicyRequest struct {
 	RepositoryFullName string `json:"repository_full_name"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -158,7 +158,7 @@ func New(cfg config.Config, store state.Store, gh *github.Client, sandbox sandbo
 		store:                     store,
 		gh:                        gh,
 		sandbox:                   sandbox,
-		sandboxHTTP:               &http.Client{Timeout: 60 * time.Second},
+		sandboxHTTP:               newSandboxHTTPClient(),
 		logger:                    logger,
 		mux:                       http.NewServeMux(),
 		slots:                     make(chan struct{}, cfg.MaxConcurrentRunners),
@@ -175,6 +175,12 @@ func New(cfg config.Config, store state.Store, gh *github.Client, sandbox sandbo
 	s.loopCtx, s.loopCancel = context.WithCancel(context.Background())
 	s.routes()
 	return s
+}
+
+func newSandboxHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = time.Minute
+	return &http.Client{Transport: transport}
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_admin_handlers.go
+++ b/internal/server/server_admin_handlers.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -234,9 +235,37 @@ func (s *Server) handleCreateProfile(w http.ResponseWriter, r *http.Request) {
 	if !s.requireAdminAuth(w, r) {
 		return
 	}
-	var input upsertProfileRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&input); err != nil {
+	payload, err := readProfileRequestPayload(r.Body)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid profile payload")
+		return
+	}
+	if payload.containsAny("managed_by", "catalog_revision", "default_template_name") {
+		writeError(w, http.StatusBadRequest, "managed runner spec metadata cannot be set by clients")
+		return
+	}
+	var input createProfileRequest
+	if err := payload.decode(&input); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid profile payload")
+		return
+	}
+	if strings.TrimSpace(input.TemplateID) == "" {
+		writeError(w, http.StatusBadRequest, "template_id is required")
+		return
+	}
+	existing, err := s.store.GetProfile(input.Name)
+	if err == nil && strings.TrimSpace(existing.ManagedBy) != "" {
+		writeErrorCode(
+			w,
+			http.StatusConflict,
+			managedRunnerSpecErrorCode,
+			"managed runner specs cannot be overwritten",
+		)
+		return
+	}
+	if err != nil && !errors.Is(err, state.ErrNotFound) {
+		s.logger.Error("load runner spec before create", "name", input.Name, "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	enabled := true
@@ -246,6 +275,7 @@ func (s *Server) handleCreateProfile(w http.ResponseWriter, r *http.Request) {
 	profile, err := s.store.UpsertProfile(state.RunnerProfile{
 		Name:             input.Name,
 		Labels:           input.Labels,
+		RequiredLabels:   input.RequiredLabels,
 		TemplateID:       input.TemplateID,
 		RunnerGroup:      input.RunnerGroup,
 		MaxConcurrency:   input.MaxConcurrency,
@@ -286,22 +316,42 @@ func (s *Server) handlePatchProfile(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "profile not found")
 		return
 	}
-	var input upsertProfileRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&input); err != nil {
+	payload, err := readProfileRequestPayload(r.Body)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid profile payload")
 		return
 	}
-	if len(input.Labels) > 0 {
-		current.Labels = input.Labels
+	if strings.TrimSpace(current.ManagedBy) != "" {
+		s.handlePatchManagedProfile(w, current, payload)
+		return
 	}
-	if input.TemplateID != "" {
-		current.TemplateID = input.TemplateID
+	if payload.containsAny("managed_by", "catalog_revision", "default_template_name") {
+		writeError(w, http.StatusBadRequest, "managed runner spec metadata cannot be set by clients")
+		return
 	}
-	if input.RunnerGroup != "" {
-		current.RunnerGroup = input.RunnerGroup
+	var input patchProfileRequest
+	if err := payload.decode(&input); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid profile payload")
+		return
 	}
-	if input.MaxConcurrency > 0 {
-		current.MaxConcurrency = input.MaxConcurrency
+	if input.Labels != nil {
+		current.Labels = *input.Labels
+	}
+	if input.RequiredLabels != nil {
+		current.RequiredLabels = *input.RequiredLabels
+	}
+	if input.TemplateID != nil {
+		current.TemplateID = *input.TemplateID
+	}
+	if strings.TrimSpace(current.TemplateID) == "" {
+		writeError(w, http.StatusBadRequest, "template_id is required")
+		return
+	}
+	if input.RunnerGroup != nil {
+		current.RunnerGroup = *input.RunnerGroup
+	}
+	if input.MaxConcurrency != nil {
+		current.MaxConcurrency = *input.MaxConcurrency
 	}
 	if input.MinIdle != nil {
 		current.MinIdle = *input.MinIdle
@@ -327,17 +377,111 @@ func (s *Server) handlePatchProfile(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, profile)
 }
 
+func (s *Server) handlePatchManagedProfile(w http.ResponseWriter, current state.RunnerProfile, payload profileRequestPayload) {
+	if payload.containsAny(
+		"labels",
+		"required_labels",
+		"template_id",
+		"runner_group",
+		"priority",
+		"default_available",
+		"default_template_name",
+		"managed_by",
+		"catalog_revision",
+	) {
+		writeErrorCode(
+			w,
+			http.StatusConflict,
+			managedRunnerSpecErrorCode,
+			"managed runner spec catalog fields cannot be changed",
+		)
+		return
+	}
+	var input patchProfileRequest
+	if err := payload.decode(&input); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid profile payload")
+		return
+	}
+	if input.MaxConcurrency != nil {
+		current.MaxConcurrency = *input.MaxConcurrency
+	}
+	if input.MinIdle != nil {
+		current.MinIdle = *input.MinIdle
+	}
+	if input.Enabled != nil {
+		current.Enabled = *input.Enabled
+	}
+	profile, err := s.store.UpsertProfile(current)
+	if err != nil {
+		s.logger.Info("managed profile update rejected", "name", current.Name, "error", err)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.logger.Info("managed profile updated", "name", profile.Name, "max_concurrency", profile.MaxConcurrency, "min_idle", profile.MinIdle, "enabled", profile.Enabled)
+	s.recordAudit("admin_api", "profile.update", "runner_profile", profile.Name, profile)
+	s.refreshMetrics()
+	writeJSON(w, http.StatusOK, profile)
+}
+
+type profileRequestPayload struct {
+	data   []byte
+	fields map[string]json.RawMessage
+}
+
+func readProfileRequestPayload(body io.Reader) (profileRequestPayload, error) {
+	data, err := io.ReadAll(io.LimitReader(body, 1<<20))
+	if err != nil {
+		return profileRequestPayload{}, err
+	}
+	payload := profileRequestPayload{data: data}
+	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&payload.fields); err != nil {
+		return profileRequestPayload{}, err
+	}
+	return payload, nil
+}
+
+func (p profileRequestPayload) decode(dst any) error {
+	return json.NewDecoder(bytes.NewReader(p.data)).Decode(dst)
+}
+
+func (p profileRequestPayload) containsAny(names ...string) bool {
+	for field := range p.fields {
+		for _, name := range names {
+			if strings.EqualFold(field, name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (s *Server) handleDeleteProfile(w http.ResponseWriter, r *http.Request) {
 	if !s.requireAdminAuth(w, r) {
 		return
 	}
-	if err := s.store.DeleteProfile(r.PathValue("name")); err != nil {
-		s.logger.Error("delete profile", "name", r.PathValue("name"), "error", err)
+	name := r.PathValue("name")
+	profile, err := s.store.GetProfile(name)
+	if err != nil && !errors.Is(err, state.ErrNotFound) {
+		s.logger.Error("load runner spec before delete", "name", name, "error", err)
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	s.logger.Info("profile deleted", "name", r.PathValue("name"))
-	s.recordAudit("admin_api", "profile.delete", "runner_profile", r.PathValue("name"), map[string]any{"status": "deleted"})
+	if err == nil && strings.TrimSpace(profile.ManagedBy) != "" {
+		writeErrorCode(
+			w,
+			http.StatusConflict,
+			managedRunnerSpecErrorCode,
+			"managed runner specs cannot be deleted",
+		)
+		return
+	}
+	if err := s.store.DeleteProfile(name); err != nil {
+		s.logger.Error("delete profile", "name", name, "error", err)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.logger.Info("profile deleted", "name", name)
+	s.recordAudit("admin_api", "profile.delete", "runner_profile", name, map[string]any{"status": "deleted"})
 	s.refreshMetrics()
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }

--- a/internal/server/server_default_templates.go
+++ b/internal/server/server_default_templates.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/qiniu/ci-runner/internal/sandboxrunner"
+)
+
+const (
+	defaultTemplateResolutionReasonMissing     = "missing"
+	defaultTemplateResolutionReasonDuplicate   = "duplicate"
+	defaultTemplateResolutionReasonPrivate     = "private"
+	defaultTemplateResolutionReasonNonRunnable = "non_runnable"
+	defaultTemplateResolutionReasonEmptyID     = "empty_template_id"
+	defaultTemplateResolutionReasonNoCatalog   = "catalog_unavailable"
+)
+
+type defaultTemplateResolutionError struct {
+	RequestedName string
+	Reason        string
+}
+
+func (e *defaultTemplateResolutionError) Error() string {
+	return fmt.Sprintf("default template %q cannot be resolved: %s", e.RequestedName, e.Reason)
+}
+
+func resolveDefaultTemplateID(requestedName string, templates []sandboxrunner.CatalogTemplate) (string, error) {
+	requestedName = strings.TrimSpace(requestedName)
+	if requestedName == "" {
+		return "", newDefaultTemplateResolutionError(requestedName, defaultTemplateResolutionReasonMissing)
+	}
+	matches := make([]sandboxrunner.CatalogTemplate, 0, 1)
+	for _, template := range templates {
+		for _, name := range template.Names {
+			name = strings.TrimSpace(name)
+			if name == requestedName || strings.HasSuffix(name, "/"+requestedName) {
+				matches = append(matches, template)
+				break
+			}
+		}
+	}
+
+	if len(matches) == 0 {
+		return "", newDefaultTemplateResolutionError(requestedName, defaultTemplateResolutionReasonMissing)
+	}
+	if len(matches) > 1 {
+		return "", newDefaultTemplateResolutionError(requestedName, defaultTemplateResolutionReasonDuplicate)
+	}
+
+	match := matches[0]
+	if !match.Public {
+		return "", newDefaultTemplateResolutionError(requestedName, defaultTemplateResolutionReasonPrivate)
+	}
+	switch strings.TrimSpace(match.BuildStatus) {
+	case "ready", "uploaded":
+	default:
+		return "", newDefaultTemplateResolutionError(requestedName, defaultTemplateResolutionReasonNonRunnable)
+	}
+	templateID := strings.TrimSpace(match.TemplateID)
+	if templateID == "" {
+		return "", newDefaultTemplateResolutionError(requestedName, defaultTemplateResolutionReasonEmptyID)
+	}
+	return templateID, nil
+}
+
+func newDefaultTemplateResolutionError(requestedName, reason string) error {
+	return &defaultTemplateResolutionError{
+		RequestedName: requestedName,
+		Reason:        reason,
+	}
+}

--- a/internal/server/server_default_templates_test.go
+++ b/internal/server/server_default_templates_test.go
@@ -1,0 +1,801 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qiniu/ci-runner/internal/config"
+	"github.com/qiniu/ci-runner/internal/github"
+	"github.com/qiniu/ci-runner/internal/sandboxrunner"
+	"github.com/qiniu/ci-runner/internal/state"
+)
+
+func TestResolveDefaultTemplateID(t *testing.T) {
+	tests := []struct {
+		name          string
+		requestedName string
+		templates     []sandboxrunner.CatalogTemplate
+		wantID        string
+		wantReason    string
+	}{
+		{
+			name:          "exact ready name",
+			requestedName: " github-runner-ubuntu-24-04 ",
+			templates: []sandboxrunner.CatalogTemplate{{
+				TemplateID:  "tpl-ready",
+				Names:       []string{" github-runner-ubuntu-24-04 "},
+				BuildStatus: "ready",
+				Public:      true,
+			}},
+			wantID: "tpl-ready",
+		},
+		{
+			name:          "qualified uploaded name",
+			requestedName: "github-runner-ubuntu-24-04",
+			templates: []sandboxrunner.CatalogTemplate{{
+				TemplateID:  "tpl-uploaded",
+				Names:       []string{"tenant/github-runner-ubuntu-24-04"},
+				BuildStatus: "uploaded",
+				Public:      true,
+			}},
+			wantID: "tpl-uploaded",
+		},
+		{
+			name:          "missing does not match alias or substring",
+			requestedName: "github-runner-ubuntu-24-04",
+			templates: []sandboxrunner.CatalogTemplate{{
+				TemplateID:  "tpl-alias",
+				Aliases:     []string{"github-runner-ubuntu-24-04"},
+				Names:       []string{"prefix-github-runner-ubuntu-24-04-suffix"},
+				BuildStatus: "ready",
+				Public:      true,
+			}},
+			wantReason: defaultTemplateResolutionReasonMissing,
+		},
+		{
+			name:          "blank requested name",
+			requestedName: "  ",
+			templates: []sandboxrunner.CatalogTemplate{{
+				TemplateID:  "tpl-namespace",
+				Names:       []string{"tenant/"},
+				BuildStatus: "ready",
+				Public:      true,
+			}},
+			wantReason: defaultTemplateResolutionReasonMissing,
+		},
+		{
+			name:          "duplicate matching templates",
+			requestedName: "github-runner-ubuntu-24-04",
+			templates: []sandboxrunner.CatalogTemplate{
+				{
+					TemplateID:  "tpl-one",
+					Names:       []string{"github-runner-ubuntu-24-04"},
+					BuildStatus: "ready",
+					Public:      true,
+				},
+				{
+					TemplateID:  "tpl-two",
+					Names:       []string{"tenant/github-runner-ubuntu-24-04"},
+					BuildStatus: "ready",
+					Public:      true,
+				},
+			},
+			wantReason: defaultTemplateResolutionReasonDuplicate,
+		},
+		{
+			name:          "valid and private matches are duplicate",
+			requestedName: "github-runner-ubuntu-24-04",
+			templates: []sandboxrunner.CatalogTemplate{
+				{
+					TemplateID:  "tpl-valid",
+					Names:       []string{"github-runner-ubuntu-24-04"},
+					BuildStatus: "ready",
+					Public:      true,
+				},
+				{
+					TemplateID:  "tpl-private",
+					Names:       []string{"tenant/github-runner-ubuntu-24-04"},
+					BuildStatus: "ready",
+					Public:      false,
+				},
+			},
+			wantReason: defaultTemplateResolutionReasonDuplicate,
+		},
+		{
+			name:          "valid and building matches are duplicate",
+			requestedName: "github-runner-ubuntu-24-04",
+			templates: []sandboxrunner.CatalogTemplate{
+				{
+					TemplateID:  "tpl-valid",
+					Names:       []string{"github-runner-ubuntu-24-04"},
+					BuildStatus: "uploaded",
+					Public:      true,
+				},
+				{
+					TemplateID:  "tpl-building",
+					Names:       []string{"tenant/github-runner-ubuntu-24-04"},
+					BuildStatus: "building",
+					Public:      true,
+				},
+			},
+			wantReason: defaultTemplateResolutionReasonDuplicate,
+		},
+		{
+			name:          "valid and empty id matches are duplicate",
+			requestedName: "github-runner-ubuntu-24-04",
+			templates: []sandboxrunner.CatalogTemplate{
+				{
+					TemplateID:  "tpl-valid",
+					Names:       []string{"github-runner-ubuntu-24-04"},
+					BuildStatus: "ready",
+					Public:      true,
+				},
+				{
+					TemplateID:  "",
+					Names:       []string{"tenant/github-runner-ubuntu-24-04"},
+					BuildStatus: "ready",
+					Public:      true,
+				},
+			},
+			wantReason: defaultTemplateResolutionReasonDuplicate,
+		},
+		{
+			name:          "private template",
+			requestedName: "github-runner-ubuntu-24-04",
+			templates: []sandboxrunner.CatalogTemplate{{
+				TemplateID:  "tpl-private",
+				Names:       []string{"github-runner-ubuntu-24-04"},
+				BuildStatus: "ready",
+				Public:      false,
+			}},
+			wantReason: defaultTemplateResolutionReasonPrivate,
+		},
+		{
+			name:          "non runnable template",
+			requestedName: "github-runner-ubuntu-24-04",
+			templates: []sandboxrunner.CatalogTemplate{{
+				TemplateID:  "tpl-building",
+				Names:       []string{"github-runner-ubuntu-24-04"},
+				BuildStatus: "building",
+				Public:      true,
+			}},
+			wantReason: defaultTemplateResolutionReasonNonRunnable,
+		},
+		{
+			name:          "empty template id",
+			requestedName: "github-runner-ubuntu-24-04",
+			templates: []sandboxrunner.CatalogTemplate{{
+				TemplateID:  "  ",
+				Names:       []string{"github-runner-ubuntu-24-04"},
+				BuildStatus: "ready",
+				Public:      true,
+			}},
+			wantReason: defaultTemplateResolutionReasonEmptyID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveDefaultTemplateID(tt.requestedName, tt.templates)
+			if tt.wantReason == "" {
+				if err != nil {
+					t.Fatalf("resolveDefaultTemplateID: %v", err)
+				}
+				if got != tt.wantID {
+					t.Fatalf("template id = %q, want %q", got, tt.wantID)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("resolveDefaultTemplateID returned id %q, want error reason %q", got, tt.wantReason)
+			}
+			var resolutionErr *defaultTemplateResolutionError
+			if !errors.As(err, &resolutionErr) {
+				t.Fatalf("error type = %T, want *defaultTemplateResolutionError", err)
+			}
+			if resolutionErr.RequestedName != strings.TrimSpace(tt.requestedName) {
+				t.Fatalf("requested name = %q, want %q", resolutionErr.RequestedName, strings.TrimSpace(tt.requestedName))
+			}
+			if resolutionErr.Reason != tt.wantReason {
+				t.Fatalf("reason = %q, want %q", resolutionErr.Reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestClassifyRetryableErrorPrefersWrappedDefaultTemplateResolutionReason(t *testing.T) {
+	err := fmt.Errorf("resolve managed runner template: %w", &defaultTemplateResolutionError{
+		RequestedName: "runner status 429 timeout",
+		Reason:        defaultTemplateResolutionReasonMissing,
+	})
+
+	code, retryable := classifyRetryableError("template_resolution", err)
+
+	if code != defaultTemplateResolutionReasonMissing || retryable {
+		t.Fatalf("classification = (%q, %v), want (%q, false)", code, retryable, defaultTemplateResolutionReasonMissing)
+	}
+}
+
+func TestRunnerLifecycleCustomTemplateUsesStoredIDWithoutCatalog(t *testing.T) {
+	events := &lifecycleEventRecorder{}
+	ghServer := newLifecycleGitHubServer(t, events)
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	upsertLifecycleProfile(t, store, state.RunnerProfile{
+		Name:           "custom",
+		Labels:         []string{"self-hosted", "custom"},
+		TemplateID:     "custom-template-id",
+		MaxConcurrency: 10,
+		Enabled:        true,
+	})
+	sandbox := &lifecycleSandboxService{events: events}
+	srv := newRunnerLifecycleTestServer(t, store, ghServer.URL, sandbox)
+	createLifecycleRequest(t, store, "custom-request", "custom", 0)
+
+	go srv.startRunner(context.Background(), "custom-request", "worker-test")
+	waitForState(t, store, "custom-request", state.StatusRunning)
+
+	inputs := sandbox.startInputs()
+	if len(inputs) != 1 || inputs[0].TemplateID != "custom-template-id" {
+		t.Fatalf("StartRunner inputs = %#v, want stored custom template id", inputs)
+	}
+}
+
+func TestRunnerLifecycleManagedDefaultResolvesBeforeRegistration(t *testing.T) {
+	events := &lifecycleEventRecorder{}
+	ghServer := newLifecycleGitHubServer(t, events)
+	defer ghServer.Close()
+
+	baseStore := state.New(t.TempDir())
+	upsertLifecycleProfile(t, baseStore, lifecycleManagedProfile("catalog-bootstrap-id"))
+	store := &profileLoadRecordingStore{Store: baseStore, events: events}
+	sandbox := &managedLifecycleSandboxService{
+		lifecycleSandboxService: &lifecycleSandboxService{events: events},
+		templates: []sandboxrunner.CatalogTemplate{{
+			TemplateID:  "scoped-template-id",
+			Names:       []string{"region/github-runner-ubuntu-24-04"},
+			BuildStatus: "uploaded",
+			Public:      true,
+		}},
+	}
+	srv := newRunnerLifecycleTestServer(t, store, ghServer.URL, sandbox)
+	createLifecycleRequest(t, store, "managed-request", "managed", 987)
+
+	go srv.startRunner(context.Background(), "managed-request", "worker-test")
+	waitForState(t, store, "managed-request", state.StatusRunning)
+
+	inputs := sandbox.startInputs()
+	if len(inputs) != 1 || inputs[0].TemplateID != "scoped-template-id" {
+		t.Fatalf("StartRunner inputs = %#v, want resolved scoped template id", inputs)
+	}
+	if got := events.snapshot(); !equalStrings(got, []string{"profile", "catalog", "token", "start"}) {
+		t.Fatalf("lifecycle order = %#v, want [profile catalog token start]", got)
+	}
+}
+
+func TestRunnerLifecycleManagedResolutionFailuresAreNonRetryable(t *testing.T) {
+	tests := []struct {
+		name          string
+		requestedName string
+		templates     []sandboxrunner.CatalogTemplate
+		reason        string
+	}{
+		{
+			name:          "missing with retry-like requested name",
+			requestedName: "runner status 429 timeout",
+			reason:        defaultTemplateResolutionReasonMissing,
+		},
+		{
+			name:          "non runnable",
+			requestedName: "github-runner-ubuntu-24-04",
+			templates: []sandboxrunner.CatalogTemplate{{
+				TemplateID:  "template-building",
+				Names:       []string{"github-runner-ubuntu-24-04"},
+				BuildStatus: "building",
+				Public:      true,
+			}},
+			reason: defaultTemplateResolutionReasonNonRunnable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tokenCalls int
+			ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tokenCalls++
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"token":"runner-token","expires_at":"2026-05-18T10:00:00Z"}`))
+			}))
+			defer ghServer.Close()
+
+			store := state.New(t.TempDir())
+			profile := lifecycleManagedProfile("catalog-bootstrap-id")
+			profile.DefaultTemplateName = tt.requestedName
+			upsertLifecycleProfile(t, store, profile)
+			sandbox := &managedLifecycleSandboxService{
+				lifecycleSandboxService: &lifecycleSandboxService{},
+				templates:               tt.templates,
+			}
+			srv := newRunnerLifecycleTestServer(t, store, ghServer.URL, sandbox)
+			createLifecycleRequest(t, store, "resolution-failure", "managed", 987)
+
+			go srv.startRunner(context.Background(), "resolution-failure", "worker-test")
+			waitForLifecycleOutcome(t, store, "resolution-failure")
+
+			got, err := store.ReadState("resolution-failure")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != state.StatusFailed ||
+				got.FailureStage != "template_resolution" ||
+				got.FailureReason != tt.reason ||
+				got.LastErrorCode != tt.reason ||
+				got.LastErrorRetryable {
+				t.Fatalf("state = %#v, want non-retryable template_resolution/%s failure", got, tt.reason)
+			}
+			var resolutionErr *defaultTemplateResolutionError
+			_, directErr := resolveDefaultTemplateID(tt.requestedName, tt.templates)
+			if !errors.As(directErr, &resolutionErr) || resolutionErr.Reason != tt.reason {
+				t.Fatalf("resolver error = %#v, want reason %q", directErr, tt.reason)
+			}
+			if tokenCalls != 0 {
+				t.Fatalf("registration token calls = %d, want 0", tokenCalls)
+			}
+			if len(sandbox.startInputs()) != 0 {
+				t.Fatalf("StartRunner inputs = %#v, want none", sandbox.startInputs())
+			}
+		})
+	}
+}
+
+func TestRunnerLifecycleManagedServiceWithoutDefaultTemplateCatalogFailsBeforeRegistration(t *testing.T) {
+	var tokenCalls int
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenCalls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"runner-token","expires_at":"2026-05-18T10:00:00Z"}`))
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	profile := lifecycleManagedProfile("catalog-bootstrap-id")
+	profile.DefaultTemplateName = "runner status 429 timeout"
+	upsertLifecycleProfile(t, store, profile)
+	sandbox := &lifecycleSandboxService{}
+	srv := newRunnerLifecycleTestServer(t, store, ghServer.URL, sandbox)
+	createLifecycleRequest(t, store, "catalog-capability-missing", "managed", 987)
+
+	srv.startRunner(context.Background(), "catalog-capability-missing", "worker-test")
+
+	got, err := store.ReadState("catalog-capability-missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusFailed ||
+		got.FailureStage != "template_resolution" ||
+		got.FailureReason != defaultTemplateResolutionReasonNoCatalog ||
+		got.LastErrorCode != defaultTemplateResolutionReasonNoCatalog ||
+		got.LastErrorRetryable {
+		t.Fatalf("state = %#v, want non-retryable template_resolution/%s failure", got, defaultTemplateResolutionReasonNoCatalog)
+	}
+	if tokenCalls != 0 {
+		t.Fatalf("registration token calls = %d, want 0", tokenCalls)
+	}
+	if len(sandbox.startInputs()) != 0 {
+		t.Fatalf("StartRunner inputs = %#v, want none", sandbox.startInputs())
+	}
+}
+
+func TestRunnerLifecycleDefaultCatalogErrorsKeepRetryClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		listErr  error
+		wantCode string
+	}{
+		{name: "rate limit", listErr: errors.New("status 429 too many requests"), wantCode: "http_rate_limited"},
+		{name: "server error", listErr: errors.New("status 503 service unavailable"), wantCode: "backend_server_error"},
+		{name: "network", listErr: errors.New("connection reset by peer"), wantCode: "temporary_network_error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tokenCalls int
+			ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tokenCalls++
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{"token":"runner-token","expires_at":"2026-05-18T10:00:00Z"}`))
+			}))
+			defer ghServer.Close()
+
+			store := state.New(t.TempDir())
+			upsertLifecycleProfile(t, store, lifecycleManagedProfile("catalog-bootstrap-id"))
+			sandbox := &managedLifecycleSandboxService{
+				lifecycleSandboxService: &lifecycleSandboxService{},
+				listErr:                 tt.listErr,
+			}
+			srv := newRunnerLifecycleTestServer(t, store, ghServer.URL, sandbox)
+			createLifecycleRequest(t, store, "catalog-error", "managed", 987)
+
+			go srv.startRunner(context.Background(), "catalog-error", "worker-test")
+			waitForLifecycleOutcome(t, store, "catalog-error")
+
+			got, err := store.ReadState("catalog-error")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != state.StatusQueued ||
+				got.FailureStage != "template_resolution" ||
+				got.LastErrorCode != tt.wantCode ||
+				!got.LastErrorRetryable {
+				t.Fatalf("state = %#v, want retryable %q template_resolution failure", got, tt.wantCode)
+			}
+			if tokenCalls != 0 || len(sandbox.startInputs()) != 0 {
+				t.Fatalf("token calls = %d StartRunner inputs = %#v, want neither", tokenCalls, sandbox.startInputs())
+			}
+		})
+	}
+}
+
+func TestRunnerLifecycleManagedResolutionUsesScopedSandboxServiceWithoutLeakingKey(t *testing.T) {
+	const apiKey = "scoped-sandbox-secret-key"
+	var catalogCalls int
+	sandboxAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/default-templates" {
+			http.Error(w, "unexpected sandbox request", http.StatusNotFound)
+			return
+		}
+		catalogCalls++
+		if got := r.Header.Get("Authorization"); got != "Bearer "+apiKey {
+			t.Errorf("sandbox authorization = %q, want scoped credential", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer sandboxAPI.Close()
+
+	var tokenCalls int
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenCalls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"runner-token","expires_at":"2026-05-18T10:00:00Z"}`))
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	upsertLifecycleProfile(t, store, lifecycleManagedProfile("catalog-bootstrap-id"))
+	srv := newRunnerLifecycleTestServer(t, store, ghServer.URL, nil)
+	srv.sandboxHTTP = sandboxAPI.Client()
+	valueJSON, err := json.Marshal(accountSandboxServicePreferenceValue{APIURL: sandboxAPI.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertAccountPreference(state.AccountPreference{
+		ScopeType: state.AccountScopeTypeGitHubInstall,
+		ScopeID:   987,
+		Namespace: accountPreferenceNamespaceSandbox,
+		Key:       accountPreferenceKeySandboxService,
+		ValueJSON: string(valueJSON),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	encryptedKey, err := encryptSecret(apiKey, srv.cfg.AuthEncryptionKey.Value())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertAccountSecret(state.AccountSecret{
+		ScopeType:      state.AccountScopeTypeGitHubInstall,
+		ScopeID:        987,
+		KeyType:        state.AccountSecretTypeSandboxAPIKey,
+		EncryptedValue: encryptedKey,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	createLifecycleRequest(t, store, "scoped-resolution", "managed", 987)
+
+	srv.startRunner(context.Background(), "scoped-resolution", "worker-test")
+
+	got, err := store.ReadState("scoped-resolution")
+	if err != nil {
+		t.Fatal(err)
+	}
+	logData, err := store.ReadLog("scoped-resolution", "control.log", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if catalogCalls != 1 {
+		t.Fatalf("scoped default catalog calls = %d, want 1", catalogCalls)
+	}
+	if tokenCalls != 0 {
+		t.Fatalf("registration token calls = %d, want 0", tokenCalls)
+	}
+	if got.FailureStage != "template_resolution" || got.LastErrorRetryable {
+		t.Fatalf("state = %#v, want non-retryable template_resolution failure", got)
+	}
+	if strings.Contains(got.Error, apiKey) ||
+		strings.Contains(got.LastErrorMessage, apiKey) ||
+		strings.Contains(string(logData), apiKey) {
+		t.Fatalf("user-visible failure exposed scoped Sandbox API key: state=%#v log=%q", got, logData)
+	}
+}
+
+func TestRunnerLifecycleManagedResolutionDoesNotCacheOrRewriteProfile(t *testing.T) {
+	ghServer := newLifecycleGitHubServer(t, nil)
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	original := lifecycleManagedProfile("catalog-bootstrap-id")
+	upsertLifecycleProfile(t, store, original)
+
+	firstSandbox := &managedLifecycleSandboxService{
+		lifecycleSandboxService: &lifecycleSandboxService{},
+		templates: []sandboxrunner.CatalogTemplate{{
+			TemplateID:  "region-a-template-id",
+			Names:       []string{"github-runner-ubuntu-24-04"},
+			BuildStatus: "ready",
+			Public:      true,
+		}},
+	}
+	firstServer := newRunnerLifecycleTestServer(t, store, ghServer.URL, firstSandbox)
+	createLifecycleRequest(t, store, "region-a", "managed", 101)
+	go firstServer.startRunner(context.Background(), "region-a", "worker-a")
+	waitForState(t, store, "region-a", state.StatusRunning)
+
+	secondSandbox := &managedLifecycleSandboxService{
+		lifecycleSandboxService: &lifecycleSandboxService{},
+		templates: []sandboxrunner.CatalogTemplate{{
+			TemplateID:  "region-b-template-id",
+			Names:       []string{"github-runner-ubuntu-24-04"},
+			BuildStatus: "ready",
+			Public:      true,
+		}},
+	}
+	secondServer := newRunnerLifecycleTestServer(t, store, ghServer.URL, secondSandbox)
+	createLifecycleRequest(t, store, "region-b", "managed", 202)
+	go secondServer.startRunner(context.Background(), "region-b", "worker-b")
+	waitForState(t, store, "region-b", state.StatusRunning)
+
+	firstInputs := firstSandbox.startInputs()
+	secondInputs := secondSandbox.startInputs()
+	if len(firstInputs) != 1 || firstInputs[0].TemplateID != "region-a-template-id" {
+		t.Fatalf("region A inputs = %#v, want its resolved template id", firstInputs)
+	}
+	if len(secondInputs) != 1 || secondInputs[0].TemplateID != "region-b-template-id" {
+		t.Fatalf("region B inputs = %#v, want its resolved template id", secondInputs)
+	}
+	if firstSandbox.catalogCallCount() != 1 || secondSandbox.catalogCallCount() != 1 {
+		t.Fatalf("catalog calls = (%d, %d), want one per runner without cache", firstSandbox.catalogCallCount(), secondSandbox.catalogCallCount())
+	}
+	saved, err := store.GetProfile("managed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.TemplateID != original.TemplateID ||
+		saved.DefaultTemplateName != original.DefaultTemplateName ||
+		saved.ManagedBy != original.ManagedBy {
+		t.Fatalf("managed profile was rewritten: got %#v want stable fields from %#v", saved, original)
+	}
+}
+
+type lifecycleEventRecorder struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (r *lifecycleEventRecorder) add(event string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+}
+
+func (r *lifecycleEventRecorder) snapshot() []string {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.events...)
+}
+
+type profileLoadRecordingStore struct {
+	state.Store
+	events *lifecycleEventRecorder
+}
+
+func (s *profileLoadRecordingStore) GetProfile(name string) (state.RunnerProfile, error) {
+	s.events.add("profile")
+	return s.Store.GetProfile(name)
+}
+
+type lifecycleSandboxService struct {
+	mu     sync.Mutex
+	events *lifecycleEventRecorder
+	inputs []sandboxrunner.StartInput
+}
+
+func (s *lifecycleSandboxService) ValidateTemplate(context.Context, string) error {
+	return nil
+}
+
+func (s *lifecycleSandboxService) StartRunner(_ context.Context, input sandboxrunner.StartInput) (sandboxrunner.StartResult, error) {
+	s.mu.Lock()
+	s.inputs = append(s.inputs, input)
+	s.mu.Unlock()
+	s.events.add("start")
+	return sandboxrunner.StartResult{SandboxID: "sandbox-" + input.RequestID, PID: 42}, nil
+}
+
+func (s *lifecycleSandboxService) RecoverRunner(_ context.Context, input sandboxrunner.RecoverInput) (sandboxrunner.StartResult, error) {
+	return sandboxrunner.StartResult{SandboxID: input.SandboxID, PID: input.PID}, nil
+}
+
+func (s *lifecycleSandboxService) StopRunner(context.Context, string, uint32) error {
+	return nil
+}
+
+func (s *lifecycleSandboxService) StartTerminal(context.Context, string, sandboxrunner.PtySize, func([]byte)) (sandboxrunner.TerminalSession, error) {
+	return nil, nil
+}
+
+func (s *lifecycleSandboxService) startInputs() []sandboxrunner.StartInput {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]sandboxrunner.StartInput(nil), s.inputs...)
+}
+
+type managedLifecycleSandboxService struct {
+	*lifecycleSandboxService
+
+	mu           sync.Mutex
+	templates    []sandboxrunner.CatalogTemplate
+	listErr      error
+	catalogCalls int
+}
+
+func (s *managedLifecycleSandboxService) ListDefaultTemplates(context.Context) ([]sandboxrunner.CatalogTemplate, error) {
+	s.mu.Lock()
+	s.catalogCalls++
+	templates := append([]sandboxrunner.CatalogTemplate(nil), s.templates...)
+	err := s.listErr
+	s.mu.Unlock()
+	s.events.add("catalog")
+	return templates, err
+}
+
+func (s *managedLifecycleSandboxService) catalogCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.catalogCalls
+}
+
+func newRunnerLifecycleTestServer(t *testing.T, store state.Store, ghURL string, sandbox sandboxrunner.Service) *Server {
+	t.Helper()
+	cfg := config.Config{
+		AuthEncryptionKey:    "lifecycle-encryption-key",
+		SandboxTimeout:       time.Hour,
+		SandboxCreateTimeout: time.Second,
+		SandboxStopTimeout:   time.Second,
+		WorkerLeaseTTL:       time.Minute,
+		RetryBaseDelay:       time.Minute,
+		RetryMaxDelay:        time.Minute,
+		RetryMaxAttempts:     3,
+		MaxConcurrentRunners: 10,
+		GitHubAPIBaseURL:     ghURL,
+	}
+	srv := New(cfg, store, github.NewClient(ghURL, http.DefaultClient), sandbox, nil)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newLifecycleGitHubServer(t *testing.T, events *lifecycleEventRecorder) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/repos/o/r/actions/runners/registration-token" {
+			t.Errorf("unexpected GitHub request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
+		}
+		events.add("token")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"runner-token","expires_at":"2026-05-18T10:00:00Z"}`))
+	}))
+}
+
+func upsertLifecycleProfile(t *testing.T, store state.Store, profile state.RunnerProfile) {
+	t.Helper()
+	if _, err := store.UpsertProfile(profile); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func lifecycleManagedProfile(templateID string) state.RunnerProfile {
+	return state.RunnerProfile{
+		Name:                "managed",
+		Labels:              []string{"self-hosted", "managed"},
+		RequiredLabels:      []string{"managed"},
+		TemplateID:          templateID,
+		DefaultTemplateName: "github-runner-ubuntu-24-04",
+		MaxConcurrency:      10,
+		Enabled:             true,
+		ManagedBy:           "qiniu/ci-runner",
+		CatalogRevision:     1,
+	}
+}
+
+func createLifecycleRequest(t *testing.T, store state.Store, id, profileName string, installationID int64) {
+	t.Helper()
+	created, _, err := store.CreateRequest(state.RunnerRequest{
+		ID:                   id,
+		Source:               "test",
+		GitHubInstallationID: installationID,
+		RepositoryFullName:   "o/r",
+		Labels:               []string{"self-hosted"},
+		ProfileName:          profileName,
+		RunnerName:           "e2b-" + id,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatalf("runner request %q was not created", id)
+	}
+}
+
+func waitForLifecycleOutcome(t *testing.T, store state.Store, id string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		current, err := store.ReadState(id)
+		if err == nil && (current.Status == state.StatusRunning || current.FailureStage != "") {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	current, _ := store.ReadState(id)
+	t.Fatalf("state %q did not reach running or failure: %#v", id, current)
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+var (
+	_ sandboxrunner.Service                = (*lifecycleSandboxService)(nil)
+	_ sandboxrunner.Service                = (*managedLifecycleSandboxService)(nil)
+	_ sandboxrunner.DefaultTemplateCatalog = (*managedLifecycleSandboxService)(nil)
+)
+
+func TestDefaultTemplateResolutionErrorIncludesRequestedNameAndMachineReason(t *testing.T) {
+	err := &defaultTemplateResolutionError{
+		RequestedName: "github-runner-ubuntu-24-04",
+		Reason:        defaultTemplateResolutionReasonMissing,
+	}
+	if got := err.Error(); !strings.Contains(got, err.RequestedName) || !strings.Contains(got, err.Reason) {
+		t.Fatalf("error message = %q, want requested name and reason", got)
+	}
+}

--- a/internal/server/server_runner_lifecycle.go
+++ b/internal/server/server_runner_lifecycle.go
@@ -136,6 +136,12 @@ func (s *Server) startRunner(ctx context.Context, id, workerID string) {
 		s.store.AppendLog(id, "control.log", []byte("runner start skipped because request is stopped\n"))
 		return
 	}
+	profile, err := s.store.GetProfile(req.ProfileName)
+	if err != nil {
+		unlock()
+		s.failStart(id, st, "profile_lookup", fmt.Errorf("load profile %q: %w", req.ProfileName, err))
+		return
+	}
 	s.admissionMu.Lock()
 	inFlight, err := s.store.InFlightCount()
 	if err != nil {
@@ -154,7 +160,7 @@ func (s *Server) startRunner(ctx context.Context, id, workerID string) {
 		return
 	}
 	if req.ProfileName != "" {
-		rejected, err := s.profileAtCapacity(req.ProfileName)
+		rejected, err := s.profileAtCapacityFor(profile)
 		if err != nil {
 			s.admissionMu.Unlock()
 			unlock()
@@ -194,21 +200,6 @@ func (s *Server) startRunner(ctx context.Context, id, workerID string) {
 		return
 	}
 
-	s.logger.Info("creating github registration token", "id", id)
-	s.store.AppendLog(id, "control.log", []byte("creating github registration token\n"))
-	createStartedAt := time.Now()
-	token, err := s.gh.CreateRegistrationToken(ctx, req.RepositoryFullName, req.RunnerGroup)
-	if err != nil {
-		s.failStart(id, st, "github_registration", err)
-		return
-	}
-	s.logger.Info("starting sandbox runner", "id", id, "runner_name", req.RunnerName)
-	s.store.AppendLog(id, "control.log", []byte("starting sandbox runner\n"))
-	profile, err := s.store.GetProfile(req.ProfileName)
-	if err != nil {
-		s.failStart(id, st, "profile_lookup", fmt.Errorf("load profile %q: %w", req.ProfileName, err))
-		return
-	}
 	sandboxService, sandboxConfig, err := s.sandboxServiceAndConfigForRunnerRequestContext(ctx, req)
 	if err != nil {
 		s.failStart(id, st, "sandbox_config", err)
@@ -228,6 +219,42 @@ func (s *Server) startRunner(ctx context.Context, id, workerID string) {
 			return
 		}
 	}
+	templateID := profile.TemplateID
+	if strings.TrimSpace(profile.ManagedBy) != "" {
+		catalog, ok := sandboxService.(sandboxrunner.DefaultTemplateCatalog)
+		if !ok {
+			s.failStart(id, st, "template_resolution", newDefaultTemplateResolutionError(
+				strings.TrimSpace(profile.DefaultTemplateName),
+				defaultTemplateResolutionReasonNoCatalog,
+			))
+			return
+		}
+		templates, err := catalog.ListDefaultTemplates(ctx)
+		if err != nil {
+			s.failStart(id, st, "template_resolution", fmt.Errorf(
+				"list default templates for %q: %w",
+				strings.TrimSpace(profile.DefaultTemplateName),
+				err,
+			))
+			return
+		}
+		templateID, err = resolveDefaultTemplateID(profile.DefaultTemplateName, templates)
+		if err != nil {
+			s.failStart(id, st, "template_resolution", err)
+			return
+		}
+	}
+
+	s.logger.Info("creating github registration token", "id", id)
+	s.store.AppendLog(id, "control.log", []byte("creating github registration token\n"))
+	createStartedAt := time.Now()
+	token, err := s.gh.CreateRegistrationToken(ctx, req.RepositoryFullName, req.RunnerGroup)
+	if err != nil {
+		s.failStart(id, st, "github_registration", err)
+		return
+	}
+	s.logger.Info("starting sandbox runner", "id", id, "runner_name", req.RunnerName)
+	s.store.AppendLog(id, "control.log", []byte("starting sandbox runner\n"))
 	exitCh := make(chan struct{})
 	startStage := "sandbox_start"
 	result, err := func() (sandboxrunner.StartResult, error) {
@@ -245,7 +272,7 @@ func (s *Server) startRunner(ctx context.Context, id, workerID string) {
 			RegistrationToken: token.Token,
 			Labels:            req.Labels,
 			RunnerGroup:       strings.TrimSpace(req.RunnerGroup),
-			TemplateID:        profile.TemplateID,
+			TemplateID:        templateID,
 			Timeout:           s.cfg.SandboxTimeout,
 			CommandContext:    ctx,
 			OnStdout:          func(data []byte) { s.appendRunnerStdout(id, data) },
@@ -1195,6 +1222,10 @@ func classifyRetryableError(stage string, err error) (string, bool) {
 	if err == nil {
 		return "", false
 	}
+	var resolutionErr *defaultTemplateResolutionError
+	if errors.As(err, &resolutionErr) {
+		return resolutionErr.Reason, false
+	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return "timeout", true
 	}
@@ -1354,15 +1385,11 @@ func appendError(current, extra string) string {
 	return current + "; " + extra
 }
 
-func (s *Server) profileAtCapacity(profileName string) (bool, error) {
-	profile, err := s.store.GetProfile(profileName)
-	if err != nil {
-		return false, err
-	}
+func (s *Server) profileAtCapacityFor(profile state.RunnerProfile) (bool, error) {
 	if profile.MaxConcurrency <= 0 {
 		return false, nil
 	}
-	inFlight, err := s.store.InFlightCountForProfile(profileName)
+	inFlight, err := s.store.InFlightCountForProfile(profile.Name)
 	if err != nil {
 		return false, err
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -36,27 +36,28 @@ import (
 )
 
 type fakeSandbox struct {
-	mu                 sync.Mutex
-	started            int
-	recovered          int
-	stopped            int
-	terminals          int
-	startBlock         chan struct{}
-	recoverBlock       chan struct{}
-	recoverStarted     chan string
-	recoverHook        func(sandboxrunner.RecoverInput)
-	recoverContextHook func(context.Context, sandboxrunner.RecoverInput)
-	recoverErr         error
-	recoverErrors      map[string]error
-	recoverResult      sandboxrunner.StartResult
-	recoverInput       sandboxrunner.RecoverInput
-	recoverInFlight    int
-	maxRecoverInFlight int
-	stopErr            error
-	commandContext     context.Context
-	repositoryURL      string
-	runnerGroup        string
-	terminal           *fakeTerminalSession
+	mu                  sync.Mutex
+	started             int
+	recovered           int
+	stopped             int
+	terminals           int
+	templateValidations int
+	startBlock          chan struct{}
+	recoverBlock        chan struct{}
+	recoverStarted      chan string
+	recoverHook         func(sandboxrunner.RecoverInput)
+	recoverContextHook  func(context.Context, sandboxrunner.RecoverInput)
+	recoverErr          error
+	recoverErrors       map[string]error
+	recoverResult       sandboxrunner.StartResult
+	recoverInput        sandboxrunner.RecoverInput
+	recoverInFlight     int
+	maxRecoverInFlight  int
+	stopErr             error
+	commandContext      context.Context
+	repositoryURL       string
+	runnerGroup         string
+	terminal            *fakeTerminalSession
 }
 
 type blockingSandboxDefaultStore struct {
@@ -76,6 +77,9 @@ func (s *blockingSandboxDefaultStore) GetSandboxServiceDefault() (state.SandboxS
 }
 
 func (f *fakeSandbox) ValidateTemplate(ctx context.Context, templateID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.templateValidations++
 	return nil
 }
 
@@ -235,6 +239,12 @@ func (f *fakeSandbox) startedCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.started
+}
+
+func (f *fakeSandbox) templateValidationCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.templateValidations
 }
 
 func (f *fakeSandbox) stoppedCount() int {
@@ -6172,9 +6182,10 @@ func TestProfileAndRepositoryPolicyEndpoints(t *testing.T) {
 
 func TestCreateProfileStoresTemplateWithoutSandboxValidation(t *testing.T) {
 	store := state.New(t.TempDir())
-	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+	fake := &fakeSandbox{}
+	srv := newTestServer(t, store, "http://example.test", fake)
 
-	profileBody := bytes.NewBufferString(`{"name":"large","labels":["self-hosted","e2b","large"],"template_id":"missing-template","max_concurrency":5,"enabled":true}`)
+	profileBody := bytes.NewBufferString(`{"name":"large","labels":["self-hosted","e2b","large"],"required_labels":["e2b","large"],"template_id":"missing-template","max_concurrency":5,"enabled":true}`)
 	req := adminRequest(http.MethodPost, "/runner_specs", profileBody)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -6188,11 +6199,78 @@ func TestCreateProfileStoresTemplateWithoutSandboxValidation(t *testing.T) {
 	if profile.TemplateID != "missing-template" {
 		t.Fatalf("template id should be persisted without sandbox validation: %#v", profile)
 	}
+	if !reflect.DeepEqual(profile.RequiredLabels, []string{"e2b", "large"}) {
+		t.Fatalf("required labels = %#v, want [e2b large]", profile.RequiredLabels)
+	}
+	if got := fake.templateValidationCount(); got != 0 {
+		t.Fatalf("sandbox template validations = %d, want 0", got)
+	}
+}
+
+func TestCreateProfileRequiresTemplateID(t *testing.T) {
+	store := state.New(t.TempDir())
+	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+
+	req := adminRequest(
+		http.MethodPost,
+		"/runner_specs",
+		bytes.NewBufferString(`{"name":"large","labels":["self-hosted","e2b","large"],"max_concurrency":5,"enabled":true}`),
+	)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if _, err := store.GetProfile("large"); err == nil {
+		t.Fatal("profile without template_id was persisted")
+	}
+}
+
+func TestCreateProfileRejectsManagedMetadata(t *testing.T) {
+	metadataFields := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "managed by value", key: "managed_by", value: `"client"`},
+		{name: "managed by null", key: "managed_by", value: `null`},
+		{name: "catalog revision value", key: "catalog_revision", value: `99`},
+		{name: "catalog revision null", key: "catalog_revision", value: `null`},
+		{name: "default template name value", key: "default_template_name", value: `"client-template"`},
+		{name: "default template name null", key: "default_template_name", value: `null`},
+		{name: "mixed case managed by value", key: "Managed_By", value: `"client"`},
+		{name: "mixed case managed by null", key: "Managed_By", value: `null`},
+		{name: "mixed case catalog revision value", key: "Catalog_Revision", value: `99`},
+		{name: "mixed case catalog revision null", key: "Catalog_Revision", value: `null`},
+		{name: "mixed case default template name value", key: "Default_Template_Name", value: `"client-template"`},
+		{name: "mixed case default template name null", key: "Default_Template_Name", value: `null`},
+	}
+
+	for _, tt := range metadataFields {
+		t.Run(tt.name, func(t *testing.T) {
+			store := state.New(t.TempDir())
+			srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+			body := `{"name":"large","labels":["self-hosted","e2b","large"],"template_id":"custom-template","` +
+				tt.key + `":` + tt.value + `}`
+
+			req := adminRequest(http.MethodPost, "/runner_specs", bytes.NewBufferString(body))
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body=%s, want 400", rec.Code, rec.Body.String())
+			}
+			if _, err := store.GetProfile("large"); err == nil {
+				t.Fatal("profile with client-supplied managed metadata was persisted")
+			}
+		})
+	}
 }
 
 func TestPatchProfileStoresTemplateWithoutSandboxValidation(t *testing.T) {
 	store := state.New(t.TempDir())
-	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+	fake := &fakeSandbox{}
+	srv := newTestServer(t, store, "http://example.test", fake)
 
 	profileBody := bytes.NewBufferString(`{"name":"large","labels":["self-hosted","e2b","large"],"template_id":"valid-template","max_concurrency":5,"enabled":true}`)
 	req := adminRequest(http.MethodPost, "/runner_specs", profileBody)
@@ -6214,6 +6292,9 @@ func TestPatchProfileStoresTemplateWithoutSandboxValidation(t *testing.T) {
 	}
 	if profile.TemplateID != "not-ready-template" {
 		t.Fatalf("template id update should be persisted without sandbox validation: %#v", profile)
+	}
+	if got := fake.templateValidationCount(); got != 0 {
+		t.Fatalf("sandbox template validations = %d, want 0", got)
 	}
 }
 
@@ -6255,6 +6336,397 @@ func TestPatchProfilePreservesAndAllowsZeroSchedulingFields(t *testing.T) {
 	}
 	if profile.MinIdle != 0 || profile.Priority != 0 {
 		t.Fatalf("explicit zero scheduling fields were not applied: %#v", profile)
+	}
+}
+
+func TestPatchProfileClearsExplicitEmptyFieldsAndPreservesOmittedFields(t *testing.T) {
+	store := state.New(t.TempDir())
+	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+	_, err := store.UpsertProfile(state.RunnerProfile{
+		Name:             "large",
+		Labels:           []string{"self-hosted", "e2b", "large"},
+		RequiredLabels:   []string{"e2b", "large"},
+		TemplateID:       "valid-template",
+		RunnerGroup:      "gpu",
+		MaxConcurrency:   5,
+		MinIdle:          2,
+		Priority:         10,
+		Enabled:          true,
+		DefaultAvailable: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := adminRequest(
+		http.MethodPatch,
+		"/runner_specs/large",
+		bytes.NewBufferString(`{"required_labels":[],"runner_group":""}`),
+	)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	profile, err := store.GetProfile("large")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(profile.RequiredLabels) != 0 {
+		t.Fatalf("required labels = %#v, want empty", profile.RequiredLabels)
+	}
+	if profile.RunnerGroup != "" {
+		t.Fatalf("runner group = %q, want empty", profile.RunnerGroup)
+	}
+	if !reflect.DeepEqual(profile.Labels, []string{"self-hosted", "e2b", "large"}) ||
+		profile.TemplateID != "valid-template" ||
+		profile.MaxConcurrency != 5 ||
+		profile.MinIdle != 2 ||
+		profile.Priority != 10 ||
+		!profile.Enabled ||
+		!profile.DefaultAvailable {
+		t.Fatalf("omitted fields changed: %#v", profile)
+	}
+}
+
+func TestPatchCustomProfileRejectsManagedMetadata(t *testing.T) {
+	metadataFields := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "managed by value", key: "managed_by", value: `"client"`},
+		{name: "managed by null", key: "managed_by", value: `null`},
+		{name: "catalog revision value", key: "catalog_revision", value: `99`},
+		{name: "catalog revision null", key: "catalog_revision", value: `null`},
+		{name: "default template name value", key: "default_template_name", value: `"client-template"`},
+		{name: "default template name null", key: "default_template_name", value: `null`},
+		{name: "mixed case managed by value", key: "Managed_By", value: `"client"`},
+		{name: "mixed case managed by null", key: "Managed_By", value: `null`},
+		{name: "mixed case catalog revision value", key: "Catalog_Revision", value: `99`},
+		{name: "mixed case catalog revision null", key: "Catalog_Revision", value: `null`},
+		{name: "mixed case default template name value", key: "Default_Template_Name", value: `"client-template"`},
+		{name: "mixed case default template name null", key: "Default_Template_Name", value: `null`},
+	}
+
+	for _, tt := range metadataFields {
+		t.Run(tt.name, func(t *testing.T) {
+			store := state.New(t.TempDir())
+			srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+			want, err := store.UpsertProfile(state.RunnerProfile{
+				Name:             "large",
+				Labels:           []string{"self-hosted", "e2b", "large"},
+				RequiredLabels:   []string{"e2b", "large"},
+				TemplateID:       "custom-template",
+				MaxConcurrency:   5,
+				MinIdle:          2,
+				Priority:         10,
+				Enabled:          true,
+				DefaultAvailable: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := `{"` + tt.key + `":` + tt.value + `}`
+
+			req := adminRequest(http.MethodPatch, "/runner_specs/large", bytes.NewBufferString(body))
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body=%s, want 400", rec.Code, rec.Body.String())
+			}
+
+			got, err := store.GetProfile("large")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("rejected patch changed custom profile: got %#v want %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestPatchManagedProfileAllowsOnlyOperatorControls(t *testing.T) {
+	store := state.New(t.TempDir())
+	managed := managedProfileForServerTest()
+	if conflicts, err := store.ReconcileManagedProfiles([]state.RunnerProfile{managed}); err != nil {
+		t.Fatal(err)
+	} else if len(conflicts) != 0 {
+		t.Fatalf("managed profile conflicts = %#v, want none", conflicts)
+	}
+	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+
+	req := adminRequest(
+		http.MethodPatch,
+		"/runner_specs/"+managed.Name,
+		bytes.NewBufferString(`{"enabled":false,"max_concurrency":3,"min_idle":1}`),
+	)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	got, err := store.GetProfile(managed.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Enabled || got.MaxConcurrency != 3 || got.MinIdle != 1 {
+		t.Fatalf("operator controls were not updated: %#v", got)
+	}
+	if !reflect.DeepEqual(got.Labels, managed.Labels) ||
+		!reflect.DeepEqual(got.RequiredLabels, managed.RequiredLabels) ||
+		got.TemplateID != managed.TemplateID ||
+		got.DefaultTemplateName != managed.DefaultTemplateName ||
+		got.RunnerGroup != managed.RunnerGroup ||
+		got.Priority != managed.Priority ||
+		got.DefaultAvailable != managed.DefaultAvailable ||
+		got.ManagedBy != managed.ManagedBy ||
+		got.CatalogRevision != managed.CatalogRevision {
+		t.Fatalf("managed catalog fields changed: got %#v want catalog fields from %#v", got, managed)
+	}
+}
+
+func TestPatchManagedProfileRejectsProtectedFieldsByPresence(t *testing.T) {
+	protectedFields := []struct {
+		name  string
+		key   string
+		value string
+		extra string
+	}{
+		{name: "labels value", key: "labels", value: `[]`},
+		{name: "labels null", key: "labels", value: `null`},
+		{name: "required labels value", key: "required_labels", value: `[]`},
+		{name: "required labels null", key: "required_labels", value: `null`},
+		{name: "template id value", key: "template_id", value: `""`},
+		{name: "template id null", key: "template_id", value: `null`},
+		{name: "runner group value", key: "runner_group", value: `""`},
+		{name: "runner group null", key: "runner_group", value: `null`},
+		{name: "priority value", key: "priority", value: `0`},
+		{name: "priority null", key: "priority", value: `null`},
+		{name: "default availability value", key: "default_available", value: `false`},
+		{name: "default availability null", key: "default_available", value: `null`},
+		{name: "default template name value", key: "default_template_name", value: `"client-template"`},
+		{name: "default template name null", key: "default_template_name", value: `null`},
+		{name: "managed by value", key: "managed_by", value: `"client"`},
+		{name: "managed by null", key: "managed_by", value: `null`},
+		{name: "catalog revision value", key: "catalog_revision", value: `99`},
+		{name: "catalog revision null", key: "catalog_revision", value: `null`},
+		{name: "mixed case labels value", key: "Labels", value: `[]`, extra: `,"enabled":false`},
+		{name: "mixed case labels null", key: "Labels", value: `null`},
+		{name: "mixed case required labels value", key: "Required_Labels", value: `[]`},
+		{name: "mixed case required labels null", key: "Required_Labels", value: `null`},
+		{name: "mixed case template id value", key: "Template_ID", value: `""`},
+		{name: "mixed case template id null", key: "Template_ID", value: `null`},
+		{name: "mixed case runner group value", key: "Runner_Group", value: `""`},
+		{name: "mixed case runner group null", key: "Runner_Group", value: `null`},
+		{name: "mixed case priority value", key: "Priority", value: `0`},
+		{name: "mixed case priority null", key: "Priority", value: `null`},
+		{name: "mixed case default availability value", key: "Default_Available", value: `false`},
+		{name: "mixed case default availability null", key: "Default_Available", value: `null`},
+		{name: "mixed case default template name value", key: "Default_Template_Name", value: `"client-template"`},
+		{name: "mixed case default template name null", key: "Default_Template_Name", value: `null`},
+		{name: "mixed case managed by value", key: "Managed_By", value: `"client"`},
+		{name: "mixed case managed by null", key: "Managed_By", value: `null`},
+		{name: "mixed case catalog revision value", key: "Catalog_Revision", value: `99`},
+		{name: "mixed case catalog revision null", key: "Catalog_Revision", value: `null`},
+	}
+
+	for _, tt := range protectedFields {
+		t.Run(tt.name, func(t *testing.T) {
+			store := state.New(t.TempDir())
+			managed := managedProfileForServerTest()
+			if conflicts, err := store.ReconcileManagedProfiles([]state.RunnerProfile{managed}); err != nil {
+				t.Fatal(err)
+			} else if len(conflicts) != 0 {
+				t.Fatalf("managed profile conflicts = %#v, want none", conflicts)
+			}
+			srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+
+			req := adminRequest(
+				http.MethodPatch,
+				"/runner_specs/"+managed.Name,
+				bytes.NewBufferString(`{"`+tt.key+`":`+tt.value+tt.extra+`}`),
+			)
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+			if rec.Code != http.StatusConflict {
+				t.Fatalf("status = %d body=%s, want 409", rec.Code, rec.Body.String())
+			}
+			var response struct {
+				Code string `json:"code"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
+			if response.Code != "managed_runner_spec" {
+				t.Fatalf("error code = %q body=%s, want managed_runner_spec", response.Code, rec.Body.String())
+			}
+
+			got, err := store.GetProfile(managed.Name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			managed.CreatedAt = got.CreatedAt
+			managed.UpdatedAt = got.UpdatedAt
+			if !reflect.DeepEqual(got, managed) {
+				t.Fatalf("rejected patch changed managed profile: got %#v want %#v", got, managed)
+			}
+		})
+	}
+}
+
+func TestDeleteManagedProfileReturnsConflict(t *testing.T) {
+	store := state.New(t.TempDir())
+	managed := managedProfileForServerTest()
+	if conflicts, err := store.ReconcileManagedProfiles([]state.RunnerProfile{managed}); err != nil {
+		t.Fatal(err)
+	} else if len(conflicts) != 0 {
+		t.Fatalf("managed profile conflicts = %#v, want none", conflicts)
+	}
+	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+
+	req := adminRequest(http.MethodDelete, "/runner_specs/"+managed.Name, nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Code != "managed_runner_spec" {
+		t.Fatalf("error code = %q body=%s, want managed_runner_spec", response.Code, rec.Body.String())
+	}
+	if _, err := store.GetProfile(managed.Name); err != nil {
+		t.Fatalf("managed profile was deleted: %v", err)
+	}
+}
+
+type profileLookupErrorStore struct {
+	state.Store
+	lookupErr   error
+	deleteCalls int
+}
+
+func (s *profileLookupErrorStore) GetProfile(string) (state.RunnerProfile, error) {
+	return state.RunnerProfile{}, s.lookupErr
+}
+
+func (s *profileLookupErrorStore) DeleteProfile(string) error {
+	s.deleteCalls++
+	return nil
+}
+
+func TestDeleteProfileFailsClosedWhenManagedStatusCannotBeLoaded(t *testing.T) {
+	store := &profileLookupErrorStore{
+		Store:     state.New(t.TempDir()),
+		lookupErr: errors.New("fixture profile lookup failure"),
+	}
+	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+
+	req := adminRequest(http.MethodDelete, "/runner_specs/qiniu-ubuntu-24.04", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d body=%s, want 500", rec.Code, rec.Body.String())
+	}
+	if store.deleteCalls != 0 {
+		t.Fatalf("DeleteProfile calls = %d, want 0 after lookup failure", store.deleteCalls)
+	}
+}
+
+func TestCreateProfileCannotOverwriteManagedProfile(t *testing.T) {
+	store := state.New(t.TempDir())
+	managed := managedProfileForServerTest()
+	if conflicts, err := store.ReconcileManagedProfiles([]state.RunnerProfile{managed}); err != nil {
+		t.Fatal(err)
+	} else if len(conflicts) != 0 {
+		t.Fatalf("managed profile conflicts = %#v, want none", conflicts)
+	}
+	before, err := store.GetProfile(managed.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+
+	req := adminRequest(
+		http.MethodPost,
+		"/runner_specs",
+		bytes.NewBufferString(`{
+			"name":"qiniu-ubuntu-24.04",
+			"labels":["self-hosted","custom"],
+			"template_id":"attacker-template",
+			"max_concurrency":1,
+			"enabled":true
+		}`),
+	)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Code != "managed_runner_spec" {
+		t.Fatalf("error code = %q body=%s, want managed_runner_spec", response.Code, rec.Body.String())
+	}
+	after, err := store.GetProfile(managed.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("managed profile changed through create endpoint:\nbefore: %#v\nafter:  %#v", before, after)
+	}
+}
+
+func TestDeleteCustomProfileRemainsAllowed(t *testing.T) {
+	store := state.New(t.TempDir())
+	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+	if _, err := store.UpsertProfile(state.RunnerProfile{
+		Name:           "custom",
+		Labels:         []string{"self-hosted", "e2b"},
+		TemplateID:     "custom-template",
+		MaxConcurrency: 2,
+		Enabled:        true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := adminRequest(http.MethodDelete, "/runner_specs/custom", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if _, err := store.GetProfile("custom"); err == nil {
+		t.Fatal("custom profile still exists after delete")
+	}
+}
+
+func managedProfileForServerTest() state.RunnerProfile {
+	return state.RunnerProfile{
+		Name:                "qiniu-ubuntu-24.04",
+		Labels:              []string{"self-hosted", "linux", "x64", "qiniu", "ubuntu-24.04"},
+		RequiredLabels:      []string{"qiniu", "ubuntu-24.04"},
+		DefaultTemplateName: "github-runner-ubuntu-24-04",
+		RunnerGroup:         "linux",
+		MaxConcurrency:      10,
+		MinIdle:             0,
+		Priority:            100,
+		Enabled:             true,
+		DefaultAvailable:    true,
+		ManagedBy:           "qiniu/ci-runner",
+		CatalogRevision:     1,
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -60,6 +60,20 @@ type fakeSandbox struct {
 	terminal            *fakeTerminalSession
 }
 
+func TestSandboxHTTPClientDoesNotBoundRunnerCommandStreams(t *testing.T) {
+	client := newSandboxHTTPClient()
+	if client.Timeout != 0 {
+		t.Fatalf("sandbox HTTP client timeout = %s, want no whole-request timeout", client.Timeout)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("sandbox HTTP transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout != time.Minute {
+		t.Fatalf("sandbox response header timeout = %s, want 1m", transport.ResponseHeaderTimeout)
+	}
+}
+
 type blockingSandboxDefaultStore struct {
 	state.Store
 	getStarted  chan struct{}

--- a/internal/state/catalog.go
+++ b/internal/state/catalog.go
@@ -39,6 +39,9 @@ func (s *DBStore) GetProfile(name string) (RunnerProfile, error) {
 	}
 	var record runnerProfileRecord
 	if err := db.First(&record, "name = ?", strings.TrimSpace(name)).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return RunnerProfile{}, ErrNotFound
+		}
 		return RunnerProfile{}, err
 	}
 	return recordToProfile(record)
@@ -53,34 +56,198 @@ func (s *DBStore) UpsertProfile(profile RunnerProfile) (RunnerProfile, error) {
 	if profile.Name == "" {
 		return RunnerProfile{}, fmt.Errorf("profile name is required")
 	}
+	if !labelsMatch(profile.RequiredLabels, profile.Labels) {
+		return RunnerProfile{}, fmt.Errorf("required labels must be a subset of labels")
+	}
 	labelsJSON, err := json.Marshal(profile.Labels)
 	if err != nil {
 		return RunnerProfile{}, err
 	}
+	if profile.RequiredLabels == nil {
+		profile.RequiredLabels = []string{}
+	}
+	requiredLabelsJSON, err := json.Marshal(profile.RequiredLabels)
+	if err != nil {
+		return RunnerProfile{}, err
+	}
+	requiredLabelsJSONText := string(requiredLabelsJSON)
 	now := time.Now().UTC()
 	record := runnerProfileRecord{
-		Name:             profile.Name,
-		LabelsJSON:       string(labelsJSON),
-		TemplateID:       profile.TemplateID,
-		RunnerGroup:      profile.RunnerGroup,
-		MaxConcurrency:   profile.MaxConcurrency,
-		MinIdle:          profile.MinIdle,
-		Priority:         profile.Priority,
-		Enabled:          profile.Enabled,
-		DefaultAvailable: profile.DefaultAvailable,
-		CreatedAt:        profile.CreatedAt,
-		UpdatedAt:        now,
+		Name:                profile.Name,
+		LabelsJSON:          string(labelsJSON),
+		RequiredLabelsJSON:  &requiredLabelsJSONText,
+		TemplateID:          profile.TemplateID,
+		DefaultTemplateName: profile.DefaultTemplateName,
+		RunnerGroup:         profile.RunnerGroup,
+		MaxConcurrency:      profile.MaxConcurrency,
+		MinIdle:             profile.MinIdle,
+		Priority:            profile.Priority,
+		Enabled:             profile.Enabled,
+		DefaultAvailable:    profile.DefaultAvailable,
+		ManagedBy:           profile.ManagedBy,
+		CatalogRevision:     profile.CatalogRevision,
+		CreatedAt:           profile.CreatedAt,
+		UpdatedAt:           now,
 	}
 	if record.CreatedAt.IsZero() {
 		record.CreatedAt = now
 	}
 	if err := db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "name"}},
-		DoUpdates: clause.Assignments(map[string]any{"labels_json": record.LabelsJSON, "template_id": record.TemplateID, "runner_group": record.RunnerGroup, "max_concurrency": record.MaxConcurrency, "min_idle": record.MinIdle, "priority": record.Priority, "enabled": record.Enabled, "default_available": record.DefaultAvailable, "updated_at": record.UpdatedAt}),
+		Columns: []clause.Column{{Name: "name"}},
+		DoUpdates: clause.Assignments(map[string]any{
+			"labels_json":           record.LabelsJSON,
+			"required_labels_json":  record.RequiredLabelsJSON,
+			"template_id":           record.TemplateID,
+			"default_template_name": record.DefaultTemplateName,
+			"runner_group":          record.RunnerGroup,
+			"max_concurrency":       record.MaxConcurrency,
+			"min_idle":              record.MinIdle,
+			"priority":              record.Priority,
+			"enabled":               record.Enabled,
+			"default_available":     record.DefaultAvailable,
+			"managed_by":            record.ManagedBy,
+			"catalog_revision":      record.CatalogRevision,
+			"updated_at":            record.UpdatedAt,
+		}),
 	}).Create(&record).Error; err != nil {
 		return RunnerProfile{}, err
 	}
 	return s.GetProfile(record.Name)
+}
+
+// ReconcileManagedProfiles creates or upgrades catalog-owned profiles while preserving operator controls.
+func (s *DBStore) ReconcileManagedProfiles(profiles []RunnerProfile) ([]ManagedProfileConflict, error) {
+	db, err := s.dbOrEnsure()
+	if err != nil {
+		return nil, err
+	}
+	conflicts := make([]ManagedProfileConflict, 0)
+	err = db.Transaction(func(tx *gorm.DB) error {
+		for _, profile := range profiles {
+			profile.Name = strings.TrimSpace(profile.Name)
+			profile.ManagedBy = strings.TrimSpace(profile.ManagedBy)
+			if profile.Name == "" {
+				return fmt.Errorf("profile name is required")
+			}
+			if profile.ManagedBy == "" {
+				return fmt.Errorf("managed profile owner is required")
+			}
+			if !labelsMatch(profile.RequiredLabels, profile.Labels) {
+				return fmt.Errorf("required labels must be a subset of labels")
+			}
+
+			var existing runnerProfileRecord
+			findErr := tx.First(&existing, "name = ?", profile.Name).Error
+			if findErr != nil && !errors.Is(findErr, gorm.ErrRecordNotFound) {
+				return findErr
+			}
+			if findErr == nil {
+				if existing.ManagedBy == "" || existing.ManagedBy != profile.ManagedBy {
+					conflicts = append(conflicts, ManagedProfileConflict{
+						Name:              profile.Name,
+						ExistingManagedBy: existing.ManagedBy,
+					})
+					continue
+				}
+				if existing.CatalogRevision >= profile.CatalogRevision {
+					continue
+				}
+			}
+
+			labelsJSON, requiredLabelsJSON, err := marshalProfileLabels(profile)
+			if err != nil {
+				return err
+			}
+			now := time.Now().UTC()
+			if errors.Is(findErr, gorm.ErrRecordNotFound) {
+				createdAt := profile.CreatedAt
+				if createdAt.IsZero() {
+					createdAt = now
+				}
+				record := runnerProfileRecord{
+					Name:                profile.Name,
+					LabelsJSON:          labelsJSON,
+					RequiredLabelsJSON:  &requiredLabelsJSON,
+					TemplateID:          profile.TemplateID,
+					DefaultTemplateName: profile.DefaultTemplateName,
+					RunnerGroup:         profile.RunnerGroup,
+					MaxConcurrency:      profile.MaxConcurrency,
+					MinIdle:             profile.MinIdle,
+					Priority:            profile.Priority,
+					Enabled:             profile.Enabled,
+					DefaultAvailable:    profile.DefaultAvailable,
+					ManagedBy:           profile.ManagedBy,
+					CatalogRevision:     profile.CatalogRevision,
+					CreatedAt:           createdAt,
+					UpdatedAt:           now,
+				}
+				if err := tx.Create(&record).Error; err != nil {
+					return err
+				}
+				continue
+			}
+
+			updates := map[string]any{
+				"labels_json":           labelsJSON,
+				"required_labels_json":  &requiredLabelsJSON,
+				"template_id":           profile.TemplateID,
+				"default_template_name": profile.DefaultTemplateName,
+				"runner_group":          profile.RunnerGroup,
+				"priority":              profile.Priority,
+				"default_available":     profile.DefaultAvailable,
+				"managed_by":            profile.ManagedBy,
+				"catalog_revision":      profile.CatalogRevision,
+				"updated_at":            now,
+			}
+			result := tx.Model(&runnerProfileRecord{}).
+				Where(
+					"name = ? AND managed_by = ? AND catalog_revision < ?",
+					profile.Name,
+					existing.ManagedBy,
+					profile.CatalogRevision,
+				).
+				Updates(updates)
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected == 0 {
+				var current runnerProfileRecord
+				if err := tx.First(&current, "name = ?", profile.Name).Error; err != nil {
+					if errors.Is(err, gorm.ErrRecordNotFound) {
+						continue
+					}
+					return err
+				}
+				if current.ManagedBy == "" || current.ManagedBy != profile.ManagedBy {
+					conflicts = append(conflicts, ManagedProfileConflict{
+						Name:              profile.Name,
+						ExistingManagedBy: current.ManagedBy,
+					})
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return conflicts, nil
+}
+
+func marshalProfileLabels(profile RunnerProfile) (string, string, error) {
+	labelsJSON, err := json.Marshal(profile.Labels)
+	if err != nil {
+		return "", "", err
+	}
+	requiredLabels := profile.RequiredLabels
+	if requiredLabels == nil {
+		requiredLabels = []string{}
+	}
+	requiredLabelsJSON, err := json.Marshal(requiredLabels)
+	if err != nil {
+		return "", "", err
+	}
+	return string(labelsJSON), string(requiredLabelsJSON), nil
 }
 
 func (s *DBStore) DeleteProfile(name string) error {
@@ -362,7 +529,7 @@ func (s *DBStore) MatchProfile(repositoryFullName string, labels []string) (Prof
 		if !profile.Enabled || !allowed[profile.Name] {
 			continue
 		}
-		if labelsMatch(labels, profile.Labels) {
+		if labelsMatch(profile.RequiredLabels, labels) && labelsMatch(labels, profile.Labels) {
 			candidates = append(candidates, profile)
 		}
 	}

--- a/internal/state/conversions.go
+++ b/internal/state/conversions.go
@@ -274,18 +274,34 @@ func recordToProfile(record runnerProfileRecord) (RunnerProfile, error) {
 	if err := json.Unmarshal([]byte(record.LabelsJSON), &labels); err != nil {
 		return RunnerProfile{}, err
 	}
+	requiredLabels := []string{}
+	if record.RequiredLabelsJSON != nil {
+		data := strings.TrimSpace(*record.RequiredLabelsJSON)
+		if data != "" && data != "null" {
+			if err := json.Unmarshal([]byte(data), &requiredLabels); err != nil {
+				return RunnerProfile{}, err
+			}
+			if requiredLabels == nil {
+				requiredLabels = []string{}
+			}
+		}
+	}
 	return RunnerProfile{
-		Name:             record.Name,
-		Labels:           labels,
-		TemplateID:       record.TemplateID,
-		RunnerGroup:      record.RunnerGroup,
-		MaxConcurrency:   record.MaxConcurrency,
-		MinIdle:          record.MinIdle,
-		Priority:         record.Priority,
-		Enabled:          record.Enabled,
-		DefaultAvailable: record.DefaultAvailable,
-		CreatedAt:        record.CreatedAt,
-		UpdatedAt:        record.UpdatedAt,
+		Name:                record.Name,
+		Labels:              labels,
+		RequiredLabels:      requiredLabels,
+		TemplateID:          record.TemplateID,
+		DefaultTemplateName: record.DefaultTemplateName,
+		RunnerGroup:         record.RunnerGroup,
+		MaxConcurrency:      record.MaxConcurrency,
+		MinIdle:             record.MinIdle,
+		Priority:            record.Priority,
+		Enabled:             record.Enabled,
+		DefaultAvailable:    record.DefaultAvailable,
+		ManagedBy:           record.ManagedBy,
+		CatalogRevision:     record.CatalogRevision,
+		CreatedAt:           record.CreatedAt,
+		UpdatedAt:           record.UpdatedAt,
 	}, nil
 }
 

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -153,12 +153,23 @@ func (s *DBStore) migrate(db *gorm.DB) error {
 	if err := migrateLegacySchemaColumns(db); err != nil {
 		return err
 	}
-	existingSQLiteRunnerRequests :=
-		s.opts.Backend == BackendSQLite &&
-			db.Migrator().HasTable(&runnerRequestRecord{})
+	existingSQLiteRunnerProfiles := s.opts.Backend == BackendSQLite &&
+		db.Migrator().HasTable(&runnerProfileRecord{})
+	if existingSQLiteRunnerProfiles {
+		if err := migrateSQLiteRunnerProfileSchema(db); err != nil {
+			return err
+		}
+	}
+	existingSQLiteRunnerRequests := s.opts.Backend == BackendSQLite &&
+		db.Migrator().HasTable(&runnerRequestRecord{})
 	models := []any{
 		&runnerEventRecord{},
-		&runnerProfileRecord{},
+	}
+	if !existingSQLiteRunnerProfiles {
+		models = append(models, &runnerProfileRecord{})
+	}
+	models = append(
+		models,
 		&runnerGroupRecord{},
 		&runnerGroupSpecRecord{},
 		&repositoryPolicyRecord{},
@@ -171,7 +182,7 @@ func (s *DBStore) migrate(db *gorm.DB) error {
 		&accountPreferenceRecord{},
 		&sandboxServiceDefaultRecord{},
 		&sandboxServiceDefaultAudienceRecord{},
-	}
+	)
 	if existingSQLiteRunnerRequests {
 		if err := migrateSQLiteRunnerRequestSchema(db); err != nil {
 			return err
@@ -188,29 +199,37 @@ func (s *DBStore) migrate(db *gorm.DB) error {
 	return nil
 }
 
+func migrateSQLiteRunnerProfileSchema(db *gorm.DB) error {
+	return migrateSQLiteSchemaAdditively(db, &runnerProfileRecord{}, "runner_profiles")
+}
+
 func migrateSQLiteRunnerRequestSchema(db *gorm.DB) error {
 	// SQLite records columns added through ALTER TABLE outside the original
 	// CREATE TABLE body. Recreating that table through the current GORM SQLite
 	// migrator can omit those columns from the copy and then add them back empty.
+	return migrateSQLiteSchemaAdditively(db, &runnerRequestRecord{}, "runner_requests")
+}
+
+func migrateSQLiteSchemaAdditively(db *gorm.DB, model any, tableName string) error {
 	stmt := &gorm.Statement{DB: db}
-	if err := stmt.Parse(&runnerRequestRecord{}); err != nil {
+	if err := stmt.Parse(model); err != nil {
 		return err
 	}
 	return db.Transaction(func(tx *gorm.DB) error {
 		for _, field := range stmt.Schema.Fields {
-			if field.IgnoreMigration || field.DBName == "" || tx.Migrator().HasColumn(&runnerRequestRecord{}, field.Name) {
+			if field.IgnoreMigration || field.DBName == "" || tx.Migrator().HasColumn(model, field.Name) {
 				continue
 			}
-			if err := tx.Migrator().AddColumn(&runnerRequestRecord{}, field.Name); err != nil {
-				return fmt.Errorf("add runner_requests.%s: %w", field.DBName, err)
+			if err := tx.Migrator().AddColumn(model, field.Name); err != nil {
+				return fmt.Errorf("add %s.%s: %w", tableName, field.DBName, err)
 			}
 		}
 		for _, index := range stmt.Schema.ParseIndexes() {
-			if tx.Migrator().HasIndex(&runnerRequestRecord{}, index.Name) {
+			if tx.Migrator().HasIndex(model, index.Name) {
 				continue
 			}
-			if err := tx.Migrator().CreateIndex(&runnerRequestRecord{}, index.Name); err != nil {
-				return fmt.Errorf("create runner_requests index %s: %w", index.Name, err)
+			if err := tx.Migrator().CreateIndex(model, index.Name); err != nil {
+				return fmt.Errorf("create %s index %s: %w", tableName, index.Name, err)
 			}
 		}
 		return nil

--- a/internal/state/records.go
+++ b/internal/state/records.go
@@ -66,17 +66,21 @@ type runnerEventRecord struct {
 func (runnerEventRecord) TableName() string { return "runner_events" }
 
 type runnerProfileRecord struct {
-	Name             string    `gorm:"column:name;primaryKey"`
-	LabelsJSON       string    `gorm:"column:labels_json;not null"`
-	TemplateID       string    `gorm:"column:template_id;not null"`
-	RunnerGroup      string    `gorm:"column:runner_group"`
-	MaxConcurrency   int       `gorm:"column:max_concurrency;not null"`
-	MinIdle          int       `gorm:"column:min_idle;not null;default:0"`
-	Priority         int       `gorm:"column:priority;not null;default:0"`
-	Enabled          bool      `gorm:"column:enabled;not null"`
-	DefaultAvailable bool      `gorm:"column:default_available;not null"`
-	CreatedAt        time.Time `gorm:"column:created_at;not null"`
-	UpdatedAt        time.Time `gorm:"column:updated_at;not null"`
+	Name                string    `gorm:"column:name;primaryKey"`
+	LabelsJSON          string    `gorm:"column:labels_json;not null"`
+	RequiredLabelsJSON  *string   `gorm:"column:required_labels_json"`
+	TemplateID          string    `gorm:"column:template_id;not null"`
+	DefaultTemplateName string    `gorm:"column:default_template_name"`
+	RunnerGroup         string    `gorm:"column:runner_group"`
+	MaxConcurrency      int       `gorm:"column:max_concurrency;not null"`
+	MinIdle             int       `gorm:"column:min_idle;not null;default:0"`
+	Priority            int       `gorm:"column:priority;not null;default:0"`
+	Enabled             bool      `gorm:"column:enabled;not null"`
+	DefaultAvailable    bool      `gorm:"column:default_available;not null"`
+	ManagedBy           string    `gorm:"column:managed_by"`
+	CatalogRevision     int       `gorm:"column:catalog_revision;not null;default:0"`
+	CreatedAt           time.Time `gorm:"column:created_at;not null"`
+	UpdatedAt           time.Time `gorm:"column:updated_at;not null"`
 }
 
 func (runnerProfileRecord) TableName() string { return "runner_profiles" }

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -90,17 +90,27 @@ type RunnerState struct {
 }
 
 type RunnerProfile struct {
-	Name             string    `json:"name"`
-	Labels           []string  `json:"labels"`
-	TemplateID       string    `json:"template_id"`
-	RunnerGroup      string    `json:"runner_group,omitempty"`
-	MaxConcurrency   int       `json:"max_concurrency"`
-	MinIdle          int       `json:"min_idle"`
-	Priority         int       `json:"priority"`
-	Enabled          bool      `json:"enabled"`
-	DefaultAvailable bool      `json:"default_available"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	Name                string    `json:"name"`
+	Labels              []string  `json:"labels"`
+	RequiredLabels      []string  `json:"required_labels"`
+	TemplateID          string    `json:"template_id"`
+	DefaultTemplateName string    `json:"default_template_name,omitempty"`
+	RunnerGroup         string    `json:"runner_group,omitempty"`
+	MaxConcurrency      int       `json:"max_concurrency"`
+	MinIdle             int       `json:"min_idle"`
+	Priority            int       `json:"priority"`
+	Enabled             bool      `json:"enabled"`
+	DefaultAvailable    bool      `json:"default_available"`
+	ManagedBy           string    `json:"managed_by,omitempty"`
+	CatalogRevision     int       `json:"catalog_revision,omitempty"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
+}
+
+// ManagedProfileConflict reports a catalog name already owned by another source.
+type ManagedProfileConflict struct {
+	Name              string
+	ExistingManagedBy string
 }
 
 type RunnerGroup struct {
@@ -304,6 +314,7 @@ type RunnerCatalogStore interface {
 	ListProfiles() ([]RunnerProfile, error)
 	GetProfile(name string) (RunnerProfile, error)
 	UpsertProfile(profile RunnerProfile) (RunnerProfile, error)
+	ReconcileManagedProfiles(profiles []RunnerProfile) ([]ManagedProfileConflict, error)
 	DeleteProfile(name string) error
 	ListRunnerGroups() ([]RunnerGroup, error)
 	GetRunnerGroup(name string) (RunnerGroup, error)

--- a/internal/state/store_extra_test.go
+++ b/internal/state/store_extra_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -338,6 +339,158 @@ func TestGetProfileReturnsCorrectProfile(t *testing.T) {
 	}
 	if got.Name != "get-prof" || got.TemplateID != "template-xyz" || got.MaxConcurrency != 7 || got.Priority != 5 {
 		t.Errorf("GetProfile returned unexpected profile: %#v", got)
+	}
+}
+
+func TestRunnerProfileManagedCatalogFieldsRoundTrip(t *testing.T) {
+	store := New(t.TempDir())
+	profile := RunnerProfile{
+		Name:                "managed-ubuntu-24.04",
+		Labels:              []string{"self-hosted", "linux", "x64", "qiniu", "ubuntu-24.04"},
+		RequiredLabels:      []string{"qiniu", "ubuntu-24.04"},
+		TemplateID:          "template-24.04",
+		DefaultTemplateName: "ubuntu-24.04",
+		MaxConcurrency:      5,
+		Enabled:             true,
+		DefaultAvailable:    true,
+		ManagedBy:           "runnerd",
+		CatalogRevision:     7,
+	}
+
+	saved, err := store.UpsertProfile(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(saved.RequiredLabels, profile.RequiredLabels) ||
+		saved.DefaultTemplateName != profile.DefaultTemplateName ||
+		saved.ManagedBy != profile.ManagedBy ||
+		saved.CatalogRevision != profile.CatalogRevision {
+		t.Fatalf("created managed catalog fields = %#v, want %#v", saved, profile)
+	}
+
+	saved.RequiredLabels = []string{"qiniu"}
+	saved.DefaultTemplateName = "ubuntu-24.04-r8"
+	saved.ManagedBy = "catalog-sync"
+	saved.CatalogRevision = 8
+	updated, err := store.UpsertProfile(saved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(updated.RequiredLabels, saved.RequiredLabels) ||
+		updated.DefaultTemplateName != saved.DefaultTemplateName ||
+		updated.ManagedBy != saved.ManagedBy ||
+		updated.CatalogRevision != saved.CatalogRevision {
+		t.Fatalf("updated managed catalog fields = %#v, want %#v", updated, saved)
+	}
+}
+
+func TestRecordToProfileTreatsMissingRequiredLabelsAsEmpty(t *testing.T) {
+	empty := ""
+	jsonNull := "null"
+	tests := []struct {
+		name               string
+		requiredLabelsJSON *string
+	}{
+		{name: "nil", requiredLabelsJSON: nil},
+		{name: "empty string", requiredLabelsJSON: &empty},
+		{name: "json null", requiredLabelsJSON: &jsonNull},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, err := recordToProfile(runnerProfileRecord{
+				Name:               "legacy",
+				LabelsJSON:         `["self-hosted"]`,
+				RequiredLabelsJSON: tt.requiredLabelsJSON,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if profile.RequiredLabels == nil || len(profile.RequiredLabels) != 0 {
+				t.Fatalf("RequiredLabels = %#v, want non-nil empty slice", profile.RequiredLabels)
+			}
+		})
+	}
+}
+
+func TestUpsertProfilePersistsNilRequiredLabelsAsEmptyJSONArray(t *testing.T) {
+	store := New(t.TempDir()).(*DBStore)
+	if _, err := store.UpsertProfile(RunnerProfile{
+		Name:           "empty-required-labels",
+		Labels:         []string{"self-hosted"},
+		TemplateID:     "base",
+		MaxConcurrency: 1,
+		Enabled:        true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.dbOrEnsure()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var requiredLabelsJSON *string
+	if err := db.Raw(`SELECT required_labels_json FROM runner_profiles WHERE name = ?`, "empty-required-labels").
+		Scan(&requiredLabelsJSON).Error; err != nil {
+		t.Fatal(err)
+	}
+	if requiredLabelsJSON == nil || *requiredLabelsJSON != "[]" {
+		t.Fatalf("required_labels_json = %#v, want non-NULL []", requiredLabelsJSON)
+	}
+}
+
+func TestManagedRunnerProfileRequiredLabelsMatch(t *testing.T) {
+	store := New(t.TempDir())
+	profile := RunnerProfile{
+		Name:             "managed-ubuntu-24.04",
+		Labels:           []string{"self-hosted", "linux", "x64", "qiniu", "ubuntu-24.04"},
+		RequiredLabels:   []string{"qiniu", "ubuntu-24.04"},
+		TemplateID:       "template-24.04",
+		MaxConcurrency:   5,
+		Enabled:          true,
+		DefaultAvailable: true,
+	}
+	if _, err := store.UpsertProfile(profile); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{name: "required labels only", labels: []string{"qiniu", "ubuntu-24.04"}, want: true},
+		{name: "full advertised labels", labels: []string{"self-hosted", "linux", "x64", "qiniu", "ubuntu-24.04"}, want: true},
+		{name: "normalized case and whitespace", labels: []string{" QINIU ", "Ubuntu-24.04"}, want: true},
+		{name: "missing qiniu", labels: []string{"ubuntu-24.04"}, want: false},
+		{name: "missing ubuntu version", labels: []string{"qiniu"}, want: false},
+		{name: "unsupported ubuntu version", labels: []string{"qiniu", "ubuntu-22.04"}, want: false},
+		{name: "unsupported gpu label", labels: []string{"qiniu", "ubuntu-24.04", "gpu"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, err := store.MatchProfile("owner/repo", tt.labels)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := match.Profile != nil; got != tt.want {
+				t.Fatalf("MatchProfile(%v) matched = %v, want %v; result = %#v", tt.labels, got, tt.want, match)
+			}
+		})
+	}
+}
+
+func TestUpsertProfileRejectsRequiredLabelsOutsideAdvertisedLabels(t *testing.T) {
+	store := New(t.TempDir())
+	profile := RunnerProfile{
+		Name:           "invalid-managed-profile",
+		Labels:         []string{"qiniu", "ubuntu-24.04"},
+		RequiredLabels: []string{"qiniu", "gpu"},
+		TemplateID:     "template-24.04",
+		MaxConcurrency: 5,
+		Enabled:        true,
+	}
+
+	if _, err := store.UpsertProfile(profile); err == nil {
+		t.Fatal("expected required labels outside advertised labels to be rejected")
 	}
 }
 

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -27,6 +27,429 @@ func closeTestDB(t *testing.T, db *gorm.DB) {
 	}
 }
 
+func managedProfileForReconciliation(name string, revision int) RunnerProfile {
+	return RunnerProfile{
+		Name:                name,
+		Labels:              []string{"self-hosted", "linux", "x64", "qiniu", "ubuntu-24.04"},
+		RequiredLabels:      []string{"qiniu", "ubuntu-24.04"},
+		DefaultTemplateName: "github-runner-ubuntu-24-04",
+		MaxConcurrency:      10,
+		Priority:            100,
+		Enabled:             true,
+		DefaultAvailable:    true,
+		ManagedBy:           "qiniu/ci-runner",
+		CatalogRevision:     revision,
+	}
+}
+
+type profileReadMutation struct {
+	fired bool
+	err   error
+}
+
+func mutateProfileAfterReconciliationRead(
+	t *testing.T,
+	store *DBStore,
+	profileName string,
+	updates map[string]any,
+) *profileReadMutation {
+	t.Helper()
+	db, err := store.dbOrEnsure()
+	if err != nil {
+		t.Fatal(err)
+	}
+	callbackName := "test:mutate-profile-after-reconciliation-read:" + profileName
+	mutation := &profileReadMutation{}
+	t.Cleanup(func() {
+		_ = db.Callback().Query().Remove(callbackName)
+	})
+	if err := db.Callback().Query().After("gorm:query").Register(callbackName, func(query *gorm.DB) {
+		if mutation.fired {
+			return
+		}
+		record, ok := query.Statement.Dest.(*runnerProfileRecord)
+		if !ok || record.Name != profileName {
+			return
+		}
+		mutation.fired = true
+		result := query.Session(&gorm.Session{NewDB: true}).
+			Model(&runnerProfileRecord{}).
+			Where("name = ?", profileName).
+			Updates(updates)
+		mutation.err = result.Error
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return mutation
+}
+
+func TestReconcileManagedProfilesCreatesMissingProfile(t *testing.T) {
+	store := New(t.TempDir())
+	want := managedProfileForReconciliation("qiniu-ubuntu-24.04", 1)
+
+	conflicts, err := store.ReconcileManagedProfiles([]RunnerProfile{want})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("conflicts = %#v, want none", conflicts)
+	}
+	got, err := store.GetProfile(want.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want.CreatedAt = got.CreatedAt
+	want.UpdatedAt = got.UpdatedAt
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("created profile = %#v, want %#v", got, want)
+	}
+}
+
+func TestReconcileManagedProfilesUpdatesCatalogFieldsAndPreservesOperatorFields(t *testing.T) {
+	store := New(t.TempDir())
+	createdAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+	existing := managedProfileForReconciliation("qiniu-ubuntu-24.04", 1)
+	existing.Labels = []string{"old"}
+	existing.RequiredLabels = []string{"old"}
+	existing.TemplateID = "old-region-specific-id"
+	existing.DefaultTemplateName = "old-template-name"
+	existing.RunnerGroup = "old-group"
+	existing.MaxConcurrency = 37
+	existing.MinIdle = 4
+	existing.Priority = 12
+	existing.Enabled = false
+	existing.DefaultAvailable = false
+	existing.CreatedAt = createdAt
+	if _, err := store.UpsertProfile(existing); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog := managedProfileForReconciliation(existing.Name, 2)
+	conflicts, err := store.ReconcileManagedProfiles([]RunnerProfile{catalog})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("conflicts = %#v, want none", conflicts)
+	}
+	got, err := store.GetProfile(existing.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got.Labels, catalog.Labels) ||
+		!reflect.DeepEqual(got.RequiredLabels, catalog.RequiredLabels) ||
+		got.TemplateID != catalog.TemplateID ||
+		got.DefaultTemplateName != catalog.DefaultTemplateName ||
+		got.RunnerGroup != catalog.RunnerGroup ||
+		got.Priority != catalog.Priority ||
+		got.DefaultAvailable != catalog.DefaultAvailable ||
+		got.ManagedBy != catalog.ManagedBy ||
+		got.CatalogRevision != catalog.CatalogRevision {
+		t.Fatalf("catalog-controlled fields were not updated: %#v", got)
+	}
+	if got.Enabled != existing.Enabled ||
+		got.MaxConcurrency != existing.MaxConcurrency ||
+		got.MinIdle != existing.MinIdle ||
+		!got.CreatedAt.Equal(createdAt) {
+		t.Fatalf("operator-controlled or creation fields changed: %#v", got)
+	}
+}
+
+func TestReconcileManagedProfilesDoesNotDowngradeHigherRevision(t *testing.T) {
+	store := New(t.TempDir())
+	existing := managedProfileForReconciliation("qiniu-ubuntu-24.04", 7)
+	existing.Labels = []string{"higher"}
+	existing.RequiredLabels = []string{"higher"}
+	existing.TemplateID = "higher-template-id"
+	existing.DefaultTemplateName = "higher-template-name"
+	existing.RunnerGroup = "higher-group"
+	existing.MaxConcurrency = 47
+	existing.MinIdle = 6
+	existing.Priority = 700
+	existing.Enabled = false
+	existing.DefaultAvailable = false
+	existing.CreatedAt = time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+	if _, err := store.UpsertProfile(existing); err != nil {
+		t.Fatal(err)
+	}
+	before, err := store.GetProfile(existing.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conflicts, err := store.ReconcileManagedProfiles([]RunnerProfile{
+		managedProfileForReconciliation(existing.Name, 2),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("conflicts = %#v, want none", conflicts)
+	}
+	after, err := store.GetProfile(existing.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("higher revision was changed:\nbefore: %#v\nafter:  %#v", before, after)
+	}
+}
+
+func TestReconcileManagedProfilesAtomicUpdateRejectsStaleRevision(t *testing.T) {
+	store := New(t.TempDir()).(*DBStore)
+	existing := managedProfileForReconciliation("qiniu-ubuntu-24.04", 1)
+	if _, err := store.UpsertProfile(existing); err != nil {
+		t.Fatal(err)
+	}
+	beforeRace, err := store.GetProfile(existing.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raceUpdatedAt := beforeRace.UpdatedAt.Add(time.Minute)
+	mutation := mutateProfileAfterReconciliationRead(t, store, existing.Name, map[string]any{
+		"labels_json":           `["higher-race"]`,
+		"required_labels_json":  `["higher-race"]`,
+		"template_id":           "higher-race-template-id",
+		"default_template_name": "higher-race-template-name",
+		"runner_group":          "higher-race-group",
+		"max_concurrency":       57,
+		"min_idle":              7,
+		"priority":              800,
+		"enabled":               false,
+		"default_available":     false,
+		"managed_by":            "qiniu/ci-runner",
+		"catalog_revision":      8,
+		"updated_at":            raceUpdatedAt,
+	})
+
+	conflicts, err := store.ReconcileManagedProfiles([]RunnerProfile{
+		managedProfileForReconciliation(existing.Name, 2),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mutation.err != nil {
+		t.Fatalf("inject stale-read mutation: %v", mutation.err)
+	}
+	if !mutation.fired {
+		t.Fatal("stale-read mutation did not run")
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("conflicts = %#v, want higher revision no-op", conflicts)
+	}
+	got, err := store.GetProfile(existing.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := RunnerProfile{
+		Name:                existing.Name,
+		Labels:              []string{"higher-race"},
+		RequiredLabels:      []string{"higher-race"},
+		TemplateID:          "higher-race-template-id",
+		DefaultTemplateName: "higher-race-template-name",
+		RunnerGroup:         "higher-race-group",
+		MaxConcurrency:      57,
+		MinIdle:             7,
+		Priority:            800,
+		Enabled:             false,
+		DefaultAvailable:    false,
+		ManagedBy:           "qiniu/ci-runner",
+		CatalogRevision:     8,
+		CreatedAt:           beforeRace.CreatedAt,
+		UpdatedAt:           raceUpdatedAt,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("stale lower-revision write changed raced row:\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestReconcileManagedProfilesAtomicUpdateRejectsStaleOwner(t *testing.T) {
+	store := New(t.TempDir()).(*DBStore)
+	existing := managedProfileForReconciliation("qiniu-ubuntu-24.04", 1)
+	if _, err := store.UpsertProfile(existing); err != nil {
+		t.Fatal(err)
+	}
+	beforeRace, err := store.GetProfile(existing.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raceUpdatedAt := beforeRace.UpdatedAt.Add(time.Minute)
+	mutation := mutateProfileAfterReconciliationRead(t, store, existing.Name, map[string]any{
+		"labels_json":           `["other-owner"]`,
+		"required_labels_json":  `["other-owner"]`,
+		"template_id":           "other-owner-template-id",
+		"default_template_name": "other-owner-template-name",
+		"runner_group":          "other-owner-group",
+		"max_concurrency":       67,
+		"min_idle":              8,
+		"priority":              900,
+		"enabled":               false,
+		"default_available":     false,
+		"managed_by":            "another/catalog",
+		"catalog_revision":      9,
+		"updated_at":            raceUpdatedAt,
+	})
+
+	conflicts, err := store.ReconcileManagedProfiles([]RunnerProfile{
+		managedProfileForReconciliation(existing.Name, 2),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mutation.err != nil {
+		t.Fatalf("inject stale-read mutation: %v", mutation.err)
+	}
+	if !mutation.fired {
+		t.Fatal("stale-read mutation did not run")
+	}
+	wantConflicts := []ManagedProfileConflict{{
+		Name:              existing.Name,
+		ExistingManagedBy: "another/catalog",
+	}}
+	if !reflect.DeepEqual(conflicts, wantConflicts) {
+		t.Fatalf("conflicts = %#v, want %#v", conflicts, wantConflicts)
+	}
+	got, err := store.GetProfile(existing.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := RunnerProfile{
+		Name:                existing.Name,
+		Labels:              []string{"other-owner"},
+		RequiredLabels:      []string{"other-owner"},
+		TemplateID:          "other-owner-template-id",
+		DefaultTemplateName: "other-owner-template-name",
+		RunnerGroup:         "other-owner-group",
+		MaxConcurrency:      67,
+		MinIdle:             8,
+		Priority:            900,
+		Enabled:             false,
+		DefaultAvailable:    false,
+		ManagedBy:           "another/catalog",
+		CatalogRevision:     9,
+		CreatedAt:           beforeRace.CreatedAt,
+		UpdatedAt:           raceUpdatedAt,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("stale owner write changed raced row:\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestReconcileManagedProfilesReportsCollisionAndContinues(t *testing.T) {
+	store := New(t.TempDir())
+	custom := RunnerProfile{
+		Name:             "qiniu-ubuntu-24.04",
+		Labels:           []string{"custom"},
+		RequiredLabels:   []string{},
+		TemplateID:       "custom-template",
+		MaxConcurrency:   2,
+		Enabled:          true,
+		DefaultAvailable: true,
+	}
+	if _, err := store.UpsertProfile(custom); err != nil {
+		t.Fatal(err)
+	}
+	missing := managedProfileForReconciliation("qiniu-ubuntu-22.04", 1)
+
+	conflicts, err := store.ReconcileManagedProfiles([]RunnerProfile{
+		managedProfileForReconciliation(custom.Name, 1),
+		missing,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantConflicts := []ManagedProfileConflict{{
+		Name:              custom.Name,
+		ExistingManagedBy: "",
+	}}
+	if !reflect.DeepEqual(conflicts, wantConflicts) {
+		t.Fatalf("conflicts = %#v, want %#v", conflicts, wantConflicts)
+	}
+	gotCustom, err := store.GetProfile(custom.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	custom.CreatedAt = gotCustom.CreatedAt
+	custom.UpdatedAt = gotCustom.UpdatedAt
+	if !reflect.DeepEqual(gotCustom, custom) {
+		t.Fatalf("custom collision row changed: %#v", gotCustom)
+	}
+	if _, err := store.GetProfile(missing.Name); err != nil {
+		t.Fatalf("non-conflicting managed profile was not reconciled: %v", err)
+	}
+}
+
+func TestReconcileManagedProfilesReportsOtherManagerCollision(t *testing.T) {
+	store := New(t.TempDir())
+	existing := managedProfileForReconciliation("qiniu-ubuntu-24.04", 1)
+	existing.ManagedBy = "another/catalog"
+	if _, err := store.UpsertProfile(existing); err != nil {
+		t.Fatal(err)
+	}
+
+	conflicts, err := store.ReconcileManagedProfiles([]RunnerProfile{
+		managedProfileForReconciliation(existing.Name, 2),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []ManagedProfileConflict{{
+		Name:              existing.Name,
+		ExistingManagedBy: "another/catalog",
+	}}
+	if !reflect.DeepEqual(conflicts, want) {
+		t.Fatalf("conflicts = %#v, want %#v", conflicts, want)
+	}
+	got, err := store.GetProfile(existing.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ManagedBy != existing.ManagedBy || got.CatalogRevision != existing.CatalogRevision {
+		t.Fatalf("other manager row changed: %#v", got)
+	}
+}
+
+func TestReconcileManagedProfilesIsIdempotent(t *testing.T) {
+	store := New(t.TempDir())
+	profile := managedProfileForReconciliation("qiniu-ubuntu-24.04", 1)
+	if _, err := store.ReconcileManagedProfiles([]RunnerProfile{profile}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := store.GetProfile(profile.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conflicts, err := store.ReconcileManagedProfiles([]RunnerProfile{profile})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("conflicts = %#v, want none", conflicts)
+	}
+	after, err := store.GetProfile(profile.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("idempotent reconciliation changed profile:\nbefore: %#v\nafter:  %#v", before, after)
+	}
+}
+
+func TestReconcileManagedProfilesRollsBackAllChangesOnError(t *testing.T) {
+	store := New(t.TempDir())
+	valid := managedProfileForReconciliation("qiniu-ubuntu-24.04", 1)
+	invalid := managedProfileForReconciliation("qiniu-ubuntu-invalid", 1)
+	invalid.RequiredLabels = []string{"missing"}
+
+	if _, err := store.ReconcileManagedProfiles([]RunnerProfile{valid, invalid}); err == nil {
+		t.Fatal("expected invalid managed profile to fail reconciliation")
+	}
+	if _, err := store.GetProfile(valid.Name); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("first profile survived failed transaction: %v", err)
+	}
+}
+
 func TestSQLiteStoreUsesWALAndBusyTimeout(t *testing.T) {
 	store := NewWithOptions(Options{
 		Backend:        BackendSQLite,
@@ -1073,7 +1496,7 @@ func TestMigrateDoesNotHandleLegacyUsers(t *testing.T) {
 	}
 }
 
-func TestMigrateBackfillsLegacyRunnerProfileDefaultAvailable(t *testing.T) {
+func TestMigratePreservesLegacyRunnerProfileAndAddsManagedCatalogColumns(t *testing.T) {
 	dir := t.TempDir()
 	databaseURL := dir + "/runnerd.db"
 	store := NewWithOptions(Options{
@@ -1100,8 +1523,12 @@ func TestMigrateBackfillsLegacyRunnerProfileDefaultAvailable(t *testing.T) {
 	);`).Error; err != nil {
 		t.Fatal(err)
 	}
-	if err := db.Exec(`INSERT INTO runner_profiles (name, labels_json, template_id, runner_group, max_concurrency, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		"default", `["self-hosted"]`, "base", "default", 1, true, now, now).Error; err != nil {
+	if err := db.Exec(`INSERT INTO runner_profiles (name, labels_json, template_id, runner_group, max_concurrency, min_idle, priority, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"default", `["self-hosted"]`, "base", "default", 1, 3, 17, true, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`CREATE INDEX idx_runner_profiles_legacy_capacity
+		ON runner_profiles (priority, min_idle)`).Error; err != nil {
 		t.Fatal(err)
 	}
 	closeTestDB(t, db)
@@ -1115,8 +1542,142 @@ func TestMigrateBackfillsLegacyRunnerProfileDefaultAvailable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if profile.Name != "default" ||
+		!reflect.DeepEqual(profile.Labels, []string{"self-hosted"}) ||
+		profile.TemplateID != "base" ||
+		profile.RunnerGroup != "default" ||
+		profile.MaxConcurrency != 1 ||
+		profile.MinIdle != 3 ||
+		profile.Priority != 17 ||
+		!profile.Enabled ||
+		!profile.CreatedAt.Equal(now) ||
+		!profile.UpdatedAt.Equal(now) {
+		t.Fatalf("legacy runner profile fields changed during migration: %#v", profile)
+	}
 	if !profile.DefaultAvailable {
 		t.Fatal("expected legacy runner profile to default to globally available")
+	}
+
+	if profile.RequiredLabels == nil || len(profile.RequiredLabels) != 0 {
+		t.Fatalf("legacy profile RequiredLabels = %#v, want non-nil empty slice", profile.RequiredLabels)
+	}
+	if profile.DefaultTemplateName != "" || profile.ManagedBy != "" || profile.CatalogRevision != 0 {
+		t.Fatalf("unexpected legacy managed catalog fields: %#v", profile)
+	}
+
+	db, err = migrated.dbOrEnsure()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var legacyIndexSQL string
+	if err := db.Raw(`SELECT sql FROM sqlite_master
+		WHERE type = 'index' AND tbl_name = 'runner_profiles' AND name = 'idx_runner_profiles_legacy_capacity'`).
+		Scan(&legacyIndexSQL).Error; err != nil {
+		t.Fatal(err)
+	}
+	if legacyIndexSQL == "" {
+		t.Fatal("legacy runner_profiles index was lost during migration; table must not be rebuilt")
+	}
+	var stored struct {
+		RequiredLabelsJSON  *string `gorm:"column:required_labels_json"`
+		DefaultTemplateName string  `gorm:"column:default_template_name"`
+		ManagedBy           string  `gorm:"column:managed_by"`
+		CatalogRevision     int     `gorm:"column:catalog_revision"`
+	}
+	if err := db.Raw(`SELECT required_labels_json, default_template_name, managed_by, catalog_revision
+		FROM runner_profiles WHERE name = ?`, "default").Scan(&stored).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.RequiredLabelsJSON != nil {
+		t.Fatalf("legacy required_labels_json = %q, want NULL after migration", *stored.RequiredLabelsJSON)
+	}
+	if stored.DefaultTemplateName != "" || stored.ManagedBy != "" || stored.CatalogRevision != 0 {
+		t.Fatalf("unexpected legacy managed catalog values after migration: %#v", stored)
+	}
+
+	profile.TemplateID = "base-updated"
+	updated, err := migrated.UpsertProfile(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "default" ||
+		!reflect.DeepEqual(updated.Labels, []string{"self-hosted"}) ||
+		updated.TemplateID != "base-updated" ||
+		updated.RunnerGroup != "default" ||
+		updated.MaxConcurrency != 1 ||
+		updated.MinIdle != 3 ||
+		updated.Priority != 17 ||
+		!updated.Enabled ||
+		!updated.DefaultAvailable ||
+		!updated.CreatedAt.Equal(now) {
+		t.Fatalf("legacy runner profile fields changed during update: %#v", updated)
+	}
+	if err := db.Raw(`SELECT required_labels_json, default_template_name, managed_by, catalog_revision
+		FROM runner_profiles WHERE name = ?`, "default").Scan(&stored).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.RequiredLabelsJSON == nil || *stored.RequiredLabelsJSON != "[]" {
+		t.Fatalf("updated required_labels_json = %#v, want non-NULL []", stored.RequiredLabelsJSON)
+	}
+}
+
+func TestMigrateExistingSQLiteRunnerProfileAddsAllModelColumns(t *testing.T) {
+	dir := t.TempDir()
+	databaseURL := dir + "/runnerd.db"
+	store := NewWithOptions(Options{
+		Backend:        BackendSQLite,
+		DatabaseDSN:    databaseURL,
+		MigrateOnStart: false,
+	}).(*DBStore)
+	db, err := store.open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if err := db.Exec(`CREATE TABLE runner_profiles (
+		name TEXT PRIMARY KEY,
+		labels_json TEXT NOT NULL,
+		template_id TEXT NOT NULL,
+		max_concurrency INTEGER NOT NULL,
+		priority INTEGER NOT NULL DEFAULT 0,
+		enabled BOOLEAN NOT NULL,
+		created_at TIMESTAMP NOT NULL,
+		updated_at TIMESTAMP NOT NULL
+	);`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO runner_profiles (
+		name, labels_json, template_id, max_concurrency, priority, enabled, created_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"minimal", `["self-hosted"]`, "base", 1, 17, true, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	closeTestDB(t, db)
+
+	migrated := NewWithOptions(Options{
+		Backend:        BackendSQLite,
+		DatabaseDSN:    databaseURL,
+		MigrateOnStart: true,
+	}).(*DBStore)
+	db, err = migrated.dbOrEnsure()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"RunnerGroup", "MinIdle"} {
+		if !db.Migrator().HasColumn(&runnerProfileRecord{}, field) {
+			t.Fatalf("runner_profiles missing model column %s after migration", field)
+		}
+	}
+	profile, err := migrated.GetProfile("minimal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profile.Name != "minimal" ||
+		profile.TemplateID != "base" ||
+		profile.MinIdle != 0 ||
+		profile.RunnerGroup != "" ||
+		!profile.DefaultAvailable {
+		t.Fatalf("migrated minimal runner profile = %#v", profile)
 	}
 }
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -21,8 +21,10 @@ The four physical templates were published, catalog-checked, and release-smoke
 verified in `cn-yangzhou-1` and `us-south-1` on 2026-08-03. The regional IDs
 and smoke evidence are retained in [Issue #38](https://github.com/qiniu/ci-runner/issues/38#issuecomment-5164811404).
 The `ubuntu-latest` row inherits the verified publication state of its 24.04
-physical template. The workflow label is not operational until the separate
-managed Runner Spec rollout verifies all five labels.
+physical template. The managed Runner Spec rollout and all five workflow
+labels were end-to-end verified by
+[GitHub Actions run 30858489153](https://github.com/miclle/qiniu-ci-runner-test/actions/runs/30858489153)
+on 2026-08-04 CST; every request completed and its Sandbox was cleaned.
 
 Publication state is restricted to `development`, `published`, or `verified`.
 `published` means the physical template is public in both supported regions.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -643,6 +643,7 @@ function App() {
 
   const {
     runnerSpecOpen,
+    editingRunnerSpec,
     runnerGroupOpen,
     runnerPolicyOpen,
     runnerSpecForm,
@@ -1134,6 +1135,7 @@ function App() {
               runnerSpecs={runnerSpecs}
               runnerGroups={runnerGroups}
               runnerSpecOpen={runnerSpecOpen}
+              editingRunnerSpec={editingRunnerSpec}
               runnerSpecForm={runnerSpecForm}
               onRefresh={() => void loadAll()}
               onResetRunnerSpecForm={resetRunnerSpecForm}

--- a/ui/src/admin-types.ts
+++ b/ui/src/admin-types.ts
@@ -57,7 +57,11 @@ export type RunnerJobGroup = {
 export type RunnerSpec = {
   name: string
   labels: string[]
+  required_labels: string[]
   template_id: string
+  default_template_name?: string
+  managed_by?: string
+  catalog_revision?: number
   runner_group?: string
   max_concurrency: number
   min_idle: number

--- a/ui/src/components/runner-specs-section.test.js
+++ b/ui/src/components/runner-specs-section.test.js
@@ -1,0 +1,308 @@
+import { describe, expect, test } from "bun:test"
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import * as RunnerSpecsModule from "./runner-specs-section"
+import * as RunnerCatalogModule from "../hooks/use-runner-catalog"
+
+const managedSpec = {
+  name: "ubuntu-24.04",
+  labels: ["self-hosted", "qiniu", "ubuntu-24.04"],
+  required_labels: ["qiniu", "ubuntu-24.04"],
+  template_id: "region-resolved-template-id",
+  default_template_name: "ubuntu-24.04-x64",
+  managed_by: "qiniu/ci-runner",
+  catalog_revision: 3,
+  runner_group: "",
+  max_concurrency: 8,
+  min_idle: 1,
+  priority: 10,
+  enabled: true,
+  default_available: true,
+  created_at: "2026-07-27T00:00:00Z",
+  updated_at: "2026-07-27T00:00:00Z",
+}
+
+const managedForm = {
+  name: managedSpec.name,
+  labels: managedSpec.labels.join(","),
+  required_labels: managedSpec.required_labels.join(","),
+  template_id: managedSpec.template_id,
+  runner_group: "",
+  group_names: [],
+  max_concurrency: String(managedSpec.max_concurrency),
+  min_idle: String(managedSpec.min_idle),
+  priority: String(managedSpec.priority),
+  enabled: managedSpec.enabled,
+  default_available: managedSpec.default_available,
+}
+
+function sectionProps(overrides = {}) {
+  return {
+    loading: false,
+    runnerSpecs: [managedSpec],
+    runnerGroups: [],
+    runnerSpecOpen: false,
+    editingRunnerSpec: null,
+    runnerSpecForm: managedForm,
+    onRefresh: () => {},
+    onResetRunnerSpecForm: () => {},
+    onRunnerSpecOpenChange: () => {},
+    onRunnerSpecFormChange: () => {},
+    onSubmitRunnerSpec: () => {},
+    onEditRunnerSpec: () => {},
+    onDeleteRunnerSpec: () => {},
+    groupNamesForSpec: () => [],
+    ...overrides,
+  }
+}
+
+function inputTag(html, id) {
+  return html.match(new RegExp(`<input[^>]*id="${id}"[^>]*>`))?.[0] || ""
+}
+
+function isDisabledInput(html, id) {
+  return /\sdisabled(?:=""|(?=[\s/>]))/.test(inputTag(html, id))
+}
+
+function collectText(node) {
+  if (typeof node === "string" || typeof node === "number") return String(node)
+  if (Array.isArray(node)) return node.map(collectText).join("")
+  if (!node || typeof node !== "object") return ""
+  return collectText(node.props?.children)
+}
+
+describe("RunnerSpecsSection", () => {
+  test("renders managed specs with catalog identity and without a delete action", () => {
+    const html = renderToStaticMarkup(
+      createElement(RunnerSpecsModule.RunnerSpecsSection, sectionProps()),
+    )
+
+    expect(html).toContain(">Managed<")
+    expect(html).toContain("Default template")
+    expect(html).toContain(managedSpec.default_template_name)
+    expect(html).not.toContain(managedSpec.template_id)
+    expect(html).toContain(`aria-label="Edit ${managedSpec.name}"`)
+    expect(html).toContain(">Edit</button>")
+    expect(html).not.toContain(">Delete<")
+  })
+
+  test("renders a managed edit dialog with only operator controls enabled", () => {
+    expect(typeof RunnerSpecsModule.RunnerSpecDialogForm).toBe("function")
+    if (typeof RunnerSpecsModule.RunnerSpecDialogForm !== "function") return
+
+    const html = renderToStaticMarkup(
+      createElement(RunnerSpecsModule.RunnerSpecDialogForm, {
+        runnerGroups: [
+          {
+            name: "production",
+            description: "",
+            spec_names: [managedSpec.name],
+            enabled: true,
+            created_at: "2026-07-27T00:00:00Z",
+            updated_at: "2026-07-27T00:00:00Z",
+          },
+        ],
+        editingRunnerSpec: managedSpec,
+        runnerSpecForm: { ...managedForm, group_names: ["production"] },
+        onRunnerSpecFormChange: () => {},
+        onRunnerSpecOpenChange: () => {},
+        onSubmitRunnerSpec: () => {},
+      }),
+    )
+
+    expect(html).toContain(managedSpec.default_template_name)
+    expect(html).not.toContain(managedSpec.template_id)
+    for (const id of [
+      "runner-spec-name",
+      "runner-spec-labels",
+      "runner-spec-required-labels",
+      "runner-spec-default-template",
+      "runner-spec-github-group",
+      "runner-spec-group-production",
+      "runner-spec-priority",
+      "runner-spec-default-available",
+    ]) {
+      expect(isDisabledInput(html, id)).toBe(true)
+    }
+    for (const id of [
+      "runner-spec-max-concurrency",
+      "runner-spec-min-idle",
+      "runner-spec-enabled",
+    ]) {
+      expect(isDisabledInput(html, id)).toBe(false)
+    }
+  })
+
+  test("derives the dialog title from editing identity instead of a populated create name", () => {
+    const createSection = RunnerSpecsModule.RunnerSpecsSection(
+      sectionProps({
+        editingRunnerSpec: null,
+        runnerSpecForm: { ...managedForm, name: "draft-custom-spec" },
+      }),
+    )
+    const editSection = RunnerSpecsModule.RunnerSpecsSection(
+      sectionProps({
+        editingRunnerSpec: managedSpec,
+        runnerSpecForm: managedForm,
+      }),
+    )
+
+    expect(collectText(createSection)).toContain("Create runner spec")
+    expect(collectText(createSection)).not.toContain("Edit runner spec")
+    expect(collectText(editSection)).toContain("Edit runner spec")
+  })
+})
+
+describe("runner spec submission", () => {
+  test("submits a managed PATCH with only operator controls and no group updates", async () => {
+    expect(typeof RunnerCatalogModule.submitRunnerSpecChanges).toBe("function")
+    if (typeof RunnerCatalogModule.submitRunnerSpecChanges !== "function") return
+
+    const requests = []
+    await RunnerCatalogModule.submitRunnerSpecChanges({
+      request: async (url, options) => {
+        requests.push({ url, options })
+        return {}
+      },
+      runnerGroups: [
+        {
+          name: "production",
+          description: "",
+          spec_names: [],
+          enabled: true,
+          created_at: "2026-07-27T00:00:00Z",
+          updated_at: "2026-07-27T00:00:00Z",
+        },
+      ],
+      editingRunnerSpec: managedSpec,
+      runnerSpecForm: {
+        ...managedForm,
+        group_names: ["production"],
+        max_concurrency: "12",
+        min_idle: "2",
+        enabled: false,
+      },
+      parseLabels: (value) => value.split(",").filter(Boolean),
+    })
+
+    expect(requests).toEqual([
+      {
+        url: "/runner_specs/ubuntu-24.04",
+        options: {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            max_concurrency: 12,
+            min_idle: 2,
+            enabled: false,
+          }),
+        },
+      },
+    ])
+  })
+
+  test("submits a custom create payload with required labels and routing fields", async () => {
+    const requests = []
+    await RunnerCatalogModule.submitRunnerSpecChanges({
+      request: async (url, options) => {
+        requests.push({ url, options })
+        return {}
+      },
+      runnerGroups: [],
+      editingRunnerSpec: null,
+      runnerSpecForm: {
+        name: "large-custom",
+        labels: "self-hosted, gpu, linux",
+        required_labels: "gpu, linux",
+        template_id: "custom-template-id",
+        runner_group: "qiniu-runners",
+        group_names: [],
+        max_concurrency: "6",
+        min_idle: "1",
+        priority: "20",
+        enabled: true,
+        default_available: false,
+      },
+      parseLabels: (value) => value.split(",").map((label) => label.trim()).filter(Boolean),
+    })
+
+    expect(requests).toEqual([
+      {
+        url: "/runner_specs",
+        options: {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "large-custom",
+            labels: ["self-hosted", "gpu", "linux"],
+            required_labels: ["gpu", "linux"],
+            template_id: "custom-template-id",
+            runner_group: "qiniu-runners",
+            max_concurrency: 6,
+            min_idle: 1,
+            priority: 20,
+            enabled: true,
+            default_available: false,
+          }),
+        },
+      },
+    ])
+  })
+
+  test("submits a custom PATCH with required labels and mutable catalog fields", async () => {
+    const customSpec = {
+      ...managedSpec,
+      name: "large-custom",
+      required_labels: ["gpu"],
+      default_template_name: "",
+      managed_by: "",
+      catalog_revision: 0,
+      template_id: "custom-template-id",
+    }
+    const requests = []
+    await RunnerCatalogModule.submitRunnerSpecChanges({
+      request: async (url, options) => {
+        requests.push({ url, options })
+        return {}
+      },
+      runnerGroups: [],
+      editingRunnerSpec: customSpec,
+      runnerSpecForm: {
+        ...managedForm,
+        name: customSpec.name,
+        labels: "self-hosted, gpu, linux",
+        required_labels: "gpu, linux",
+        template_id: "new-template-id",
+        runner_group: "qiniu-runners",
+        max_concurrency: "9",
+        min_idle: "3",
+        priority: "30",
+        enabled: false,
+        default_available: false,
+      },
+      parseLabels: (value) => value.split(",").map((label) => label.trim()).filter(Boolean),
+    })
+
+    expect(requests).toEqual([
+      {
+        url: "/runner_specs/large-custom",
+        options: {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            labels: ["self-hosted", "gpu", "linux"],
+            required_labels: ["gpu", "linux"],
+            template_id: "new-template-id",
+            runner_group: "qiniu-runners",
+            max_concurrency: 9,
+            min_idle: 3,
+            priority: 30,
+            enabled: false,
+            default_available: false,
+          }),
+        },
+      },
+    ])
+  })
+})

--- a/ui/src/components/runner-specs-section.tsx
+++ b/ui/src/components/runner-specs-section.tsx
@@ -1,7 +1,8 @@
 import { type Dispatch, type FormEvent, type SetStateAction } from "react"
-import { Plus, RefreshCw, Trash2 } from "lucide-react"
+import { Pencil, Plus, RefreshCw, Trash2 } from "lucide-react"
 
 import { type RunnerGroup, type RunnerSpec } from "@/admin-types"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -19,6 +20,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import {
   Table,
   TableBody,
@@ -32,6 +34,7 @@ import { cn } from "@/lib/utils"
 export type RunnerSpecFormState = {
   name: string
   labels: string
+  required_labels: string
   template_id: string
   runner_group: string
   group_names: string[]
@@ -42,11 +45,219 @@ export type RunnerSpecFormState = {
   default_available: boolean
 }
 
+export function RunnerSpecDialogForm({
+  runnerGroups,
+  editingRunnerSpec,
+  runnerSpecForm,
+  onRunnerSpecFormChange,
+  onRunnerSpecOpenChange,
+  onSubmitRunnerSpec,
+}: {
+  runnerGroups: RunnerGroup[]
+  editingRunnerSpec: RunnerSpec | null
+  runnerSpecForm: RunnerSpecFormState
+  onRunnerSpecFormChange: Dispatch<SetStateAction<RunnerSpecFormState>>
+  onRunnerSpecOpenChange: (open: boolean) => void
+  onSubmitRunnerSpec: (event: FormEvent<HTMLFormElement>) => void
+}) {
+  const managed = Boolean(editingRunnerSpec?.managed_by?.trim())
+
+  return (
+    <form className="grid gap-4" onSubmit={onSubmitRunnerSpec}>
+      {managed ? (
+        <div
+          id="managed-runner-spec-note"
+          className="flex items-start gap-3 rounded-md border bg-muted/35 px-3 py-2.5"
+        >
+          <Badge variant="secondary" className="mt-0.5">Managed</Badge>
+          <p className="text-sm leading-5 text-muted-foreground">
+            Catalog identity and routing fields are read-only. Capacity and availability remain operator controlled.
+          </p>
+        </div>
+      ) : null}
+
+      <div className="grid gap-2">
+        <Label htmlFor="runner-spec-name">Name</Label>
+        <Input
+          id="runner-spec-name"
+          value={runnerSpecForm.name}
+          onChange={(event) => onRunnerSpecFormChange((current) => ({ ...current, name: event.target.value }))}
+          placeholder="runner spec name"
+          disabled={editingRunnerSpec !== null}
+        />
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        <div className="grid gap-2">
+          <Label htmlFor="runner-spec-labels">Labels</Label>
+          <Input
+            id="runner-spec-labels"
+            value={runnerSpecForm.labels}
+            onChange={(event) => onRunnerSpecFormChange((current) => ({ ...current, labels: event.target.value }))}
+            placeholder="self-hosted,e2b"
+            disabled={managed}
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="runner-spec-required-labels">Required labels</Label>
+          <Input
+            id="runner-spec-required-labels"
+            value={runnerSpecForm.required_labels}
+            onChange={(event) =>
+              onRunnerSpecFormChange((current) => ({ ...current, required_labels: event.target.value }))
+            }
+            placeholder="e2b"
+            disabled={managed}
+          />
+          {!managed ? (
+            <p className="text-xs text-muted-foreground">Every matching job must request these labels.</p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        {managed ? (
+          <div className="grid gap-2">
+            <Label htmlFor="runner-spec-default-template">Default template</Label>
+            <Input
+              id="runner-spec-default-template"
+              value={editingRunnerSpec?.default_template_name || ""}
+              disabled
+            />
+          </div>
+        ) : (
+          <div className="grid gap-2">
+            <Label htmlFor="runner-spec-template-id">Template ID</Label>
+            <Input
+              id="runner-spec-template-id"
+              value={runnerSpecForm.template_id}
+              onChange={(event) =>
+                onRunnerSpecFormChange((current) => ({ ...current, template_id: event.target.value }))
+              }
+              placeholder="template id"
+            />
+          </div>
+        )}
+        <div className="grid gap-2">
+          <Label htmlFor="runner-spec-github-group">GitHub runner group</Label>
+          <Input
+            id="runner-spec-github-group"
+            value={runnerSpecForm.runner_group}
+            onChange={(event) =>
+              onRunnerSpecFormChange((current) => ({ ...current, runner_group: event.target.value }))
+            }
+            placeholder="optional GitHub runner group"
+            disabled={managed}
+          />
+        </div>
+      </div>
+
+      <fieldset className="grid gap-2 rounded-md border p-3" disabled={managed}>
+        <legend className="px-1 text-sm font-medium">Internal runner groups</legend>
+        {runnerGroups.length === 0 ? (
+          <div className="text-sm text-muted-foreground">No internal runner groups configured.</div>
+        ) : (
+          runnerGroups.map((group) => (
+            <label key={group.name} className="flex items-center gap-2 text-sm">
+              <input
+                id={`runner-spec-group-${group.name}`}
+                type="checkbox"
+                checked={runnerSpecForm.group_names.includes(group.name)}
+                onChange={(event) =>
+                  onRunnerSpecFormChange((current) => ({
+                    ...current,
+                    group_names: event.target.checked
+                      ? [...current.group_names, group.name]
+                      : current.group_names.filter((name) => name !== group.name),
+                  }))
+                }
+                disabled={managed}
+              />
+              {group.name}
+            </label>
+          ))
+        )}
+      </fieldset>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="grid gap-2">
+          <Label htmlFor="runner-spec-max-concurrency">Max concurrency</Label>
+          <Input
+            id="runner-spec-max-concurrency"
+            inputMode="numeric"
+            value={runnerSpecForm.max_concurrency}
+            onChange={(event) =>
+              onRunnerSpecFormChange((current) => ({ ...current, max_concurrency: event.target.value }))
+            }
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="runner-spec-min-idle">Min idle</Label>
+          <Input
+            id="runner-spec-min-idle"
+            inputMode="numeric"
+            value={runnerSpecForm.min_idle}
+            onChange={(event) =>
+              onRunnerSpecFormChange((current) => ({ ...current, min_idle: event.target.value }))
+            }
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="runner-spec-priority">Priority</Label>
+          <Input
+            id="runner-spec-priority"
+            inputMode="numeric"
+            value={runnerSpecForm.priority}
+            onChange={(event) =>
+              onRunnerSpecFormChange((current) => ({ ...current, priority: event.target.value }))
+            }
+            disabled={managed}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-2">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            id="runner-spec-enabled"
+            type="checkbox"
+            checked={runnerSpecForm.enabled}
+            onChange={(event) =>
+              onRunnerSpecFormChange((current) => ({ ...current, enabled: event.target.checked }))
+            }
+          />
+          enabled
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            id="runner-spec-default-available"
+            type="checkbox"
+            checked={runnerSpecForm.default_available}
+            onChange={(event) =>
+              onRunnerSpecFormChange((current) => ({ ...current, default_available: event.target.checked }))
+            }
+            disabled={managed}
+          />
+          globally available by default
+        </label>
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={() => onRunnerSpecOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button type="submit">Save runner spec</Button>
+      </DialogFooter>
+    </form>
+  )
+}
+
 export function RunnerSpecsSection({
   loading,
   runnerSpecs,
   runnerGroups,
   runnerSpecOpen,
+  editingRunnerSpec,
   runnerSpecForm,
   onRefresh,
   onResetRunnerSpecForm,
@@ -61,6 +272,7 @@ export function RunnerSpecsSection({
   runnerSpecs: RunnerSpec[]
   runnerGroups: RunnerGroup[]
   runnerSpecOpen: boolean
+  editingRunnerSpec: RunnerSpec | null
   runnerSpecForm: RunnerSpecFormState
   onRefresh: () => void
   onResetRunnerSpecForm: () => void
@@ -113,35 +325,71 @@ export function RunnerSpecsSection({
                 <TableHead>Runner groups</TableHead>
                 <TableHead>Default</TableHead>
                 <TableHead>Limit</TableHead>
-                <TableHead className="w-24" />
+                <TableHead className="w-44">
+                  <span className="sr-only">Actions</span>
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {runnerSpecs.map((runnerSpec) => (
+              {runnerSpecs.map((runnerSpec) => {
+                const managed = Boolean(runnerSpec.managed_by?.trim())
+                return (
                 <TableRow key={runnerSpec.name} className="cursor-pointer" onClick={() => onEditRunnerSpec(runnerSpec)}>
-                  <TableCell><div className="max-w-[220px] truncate">{runnerSpec.name}</div></TableCell>
+                  <TableCell>
+                    <div className="flex max-w-[240px] items-center gap-2">
+                      <span className="truncate">{runnerSpec.name}</span>
+                      {managed ? <Badge variant="secondary">Managed</Badge> : null}
+                    </div>
+                  </TableCell>
                   <TableCell><div className="max-w-[260px] truncate">{runnerSpec.labels.join(", ")}</div></TableCell>
-                  <TableCell><div className="max-w-[220px] truncate">{runnerSpec.template_id}</div></TableCell>
+                  <TableCell>
+                    <div className="max-w-[240px]">
+                      <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                        {managed ? "Default template" : "Template ID"}
+                      </div>
+                      <div className="truncate">
+                        {managed ? runnerSpec.default_template_name || "—" : runnerSpec.template_id}
+                      </div>
+                    </div>
+                  </TableCell>
                   <TableCell><div className="max-w-[220px] truncate">{runnerSpec.runner_group || "-"}</div></TableCell>
                   <TableCell><div className="max-w-[260px] truncate">{groupNamesForSpec(runnerSpec.name).join(", ") || "-"}</div></TableCell>
                   <TableCell>{runnerSpec.default_available ? "yes" : "no"}</TableCell>
                   <TableCell>{runnerSpec.max_concurrency}</TableCell>
                   <TableCell>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        onDeleteRunnerSpec(runnerSpec.name)
-                      }}
-                    >
-                      <Trash2 />
-                      Delete
-                    </Button>
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        aria-label={`Edit ${runnerSpec.name}`}
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          onEditRunnerSpec(runnerSpec)
+                        }}
+                      >
+                        <Pencil />
+                        Edit
+                      </Button>
+                      {!managed ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            onDeleteRunnerSpec(runnerSpec.name)
+                          }}
+                        >
+                          <Trash2 />
+                          Delete
+                        </Button>
+                      ) : null}
+                    </div>
                   </TableCell>
                 </TableRow>
-              ))}
+                )
+              })}
             </TableBody>
           </Table>
         </CardContent>
@@ -149,97 +397,17 @@ export function RunnerSpecsSection({
       <Dialog open={runnerSpecOpen} onOpenChange={onRunnerSpecOpenChange}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{runnerSpecForm.name ? "Edit runner spec" : "Create runner spec"}</DialogTitle>
+            <DialogTitle>{editingRunnerSpec ? "Edit runner spec" : "Create runner spec"}</DialogTitle>
             <DialogDescription>Define labels, template, group membership, and capacity.</DialogDescription>
           </DialogHeader>
-          <form className="grid gap-3" onSubmit={onSubmitRunnerSpec}>
-            <Input
-              value={runnerSpecForm.name}
-              onChange={(event) => onRunnerSpecFormChange((current) => ({ ...current, name: event.target.value }))}
-              placeholder="runner spec name"
-            />
-            <Input
-              value={runnerSpecForm.labels}
-              onChange={(event) => onRunnerSpecFormChange((current) => ({ ...current, labels: event.target.value }))}
-              placeholder="self-hosted,e2b"
-            />
-            <div className="grid gap-2 sm:grid-cols-2">
-              <Input
-                value={runnerSpecForm.template_id}
-                onChange={(event) => onRunnerSpecFormChange((current) => ({ ...current, template_id: event.target.value }))}
-                placeholder="template id"
-              />
-              <Input
-                value={runnerSpecForm.runner_group}
-                onChange={(event) => onRunnerSpecFormChange((current) => ({ ...current, runner_group: event.target.value }))}
-                placeholder="optional GitHub runner group"
-              />
-            </div>
-            <div className="grid gap-2 rounded-md border p-3">
-              {runnerGroups.length === 0 ? (
-                <div className="text-sm text-muted-foreground">No internal runner groups configured.</div>
-              ) : (
-                runnerGroups.map((group) => (
-                  <label key={group.name} className="flex items-center gap-2 text-sm">
-                    <input
-                      type="checkbox"
-                      checked={runnerSpecForm.group_names.includes(group.name)}
-                      onChange={(event) =>
-                        onRunnerSpecFormChange((current) => ({
-                          ...current,
-                          group_names: event.target.checked
-                            ? [...current.group_names, group.name]
-                            : current.group_names.filter((name) => name !== group.name),
-                        }))
-                      }
-                    />
-                    {group.name}
-                  </label>
-                ))
-              )}
-            </div>
-            <div className="grid grid-cols-3 gap-2">
-              <Input
-                value={runnerSpecForm.max_concurrency}
-                onChange={(event) => onRunnerSpecFormChange((current) => ({ ...current, max_concurrency: event.target.value }))}
-                placeholder="max concurrency"
-              />
-              <Input
-                value={runnerSpecForm.min_idle}
-                onChange={(event) => onRunnerSpecFormChange((current) => ({ ...current, min_idle: event.target.value }))}
-                placeholder="min idle"
-              />
-              <Input
-                value={runnerSpecForm.priority}
-                onChange={(event) => onRunnerSpecFormChange((current) => ({ ...current, priority: event.target.value }))}
-                placeholder="priority"
-              />
-            </div>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={runnerSpecForm.enabled}
-                onChange={(event) => onRunnerSpecFormChange((current) => ({ ...current, enabled: event.target.checked }))}
-              />
-              enabled
-            </label>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={runnerSpecForm.default_available}
-                onChange={(event) =>
-                  onRunnerSpecFormChange((current) => ({ ...current, default_available: event.target.checked }))
-                }
-              />
-              globally available by default
-            </label>
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => onRunnerSpecOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button type="submit">Save runner spec</Button>
-            </DialogFooter>
-          </form>
+          <RunnerSpecDialogForm
+            runnerGroups={runnerGroups}
+            editingRunnerSpec={editingRunnerSpec}
+            runnerSpecForm={runnerSpecForm}
+            onRunnerSpecFormChange={onRunnerSpecFormChange}
+            onRunnerSpecOpenChange={onRunnerSpecOpenChange}
+            onSubmitRunnerSpec={onSubmitRunnerSpec}
+          />
         </DialogContent>
       </Dialog>
     </div>

--- a/ui/src/hooks/use-runner-catalog.ts
+++ b/ui/src/hooks/use-runner-catalog.ts
@@ -8,6 +8,68 @@ import { type AdminSection, type RunnerGroup, type RunnerPolicy, type RunnerSpec
 
 type RequestFn = (url: string, options?: RequestInit) => Promise<unknown>
 
+export async function submitRunnerSpecChanges({
+  request,
+  runnerGroups,
+  editingRunnerSpec,
+  runnerSpecForm,
+  parseLabels,
+}: {
+  request: RequestFn
+  runnerGroups: RunnerGroup[]
+  editingRunnerSpec: RunnerSpec | null
+  runnerSpecForm: RunnerSpecFormState
+  parseLabels: (value: string) => string[]
+}) {
+  const name = editingRunnerSpec?.name || runnerSpecForm.name.trim()
+  const managed = Boolean(editingRunnerSpec?.managed_by?.trim())
+  const payload = managed
+    ? {
+        max_concurrency: Number(runnerSpecForm.max_concurrency) || 0,
+        min_idle: Number(runnerSpecForm.min_idle) || 0,
+        enabled: runnerSpecForm.enabled,
+      }
+    : {
+        ...(editingRunnerSpec ? {} : { name }),
+        labels: parseLabels(runnerSpecForm.labels),
+        required_labels: parseLabels(runnerSpecForm.required_labels),
+        template_id: runnerSpecForm.template_id.trim(),
+        runner_group: runnerSpecForm.runner_group.trim(),
+        max_concurrency: Number(runnerSpecForm.max_concurrency) || 0,
+        min_idle: Number(runnerSpecForm.min_idle) || 0,
+        priority: Number(runnerSpecForm.priority) || 0,
+        enabled: runnerSpecForm.enabled,
+        default_available: runnerSpecForm.default_available,
+      }
+  await request(editingRunnerSpec ? `/runner_specs/${encodeURIComponent(name)}` : "/runner_specs", {
+    method: editingRunnerSpec ? "PATCH" : "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  })
+
+  if (managed) return name
+
+  for (const group of runnerGroups) {
+    const shouldContain = runnerSpecForm.group_names.includes(group.name)
+    const currentSpecs = new Set(group.spec_names)
+    if (shouldContain === currentSpecs.has(name)) {
+      continue
+    }
+    if (shouldContain) currentSpecs.add(name)
+    else currentSpecs.delete(name)
+    await request(`/runner_groups/${encodeURIComponent(group.name)}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        spec_names: Array.from(currentSpecs).sort(),
+        enabled: group.enabled,
+      }),
+    })
+  }
+
+  return name
+}
+
 export function useRunnerCatalog({
   runnerSpecs,
   runnerGroups,
@@ -26,11 +88,13 @@ export function useRunnerCatalog({
   parseLabels: (value: string) => string[]
 }) {
   const [runnerSpecOpen, setRunnerSpecOpen] = useState(false)
+  const [editingRunnerSpec, setEditingRunnerSpec] = useState<RunnerSpec | null>(null)
   const [runnerGroupOpen, setRunnerGroupOpen] = useState(false)
   const [runnerPolicyOpen, setRunnerPolicyOpen] = useState(false)
   const [runnerSpecForm, setRunnerSpecForm] = useState<RunnerSpecFormState>({
     name: "",
     labels: "self-hosted,e2b",
+    required_labels: "",
     template_id: "",
     runner_group: "",
     group_names: [],
@@ -64,9 +128,11 @@ export function useRunnerCatalog({
   )
 
   const resetRunnerSpecForm = () => {
+    setEditingRunnerSpec(null)
     setRunnerSpecForm({
       name: "",
       labels: "self-hosted,e2b",
+      required_labels: "",
       template_id: "",
       runner_group: "",
       group_names: [],
@@ -113,43 +179,14 @@ export function useRunnerCatalog({
   const saveRunnerSpec = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     try {
-      const payload = {
-        name: runnerSpecForm.name.trim(),
-        labels: parseLabels(runnerSpecForm.labels),
-        template_id: runnerSpecForm.template_id.trim(),
-        runner_group: runnerSpecForm.runner_group.trim(),
-        max_concurrency: Number(runnerSpecForm.max_concurrency) || 0,
-        min_idle: Number(runnerSpecForm.min_idle) || 0,
-        priority: Number(runnerSpecForm.priority) || 0,
-        enabled: runnerSpecForm.enabled,
-        default_available: runnerSpecForm.default_available,
-      }
-      const isUpdate = runnerSpecs.some((runnerSpec) => runnerSpec.name === payload.name)
-      const url = isUpdate ? `/runner_specs/${encodeURIComponent(payload.name)}` : "/runner_specs"
-      const method = isUpdate ? "PATCH" : "POST"
-      await request(url, {
-        method,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+      const name = await submitRunnerSpecChanges({
+        request,
+        runnerGroups,
+        editingRunnerSpec,
+        runnerSpecForm,
+        parseLabels,
       })
-      for (const group of runnerGroups) {
-        const shouldContain = runnerSpecForm.group_names.includes(group.name)
-        const currentSpecs = new Set(group.spec_names)
-        if (shouldContain === currentSpecs.has(payload.name)) {
-          continue
-        }
-        if (shouldContain) currentSpecs.add(payload.name)
-        else currentSpecs.delete(payload.name)
-        await request(`/runner_groups/${encodeURIComponent(group.name)}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            spec_names: Array.from(currentSpecs).sort(),
-            enabled: group.enabled,
-          }),
-        })
-      }
-      toast.success(`Runner spec ${payload.name} saved`)
+      toast.success(`Runner spec ${name} saved`)
       setRunnerSpecOpen(false)
       await loadAll()
     } catch (error) {
@@ -159,9 +196,11 @@ export function useRunnerCatalog({
 
   const loadRunnerSpecIntoForm = (runnerSpec: RunnerSpec) => {
     setSection("runner_specs")
+    setEditingRunnerSpec(runnerSpec)
     setRunnerSpecForm({
       name: runnerSpec.name,
       labels: runnerSpec.labels.join(","),
+      required_labels: runnerSpec.required_labels.join(","),
       template_id: runnerSpec.template_id,
       runner_group: runnerSpec.runner_group || "",
       group_names: runnerGroups
@@ -301,6 +340,7 @@ export function useRunnerCatalog({
 
   return {
     runnerSpecOpen,
+    editingRunnerSpec,
     runnerGroupOpen,
     runnerPolicyOpen,
     runnerSpecForm,


### PR DESCRIPTION
Completes #38 after the public template supply chain landed in #62.

Summary:
- reconcile five runnerd-owned managed Runner Specs for Ubuntu Slim, 22.04, 24.04, preview 26.04, and ubuntu-latest while preserving enabled, max_concurrency, and min_idle operator controls
- resolve each stable public template name from the account or organization scoped Sandbox ListDefaultTemplates response immediately before runner registration
- keep custom specs operator-owned with explicit template IDs
- add additive SQLite runner_profiles migration coverage, admin API behavior, UI controls, and bilingual operator documentation
- bootstrap the Sandbox command as root, tolerate runner-images environment entries that reference build-only variables, and keep long-lived runner command streams free of a whole-request HTTP timeout

Release evidence:
- all four physical templates are public, catalog-checked, and release-smoke verified in cn-yangzhou-1 and us-south-1; IDs and build evidence: https://github.com/qiniu/ci-runner/issues/38#issuecomment-5164811404
- end-to-end managed workflow acceptance: https://github.com/miclle/qiniu-ci-runner-test/actions/runs/30858489153
- signed GitHub workflow_run and workflow_job deliveries covered queued, in_progress, and completed actions
- all five logical labels succeeded; every request reached completed, every Sandbox was cleaned, and the test repository finished with zero self-hosted runners
- the acceptance used a temporary repository webhook targeting the isolated local runnerd and removed it afterward; the repository finished with zero webhooks

Verification:
- bash -n internal/sandboxrunner/scripts/start-github-runner.sh
- shellcheck -e SC2182 internal/sandboxrunner/scripts/start-github-runner.sh
- go test ./internal/state -count=1
- go test ./internal/runnercatalog ./internal/sandboxrunner ./internal/server -count=1
- task template-check-all
- GOFLAGS=-buildvcs=false task lint
- GOFLAGS=-buildvcs=false task test (UI 129/129 plus Go race and coverage)
- go mod tidy -diff
- go mod verify
- go build -trimpath -buildvcs=false ./cmd/runnerd and --help smoke

The linked-worktree checkout cannot use Go VCS auto-stamping because Go resolves git status from the parent worktree path; the normal-clone GitHub build check remains the authoritative VCS-stamped build.