### PR TITLE
fix(runner): preserve custom Docker fallback

### DIFF
--- a/docs/default-runner-templates.md
+++ b/docs/default-runner-templates.md
@@ -63,6 +63,11 @@ workflow disables managed-default selection from the workflow side. Custom
 specs remain available with operator-defined required labels and explicit
 template IDs.
 
+At runner bootstrap, managed specs fail closed if their template cannot make
+the Docker daemon available because Docker is part of the managed compatibility
+contract. Custom specs retain the legacy best-effort behavior: runnerd logs a
+warning and continues registration so non-Docker jobs can still run.
+
 ## Software compatibility
 
 These templates track the pinned `actions/runner-images` reports item by item,

--- a/docs/zh/default-runner-templates.md
+++ b/docs/zh/default-runner-templates.md
@@ -61,6 +61,10 @@ Admin 中禁用单个 managed spec；从 workflow 中移除 `qiniu` 则会从 wo
 侧阻止 managed-default selection。自定义 spec 仍可使用 operator 定义的
 required labels 和显式 template ID。
 
+Runner 启动时，如果模板无法使 Docker daemon 可用，managed spec 会直接失败，
+因为 Docker 属于 managed 兼容性契约。自定义 spec 保留原有的 best-effort 行为：
+runnerd 记录 warning 后继续注册，使不依赖 Docker 的 jobs 仍可运行。
+
 ## 软件兼容性
 
 这些模板会逐项跟踪固定版本的 `actions/runner-images` 软件报告，但并非与 GitHub

--- a/internal/sandboxrunner/runner.go
+++ b/internal/sandboxrunner/runner.go
@@ -23,6 +23,7 @@ type StartInput struct {
 	Labels            []string
 	RunnerGroup       string
 	TemplateID        string
+	RequireDocker     bool
 	Timeout           time.Duration
 	CommandContext    context.Context
 	OnStdout          func([]byte)
@@ -478,6 +479,10 @@ func (s *e2bTerminalSession) Close(ctx context.Context) error {
 
 func startScript(input StartInput, sandboxID string) string {
 	labels := strings.Join(input.Labels, ",")
+	requireDocker := "0"
+	if input.RequireDocker {
+		requireDocker = "1"
+	}
 	return fmt.Sprintf(
 		startRunnerScriptTemplate,
 		base64.StdEncoding.EncodeToString([]byte(input.RepositoryURL)),
@@ -487,5 +492,6 @@ func startScript(input StartInput, sandboxID string) string {
 		base64.StdEncoding.EncodeToString([]byte(input.RunnerGroup)),
 		base64.StdEncoding.EncodeToString([]byte(input.RequestID)),
 		base64.StdEncoding.EncodeToString([]byte(sandboxID)),
+		requireDocker,
 	)
 }

--- a/internal/sandboxrunner/runner_test.go
+++ b/internal/sandboxrunner/runner_test.go
@@ -192,12 +192,15 @@ printf 'run HOME=%s PWD=%s RUNASROOT=%s\n' "$HOME" "$PWD" "${RUNNER_ALLOW_RUNASR
 
 func TestStartScriptDockerBootstrapPolicy(t *testing.T) {
 	tests := []struct {
-		name          string
-		requireDocker bool
-		wantSuccess   bool
+		name                string
+		requireDocker       bool
+		installDockerHelper bool
+		wantSuccess         bool
 	}{
-		{name: "custom runner continues without Docker", wantSuccess: true},
-		{name: "managed runner requires Docker", requireDocker: true},
+		{name: "custom runner continues when Docker bootstrap fails", installDockerHelper: true, wantSuccess: true},
+		{name: "managed runner requires working Docker", requireDocker: true, installDockerHelper: true},
+		{name: "custom runner continues when Docker helper is missing", wantSuccess: true},
+		{name: "managed runner requires Docker helper", requireDocker: true},
 	}
 
 	for _, tt := range tests {
@@ -218,9 +221,11 @@ printf 'config %s\n' "$*" >>"$RUNNER_TEST_LOG"
 set -euo pipefail
 printf 'run\n' >>"$RUNNER_TEST_LOG"
 `)
-			writeExecutable(t, ensureDockerPath, `#!/usr/bin/env bash
+			if tt.installDockerHelper {
+				writeExecutable(t, ensureDockerPath, `#!/usr/bin/env bash
 exit 1
 `)
+			}
 
 			script := startScript(StartInput{
 				RequestID:         "request-1",

--- a/internal/sandboxrunner/runner_test.go
+++ b/internal/sandboxrunner/runner_test.go
@@ -190,6 +190,85 @@ printf 'run HOME=%s PWD=%s RUNASROOT=%s\n' "$HOME" "$PWD" "${RUNNER_ALLOW_RUNASR
 	}
 }
 
+func TestStartScriptDockerBootstrapPolicy(t *testing.T) {
+	tests := []struct {
+		name          string
+		requireDocker bool
+		wantSuccess   bool
+	}{
+		{name: "custom runner continues without Docker", wantSuccess: true},
+		{name: "managed runner requires Docker", requireDocker: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := t.TempDir()
+			actionsRunnerRoot := filepath.Join(fixture, "actions-runner")
+			ensureDockerPath := filepath.Join(fixture, "ensure-docker")
+			workdir := filepath.Join(fixture, "workdir")
+			logPath := filepath.Join(fixture, "runner.log")
+			if err := os.MkdirAll(actionsRunnerRoot, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeExecutable(t, filepath.Join(actionsRunnerRoot, "config.sh"), `#!/usr/bin/env bash
+set -euo pipefail
+printf 'config %s\n' "$*" >>"$RUNNER_TEST_LOG"
+`)
+			writeExecutable(t, filepath.Join(actionsRunnerRoot, "run.sh"), `#!/usr/bin/env bash
+set -euo pipefail
+printf 'run\n' >>"$RUNNER_TEST_LOG"
+`)
+			writeExecutable(t, ensureDockerPath, `#!/usr/bin/env bash
+exit 1
+`)
+
+			script := startScript(StartInput{
+				RequestID:         "request-1",
+				RepositoryURL:     "https://github.com/o/r",
+				RegistrationToken: "token",
+				RunnerName:        "runner",
+				Labels:            []string{"self-hosted", "linux", "x64"},
+				RequireDocker:     tt.requireDocker,
+			}, "sandbox-1")
+			scriptPath := filepath.Join(fixture, "start-runner.sh")
+			writeExecutable(t, scriptPath, script)
+
+			output, err := runCommand(
+				t,
+				"bash",
+				[]string{scriptPath},
+				"ACTIONS_RUNNER_ROOT="+actionsRunnerRoot,
+				"RUNNER_WORKDIR="+workdir,
+				"RUNNER_JOB_WORK="+filepath.Join(fixture, "job-work"),
+				"RUNNER_HOME="+filepath.Join(fixture, "home"),
+				"RUNNER_HOOK_ROOT="+filepath.Join(fixture, "hooks"),
+				"RUNNER_ENVIRONMENT_FILE="+filepath.Join(fixture, "missing-environment"),
+				"RUNNER_TEST_LOG="+logPath,
+				"RUNNERD_AS_RUNNER=1",
+				"ENSURE_DOCKER="+ensureDockerPath,
+			)
+			if tt.wantSuccess && err != nil {
+				t.Fatalf("custom runner start failed: %v\n%s", err, output)
+			}
+			if !tt.wantSuccess && err == nil {
+				t.Fatalf("managed runner start succeeded without Docker:\n%s", output)
+			}
+
+			logBytes, readErr := os.ReadFile(logPath)
+			if tt.wantSuccess {
+				if readErr != nil {
+					t.Fatal(readErr)
+				}
+				if !strings.Contains(string(logBytes), "run\n") {
+					t.Fatalf("custom runner did not execute after Docker failure: %q", logBytes)
+				}
+			} else if readErr == nil && strings.Contains(string(logBytes), "run\n") {
+				t.Fatalf("managed runner executed after Docker failure: %q", logBytes)
+			}
+		})
+	}
+}
+
 func TestRunnerTemplateMatrixGateAcceptsManagedCatalog(t *testing.T) {
 	output, err := runCommand(t, "bash", []string{"scripts/check-runner-template-matrix.sh"})
 	if err != nil {

--- a/internal/sandboxrunner/scripts/start-github-runner.sh
+++ b/internal/sandboxrunner/scripts/start-github-runner.sh
@@ -7,6 +7,7 @@ workdir="${RUNNER_WORKDIR:-/home/runner/actions-runner}"
 runner_job_work="${RUNNER_JOB_WORK:-/home/runner/work}"
 hook_root="${RUNNER_HOOK_ROOT:-/home/runner/_runnerd-hooks}"
 ensure_docker="${ENSURE_DOCKER:-/usr/local/bin/ensure-docker}"
+require_docker="%[8]s"
 runner_environment_file="${RUNNER_ENVIRONMENT_FILE:-/etc/environment}"
 export HOME="${RUNNER_HOME:-/home/runner}"
 export XDG_CONFIG_HOME="${HOME}/.config"
@@ -62,7 +63,13 @@ fi
 
 if [ -x "$ensure_docker" ]; then
   echo "checking Docker daemon"
-  "$ensure_docker"
+  if ! "$ensure_docker"; then
+    if [ "$require_docker" = 1 ]; then
+      echo "Docker daemon is required for this managed runner" >&2
+      exit 1
+    fi
+    echo "Docker daemon is unavailable; continuing without Docker" >&2
+  fi
 fi
 
 runner_url="$(printf '%%s' "%[1]s" | base64 -d)"

--- a/internal/sandboxrunner/scripts/start-github-runner.sh
+++ b/internal/sandboxrunner/scripts/start-github-runner.sh
@@ -61,7 +61,13 @@ if [ ! -x ./config.sh ]; then
   cp -a "$actions_runner_root"/. "$workdir"/
 fi
 
-if [ -x "$ensure_docker" ]; then
+if [ ! -x "$ensure_docker" ]; then
+  if [ "$require_docker" = 1 ]; then
+    echo "missing required Docker bootstrap helper at $ensure_docker" >&2
+    exit 1
+  fi
+  echo "Docker bootstrap helper is unavailable; continuing without Docker" >&2
+else
   echo "checking Docker daemon"
   if ! "$ensure_docker"; then
     if [ "$require_docker" = 1 ]; then

--- a/internal/server/server_default_templates_test.go
+++ b/internal/server/server_default_templates_test.go
@@ -249,6 +249,9 @@ func TestRunnerLifecycleCustomTemplateUsesStoredIDWithoutCatalog(t *testing.T) {
 	if len(inputs) != 1 || inputs[0].TemplateID != "custom-template-id" {
 		t.Fatalf("StartRunner inputs = %#v, want stored custom template id", inputs)
 	}
+	if inputs[0].RequireDocker {
+		t.Fatalf("custom StartRunner input requires Docker: %#v", inputs[0])
+	}
 }
 
 func TestRunnerLifecycleManagedDefaultResolvesBeforeRegistration(t *testing.T) {
@@ -277,6 +280,9 @@ func TestRunnerLifecycleManagedDefaultResolvesBeforeRegistration(t *testing.T) {
 	inputs := sandbox.startInputs()
 	if len(inputs) != 1 || inputs[0].TemplateID != "scoped-template-id" {
 		t.Fatalf("StartRunner inputs = %#v, want resolved scoped template id", inputs)
+	}
+	if !inputs[0].RequireDocker {
+		t.Fatalf("managed StartRunner input does not require Docker: %#v", inputs[0])
 	}
 	if got := events.snapshot(); !equalStrings(got, []string{"profile", "catalog", "token", "start"}) {
 		t.Fatalf("lifecycle order = %#v, want [profile catalog token start]", got)

--- a/internal/server/server_runner_lifecycle.go
+++ b/internal/server/server_runner_lifecycle.go
@@ -273,6 +273,7 @@ func (s *Server) startRunner(ctx context.Context, id, workerID string) {
 			Labels:            req.Labels,
 			RunnerGroup:       strings.TrimSpace(req.RunnerGroup),
 			TemplateID:        templateID,
+			RequireDocker:     strings.TrimSpace(profile.ManagedBy) != "",
 			Timeout:           s.cfg.SandboxTimeout,
 			CommandContext:    ctx,
 			OnStdout:          func(data []byte) { s.appendRunnerStdout(id, data) },

--- a/templates/README.md
+++ b/templates/README.md
@@ -212,9 +212,3 @@ target for rollback. Qshell publish and unpublish do not support the build-only
 `--config` option. Their Task targets run from the matching template directory,
 read the stable name from its tracked `qshell.sandbox.toml`, and invoke the
 matching operation with `-y`; no Region-specific template ID is committed.
-
-## Current versus target state
-
-All rows above are currently `development`. They are tracked build definitions,
-not a claim that the templates are public. The target catalog becomes public
-only through the publication and verification transitions described above.


### PR DESCRIPTION
## Summary

- keep managed default runners fail-closed when Docker bootstrap fails while preserving best-effort startup for custom Runner Specs
- remove the stale template publication-state paragraph that contradicted the verified support matrix
- document the managed/custom Docker policy and cover both script behavior and lifecycle propagation

## Verification

- `task template-check-all`
- `task test`
- `task lint`
- `shellcheck -e SC2182 internal/sandboxrunner/scripts/start-github-runner.sh`

## Context

Follow-up for the two unresolved threads in the post-merge review on #62: https://github.com/qiniu/ci-runner/pull/62#pullrequestreview-4848944203