### PR TITLE
fix(templates): harden public runner builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ loading.
 Run `task template-check-all`, then use the four
 `task template-build-ubuntu-*` targets for real qshell Sandbox builds. See
 [Public Runner Templates](docs/default-runner-templates.md) for publication and
+cache-resume guidance after a remote build time limit, plus publication and
 smoke commands. The qbox-kodo base image remains a separate
 `task qbox-kodo-base-build` workflow.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -267,7 +267,8 @@ task release-check # 验证发布构建
 
 先运行 `task template-check-all`，再通过 4 个
 `task template-build-ubuntu-*` targets 执行真实 qshell Sandbox 构建。发布与
-smoke 命令见[公共 Runner 模板](docs/zh/default-runner-templates.md)。qbox-kodo
+远程构建超时后的缓存续跑、发布与 smoke 命令见
+[公共 Runner 模板](docs/zh/default-runner-templates.md)。qbox-kodo
 基础镜像仍使用独立的 `task qbox-kodo-base-build` 流程。
 
 ## 文档

--- a/docs/default-runner-templates.md
+++ b/docs/default-runner-templates.md
@@ -116,12 +116,14 @@ Then build the actual Sandbox templates with qshell. Each target waits for
 qshell to report terminal `Status: ready`; a zero process exit without that
 status is treated as a failed build.
 
-The source gate rejects Actions Runner versions below `2.336.0`. Runtime
-conformance also checks the exact pinned Runner and Azure CLI versions, so
-their Dockerfile versions, official checksums, and compatibility verification
-must be updated together. Python and pipx installation has bounded retries for
-transient package-index failures; other upstream installers are not retried
-automatically because they may not be idempotent.
+The source gate rejects Actions Runner versions below `2.336.0`. Release smoke
+checks the exact Dockerfile-pinned Runner version and the template name/version
+persisted into the Sandbox runtime environment. Full runtime conformance also
+checks the exact pinned Azure CLI version, so Dockerfile versions, official
+checksums, and compatibility verification must be updated together. Python and
+pipx installation has bounded retries for transient package-index failures;
+other upstream installers are not retried automatically because they may not
+be idempotent.
 
 ```bash
 task template-build-ubuntu-slim
@@ -130,8 +132,14 @@ task template-build-ubuntu-24-04
 task template-build-ubuntu-26-04
 ```
 
-The Dockerfiles keep `bootstrap`, `platform`, `toolchain`, and `runtime` as
-separate qshell-compatible cache layers. If a remote build reaches the service
+The Dockerfiles keep `bootstrap`, `platform`, `node`, `toolchain`, and
+`runtime` work in separate qshell-compatible cache layers where applicable.
+Ubuntu 26.04 additionally preinstalls the pinned runner-images apt package list
+in eighteen cacheable batches before the upstream platform installer rechecks
+the packages and runs its Pester contract. Large emoji-font, ICU, RPM, Tk,
+Xvfb, binutils, and `systemd-coredump` dependency sets are isolated, and the
+final batch is open-ended so appended pinned packages are not skipped. If a
+remote build reaches the service
 time limit after completing an earlier layer, rerun the same command with the
 normal cache enabled. Do not force `--no-cache`; the release gate remains a
 single build reaching terminal `Status: ready`.

--- a/docs/default-runner-templates.md
+++ b/docs/default-runner-templates.md
@@ -118,12 +118,14 @@ status is treated as a failed build.
 
 The source gate rejects Actions Runner versions below `2.336.0`. Release smoke
 checks the exact Dockerfile-pinned Runner version and the template name/version
-persisted into the Sandbox runtime environment. Full runtime conformance also
-checks the exact pinned Azure CLI version, so Dockerfile versions, official
-checksums, and compatibility verification must be updated together. Python and
-pipx installation has bounded retries for transient package-index failures;
-other upstream installers are not retried automatically because they may not
-be idempotent.
+persisted into the Sandbox runtime environment. It also loads NVM as the
+`runner` user and requires `/home/runner/.nvm` to be writable, preventing a
+root-owned build skeleton from passing the release gate. Full runtime
+conformance also checks the exact pinned Azure CLI version, so Dockerfile
+versions, official checksums, and compatibility verification must be updated
+together. Python and pipx installation has bounded retries for transient
+package-index failures; other upstream installers are not retried automatically
+because they may not be idempotent.
 
 ```bash
 task template-build-ubuntu-slim
@@ -134,6 +136,16 @@ task template-build-ubuntu-26-04
 
 The Dockerfiles keep `bootstrap`, `platform`, `node`, `toolchain`, and
 `runtime` work in separate qshell-compatible cache layers where applicable.
+Template version metadata is applied after provisioning, and the runner-owned
+NVM copy is isolated between `toolchain` and `runtime`, so either change keeps
+the heavy installer layers reusable.
+Before `platform`, each Dockerfile downloads the checksum-pinned AWS SAM
+archive in independent 16 MiB-or-smaller Range layers. Completed chunks remain
+cacheable across a service timeout under `/opt/qiniu-runner-build-cache`;
+qshell does not restore cached `/tmp` outputs. The Dockerfile checks the
+assembled byte count and full SHA-256 digest, then runs the `platform`
+installer in the same layer. The checked oversized archive is consumed
+immediately and never becomes a cache output.
 Ubuntu 26.04 additionally preinstalls the pinned runner-images apt package list
 in eighteen cacheable batches before the upstream platform installer rechecks
 the packages and runs its Pester contract. Large emoji-font, ICU, RPM, Tk,

--- a/docs/default-runner-templates.md
+++ b/docs/default-runner-templates.md
@@ -116,12 +116,25 @@ Then build the actual Sandbox templates with qshell. Each target waits for
 qshell to report terminal `Status: ready`; a zero process exit without that
 status is treated as a failed build.
 
+The source gate rejects Actions Runner versions below `2.336.0`. Runtime
+conformance also checks the exact pinned Runner and Azure CLI versions, so
+their Dockerfile versions, official checksums, and compatibility verification
+must be updated together. Python and pipx installation has bounded retries for
+transient package-index failures; other upstream installers are not retried
+automatically because they may not be idempotent.
+
 ```bash
 task template-build-ubuntu-slim
 task template-build-ubuntu-22-04
 task template-build-ubuntu-24-04
 task template-build-ubuntu-26-04
 ```
+
+The Dockerfiles keep `bootstrap`, `platform`, `toolchain`, and `runtime` as
+separate qshell-compatible cache layers. If a remote build reaches the service
+time limit after completing an earlier layer, rerun the same command with the
+normal cache enabled. Do not force `--no-cache`; the release gate remains a
+single build reaching terminal `Status: ready`.
 
 Publish only after all four builds are ready:
 

--- a/docs/zh/default-runner-templates.md
+++ b/docs/zh/default-runner-templates.md
@@ -108,12 +108,22 @@ task template-check-all
 然后使用 qshell 构建真正的 Sandbox 模板。每个任务都会等待 qshell 输出终态
 `Status: ready`；如果进程退出码为 0，却没有出现该状态，任务仍会判定构建失败。
 
+源码门槛会拒绝低于 `2.336.0` 的 Actions Runner。运行时 conformance 还会检查
+固定的 Runner 和 Azure CLI 精确版本，因此 Dockerfile 中的版本、官方校验和与
+compatibility verification 必须同步更新。Python 和 pipx 安装会对软件包索引的
+瞬时失败执行有限重试；其他上游安装器可能不具备幂等性，因此不会自动重试。
+
 ```bash
 task template-build-ubuntu-slim
 task template-build-ubuntu-22-04
 task template-build-ubuntu-24-04
 task template-build-ubuntu-26-04
 ```
+
+Dockerfile 将 `bootstrap`、`platform`、`toolchain` 和 `runtime` 保留为独立的
+qshell 兼容缓存层。如果远程构建在已有阶段完成后触及服务时限，请保留默认缓存并
+重跑同一命令，不要强制使用 `--no-cache`。发布门槛仍然是某一次构建最终达到
+`Status: ready`。
 
 4 个构建全部 ready 后再发布：
 

--- a/docs/zh/default-runner-templates.md
+++ b/docs/zh/default-runner-templates.md
@@ -108,10 +108,12 @@ task template-check-all
 然后使用 qshell 构建真正的 Sandbox 模板。每个任务都会等待 qshell 输出终态
 `Status: ready`；如果进程退出码为 0，却没有出现该状态，任务仍会判定构建失败。
 
-源码门槛会拒绝低于 `2.336.0` 的 Actions Runner。运行时 conformance 还会检查
-固定的 Runner 和 Azure CLI 精确版本，因此 Dockerfile 中的版本、官方校验和与
-compatibility verification 必须同步更新。Python 和 pipx 安装会对软件包索引的
-瞬时失败执行有限重试；其他上游安装器可能不具备幂等性，因此不会自动重试。
+源码门槛会拒绝低于 `2.336.0` 的 Actions Runner。Release smoke 会检查
+Dockerfile 固定的 Runner 精确版本，以及持久化到 Sandbox 运行时环境中的模板名和
+模板版本。完整 runtime conformance 还会检查固定的 Azure CLI 精确版本，因此
+Dockerfile 中的版本、官方校验和与 compatibility verification 必须同步更新。
+Python 和 pipx 安装会对软件包索引的瞬时失败执行有限重试；其他上游安装器可能不
+具备幂等性，因此不会自动重试。
 
 ```bash
 task template-build-ubuntu-slim
@@ -120,10 +122,15 @@ task template-build-ubuntu-24-04
 task template-build-ubuntu-26-04
 ```
 
-Dockerfile 将 `bootstrap`、`platform`、`toolchain` 和 `runtime` 保留为独立的
-qshell 兼容缓存层。如果远程构建在已有阶段完成后触及服务时限，请保留默认缓存并
-重跑同一命令，不要强制使用 `--no-cache`。发布门槛仍然是某一次构建最终达到
-`Status: ready`。
+Dockerfile 会按需将 `bootstrap`、`platform`、`node`、`toolchain` 和
+`runtime` 工作保留为独立的 qshell 兼容缓存层。Ubuntu 26.04 还会先将固定的
+runner-images apt 软件包列表拆成 18 个可缓存批次安装，再由上游 platform 安装器
+逐包确认并运行 Pester 契约。大体积的 emoji 字体、ICU、RPM、Tk、Xvfb、
+binutils 和 `systemd-coredump` 依赖集分别独立成层，最后一批使用开放区间，
+避免遗漏固定列表后续新增项。如果远程构建
+在已有阶段完成后触及服务时限，请保留
+默认缓存并重跑同一命令，不要强制使用 `--no-cache`。发布门槛仍然是某一次构建
+最终达到 `Status: ready`。
 
 4 个构建全部 ready 后再发布：
 

--- a/docs/zh/default-runner-templates.md
+++ b/docs/zh/default-runner-templates.md
@@ -110,10 +110,11 @@ task template-check-all
 
 源码门槛会拒绝低于 `2.336.0` 的 Actions Runner。Release smoke 会检查
 Dockerfile 固定的 Runner 精确版本，以及持久化到 Sandbox 运行时环境中的模板名和
-模板版本。完整 runtime conformance 还会检查固定的 Azure CLI 精确版本，因此
-Dockerfile 中的版本、官方校验和与 compatibility verification 必须同步更新。
-Python 和 pipx 安装会对软件包索引的瞬时失败执行有限重试；其他上游安装器可能不
-具备幂等性，因此不会自动重试。
+模板版本。它还会以 `runner` 用户加载 NVM，并要求 `/home/runner/.nvm` 可写，
+防止 root 所有的构建 skeleton 错误通过发布门禁。完整 runtime conformance 还会
+检查固定的 Azure CLI 精确版本，因此 Dockerfile 中的版本、官方校验和与
+compatibility verification 必须同步更新。Python 和 pipx 安装会对软件包索引的
+瞬时失败执行有限重试；其他上游安装器可能不具备幂等性，因此不会自动重试。
 
 ```bash
 task template-build-ubuntu-slim
@@ -123,7 +124,16 @@ task template-build-ubuntu-26-04
 ```
 
 Dockerfile 会按需将 `bootstrap`、`platform`、`node`、`toolchain` 和
-`runtime` 工作保留为独立的 qshell 兼容缓存层。Ubuntu 26.04 还会先将固定的
+`runtime` 工作保留为独立的 qshell 兼容缓存层。模板版本元数据会在预置工作
+结束后才写入，runner 所有的 NVM 副本则独立放在 `toolchain` 与 `runtime` 之间，
+因此两类变更都不会让重型安装层的缓存失效。
+在 `platform` 之前，每个 Dockerfile 还会将固定校验和的 AWS SAM 归档拆成
+不超过 16 MiB 的独立 Range 下载层。服务超时后可复用已经完成的分块；
+这些分块保存在 `/opt/qiniu-runner-build-cache`，因为 qshell 不会恢复缓存层中
+写入 `/tmp` 的输出。Dockerfile 会校验拼接后的精确字节数和完整 SHA-256，
+但不会把单个大归档作为缓存层输出保留；校验通过后会在同一个 `RUN` 中继续
+执行 `platform` 安装，立即消费该归档。
+Ubuntu 26.04 还会先将固定的
 runner-images apt 软件包列表拆成 18 个可缓存批次安装，再由上游 platform 安装器
 逐包确认并运行 Pester 契约。大体积的 emoji 字体、ICU、RPM、Tk、Xvfb、
 binutils 和 `systemd-coredump` 依赖集分别独立成层，最后一批使用开放区间，

--- a/internal/sandboxrunner/runner_test.go
+++ b/internal/sandboxrunner/runner_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -1164,7 +1165,7 @@ esac
 	}
 }
 
-func TestTemplateReleaseSmokeRunsOnlyUsabilityContract(t *testing.T) {
+func TestTemplateReleaseSmokeRunsUsabilityAndIdentityContract(t *testing.T) {
 	fixture := t.TempDir()
 	binDir := filepath.Join(fixture, "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
@@ -1253,12 +1254,23 @@ esac
 	if !result.Passed ||
 		result.SupportChannel != "preview" ||
 		!result.Cleanup.Passed ||
-		len(result.Results) != 6 {
-		t.Fatalf("release smoke result = %#v, want six passing usability checks and cleanup", result)
+		len(result.Results) != 7 {
+		t.Fatalf("release smoke result = %#v, want seven passing usability and identity checks plus cleanup", result)
 	}
+	runnerVersionChecked := false
+	runtimeMetadataChecked := false
 	for _, check := range result.Results {
 		if check.Category != "Release smoke" {
 			t.Fatalf("release smoke unexpectedly ran full inventory check %#v", check)
+		}
+		if check.Name == "preinstalled Actions runner" {
+			runnerVersionChecked = strings.Contains(check.Command, "Runner.Listener --version") &&
+				strings.Contains(check.Command, `= "2.336.0"`)
+		}
+		if check.Name == "runtime image metadata" {
+			runtimeMetadataChecked = strings.Contains(check.Command, `"$IMAGE_TEMPLATE" = "github-runner-ubuntu-26-04"`) &&
+				strings.Contains(check.Command, `"$ImageVersion" = "20260805.1"`) &&
+				strings.Contains(check.Command, `"$IMAGE_VERSION" = "20260805.1"`)
 		}
 		if check.Name == "Docker daemon" {
 			if !strings.Contains(check.Command, "sudo -H -u runner") {
@@ -1271,6 +1283,12 @@ esac
 				t.Fatalf("Docker daemon smoke must execute a local container without a registry pull: %#v", check)
 			}
 		}
+	}
+	if !runnerVersionChecked {
+		t.Fatalf("release smoke did not pin the Actions runner version: %#v", result.Results)
+	}
+	if !runtimeMetadataChecked {
+		t.Fatalf("release smoke did not pin runtime template metadata: %#v", result.Results)
 	}
 }
 
@@ -2163,6 +2181,106 @@ func TestRunnerTemplateDockerfilesSplitSetupIntoCacheablePhases(t *testing.T) {
 	}
 }
 
+func TestUbuntu2604DockerfilePreinstallsAptCommonInCacheableChunks(t *testing.T) {
+	dockerfileBytes, err := os.ReadFile(filepath.Join(
+		repositoryRoot(t),
+		"templates",
+		"github-runner-ubuntu-26.04",
+		"Dockerfile",
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dockerfile := string(dockerfileBytes)
+	bootstrap := strings.Index(
+		dockerfile,
+		"RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=bootstrap ",
+	)
+	platform := strings.Index(
+		dockerfile,
+		"RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform ",
+	)
+	if bootstrap < 0 || platform < 0 || bootstrap >= platform {
+		t.Fatalf("Ubuntu 26.04 setup phases are not ordered: bootstrap=%d platform=%d", bootstrap, platform)
+	}
+
+	previous := bootstrap
+	for _, packageRange := range []string{
+		"0:7",
+		"7:8",
+		"8:14",
+		"14:15",
+		"15:18",
+		"18:21",
+		"21:22",
+		"22:23",
+		"23:24",
+		"24:27",
+		"27:28",
+		"28:30",
+		"30:32",
+		"32:33",
+		"33:45",
+		"45:56",
+		"56:57",
+		"57:",
+	} {
+		chunk := "[.apt.common_packages[], .apt.cmd_packages[]] | .[" +
+			packageRange + "][]"
+		index := strings.Index(dockerfile, chunk)
+		if index < 0 {
+			t.Fatalf("Ubuntu 26.04 Dockerfile must preinstall apt package chunk %s", packageRange)
+		}
+		if index <= previous || index >= platform {
+			t.Fatalf(
+				"Ubuntu 26.04 apt package chunk %s must be cacheable between bootstrap and platform: index=%d previous=%d platform=%d",
+				packageRange,
+				index,
+				previous,
+				platform,
+			)
+		}
+		previous = index
+	}
+	if count := strings.Count(
+		dockerfile,
+		`packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]]`,
+	); count != 18 {
+		t.Fatalf("Ubuntu 26.04 must expose exactly 18 cacheable apt package chunks; got %d", count)
+	}
+
+	if !strings.Contains(
+		dockerfile,
+		`map(if . == "netcat" then "netcat-openbsd" else . end)`,
+	) {
+		t.Fatal("Ubuntu 26.04 apt preinstall must resolve the virtual netcat package to netcat-openbsd")
+	}
+	restoreVirtualPackage := strings.Index(
+		dockerfile,
+		`map(if . == "netcat-openbsd" then "netcat" else . end)`,
+	)
+	patchUpstreamInstaller := strings.Index(
+		dockerfile,
+		`${package/netcat/netcat-openbsd}`,
+	)
+	if restoreVirtualPackage <= previous || restoreVirtualPackage >= platform {
+		t.Fatalf(
+			"Ubuntu 26.04 must restore netcat for the upstream command test after preinstalling every package: restore=%d last_chunk=%d platform=%d",
+			restoreVirtualPackage,
+			previous,
+			platform,
+		)
+	}
+	if patchUpstreamInstaller <= restoreVirtualPackage || patchUpstreamInstaller >= platform {
+		t.Fatalf(
+			"Ubuntu 26.04 must map netcat only for the upstream apt install before platform tests: patch=%d restore=%d platform=%d",
+			patchUpstreamInstaller,
+			restoreVirtualPackage,
+			platform,
+		)
+	}
+}
+
 func TestVersionedTemplateBuildStagesPinnedUpstreamTests(t *testing.T) {
 	root := repositoryRoot(t)
 	for _, image := range []string{
@@ -2551,7 +2669,7 @@ func TestPublicTemplatesPinFloatingCompatibilityTools(t *testing.T) {
 
 func TestPublicTemplateCheckedDownloadsResumeAcrossTransientFailures(t *testing.T) {
 	root := repositoryRoot(t)
-	var downloadChecked string
+	downloadCheckedByImage := make(map[string]string)
 	for _, image := range []string{
 		"ubuntu-slim",
 		"ubuntu-22.04",
@@ -2575,7 +2693,8 @@ func TestPublicTemplateCheckedDownloadsResumeAcrossTransientFailures(t *testing.
 			if functionStart < 0 || functionEnd < functionStart {
 				t.Fatal("setup must define download_checked before the upstream test helper")
 			}
-			downloadChecked = script[functionStart:functionEnd]
+			downloadChecked := script[functionStart:functionEnd]
+			downloadCheckedByImage[image] = downloadChecked
 			for _, required := range []string{
 				`RUNNER_TEMPLATE_DOWNLOAD_ATTEMPTS:-20`,
 				`RUNNER_TEMPLATE_DOWNLOAD_RETRY_DELAY:-2`,
@@ -2588,6 +2707,46 @@ func TestPublicTemplateCheckedDownloadsResumeAcrossTransientFailures(t *testing.
 			}
 			if strings.Contains(downloadChecked, `--retry 5`) {
 				t.Fatal("download_checked must use an explicit resume loop instead of curl retries that discard partial output")
+			}
+		})
+	}
+
+	for image, downloadChecked := range downloadCheckedByImage {
+		t.Run(image+"-bounded-backoff", func(t *testing.T) {
+			failureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "transient failure", http.StatusServiceUnavailable)
+			}))
+			defer failureServer.Close()
+
+			fixture := t.TempDir()
+			fakeBin := filepath.Join(fixture, "bin")
+			if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			delayLog := filepath.Join(fixture, "delays")
+			writeExecutable(t, filepath.Join(fakeBin, "sleep"), "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$1\" >> \"$DELAY_LOG\"\n")
+			testScript := filepath.Join(fixture, "download-checked.sh")
+			writeExecutable(t, testScript, "#!/usr/bin/env bash\nset -euo pipefail\n"+
+				downloadChecked+"\ndownload_checked \"$1\" \"$2\" \"$3\"\n")
+			output, err := runCommand(
+				t,
+				"bash",
+				[]string{testScript, failureServer.URL, filepath.Join(fixture, "artifact"), strings.Repeat("0", 64)},
+				"PATH="+fakeBin+":"+os.Getenv("PATH"),
+				"DELAY_LOG="+delayLog,
+				"RUNNER_TEMPLATE_DOWNLOAD_ATTEMPTS=5",
+				"RUNNER_TEMPLATE_DOWNLOAD_RETRY_DELAY=1",
+				"RUNNER_TEMPLATE_DOWNLOAD_RETRY_MAX_DELAY=3",
+			)
+			if err == nil {
+				t.Fatalf("download unexpectedly succeeded:\n%s", output)
+			}
+			delays, readErr := os.ReadFile(delayLog)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if got, want := strings.Fields(string(delays)), []string{"1", "2", "3", "3"}; !slices.Equal(got, want) {
+				t.Fatalf("retry delays = %v, want bounded exponential backoff %v", got, want)
 			}
 		})
 	}
@@ -2628,7 +2787,7 @@ func TestPublicTemplateCheckedDownloadsResumeAcrossTransientFailures(t *testing.
 
 	testScript := filepath.Join(t.TempDir(), "download-checked.sh")
 	writeExecutable(t, testScript, "#!/usr/bin/env bash\nset -euo pipefail\n"+
-		downloadChecked+"\ndownload_checked \"$1\" \"$2\" \"$3\"\n")
+		downloadCheckedByImage["ubuntu-slim"]+"\ndownload_checked \"$1\" \"$2\" \"$3\"\n")
 	destination := filepath.Join(t.TempDir(), "artifact")
 	expectedSHA := fmt.Sprintf("%x", sha256.Sum256(payload))
 	output, err := runCommand(
@@ -3540,10 +3699,14 @@ func TestRunnerTemplateFallsBackToUbuntuDockerPackages(t *testing.T) {
 			script := string(scriptBytes)
 			for _, required := range []string{
 				"configure_docker_apt_repository() {",
+				"remove_official_docker_packages() {",
 				`download_checked https://download.docker.com/linux/ubuntu/gpg /tmp/docker.gpg "$DOCKER_GPG_SHA256" || return 1`,
 				`if [ "$installer_name" = install-docker-cli.sh ]; then`,
 				"upstream Docker CLI installer unavailable; deferring to sandbox-aware installer",
 				"official Docker packages unavailable; using Ubuntu archive packages",
+				"apt-get purge -y \"${official_docker_packages[@]}\"",
+				"dpkg --purge --force-depends \"${official_docker_packages[@]}\"",
+				"apt-get -f install -y",
 				"rm -f /etc/apt/sources.list.d/docker.list /etc/apt/keyrings/docker.gpg",
 				"apt-get install -y --no-install-recommends docker.io docker-buildx docker-compose-v2",
 				"docker --version",

--- a/internal/sandboxrunner/runner_test.go
+++ b/internal/sandboxrunner/runner_test.go
@@ -3128,6 +3128,87 @@ func TestCompatibilityGeneratorVerifiesConcreteNetcatProvider(t *testing.T) {
 	}
 }
 
+func TestCompatibilityGeneratorUsesCanonicalSystemdExecutable(t *testing.T) {
+	fixture := t.TempDir()
+	reportDir := filepath.Join(fixture, "reports")
+	if err := os.MkdirAll(reportDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	report := []byte(`# Fixture
+- OS Version: 26.04
+- Systemd version: 259.5-0ubuntu3
+`)
+	reports := map[string]string{
+		"ubuntu-slim":  "ubuntu-slim-Readme.md",
+		"ubuntu-22.04": "Ubuntu2204-Readme.md",
+		"ubuntu-24.04": "Ubuntu2404-Readme.md",
+		"ubuntu-26.04": "Ubuntu2604-Readme.md",
+	}
+	reportChecksums := make(map[string]string, len(reports))
+	for image, name := range reports {
+		if err := os.WriteFile(filepath.Join(reportDir, name), report, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		reportChecksums[image] = fmt.Sprintf("%x", sha256.Sum256(report))
+	}
+	lockBytes, err := json.Marshal(map[string]any{
+		"repository":    "actions/runner-images",
+		"commit":        "fixture",
+		"reports":       reports,
+		"report_sha256": reportChecksums,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(fixture, "lock.json")
+	if err := os.WriteFile(lockPath, lockBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(fixture, "compatibility.json")
+	output, err := runCommand(
+		t,
+		"node",
+		[]string{"scripts/generate-runner-image-compatibility.mjs"},
+		"RUNNER_IMAGES_REPORT_DIR="+reportDir,
+		"RUNNER_IMAGES_LOCK="+lockPath,
+		"RUNNER_IMAGES_MANIFEST="+manifestPath,
+	)
+	if err != nil {
+		t.Fatalf("generate compatibility manifest: %v\n%s", err, output)
+	}
+	manifestBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest struct {
+		Images map[string]struct {
+			Entries []struct {
+				UpstreamName string `json:"upstream_name"`
+				Verification string `json:"verification"`
+			} `json:"entries"`
+		} `json:"images"`
+	}
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	const verification = "test -x /usr/lib/systemd/systemd && /usr/lib/systemd/systemd --version >/dev/null"
+	for _, image := range []string{"ubuntu-slim", "ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04"} {
+		found := false
+		for _, entry := range manifest.Images[image].Entries {
+			if entry.UpstreamName != "Systemd version" {
+				continue
+			}
+			found = true
+			if entry.Verification != verification {
+				t.Fatalf("%s systemd verification = %q, want %q", image, entry.Verification, verification)
+			}
+		}
+		if !found {
+			t.Fatalf("%s has no Systemd version compatibility entry", image)
+		}
+	}
+}
+
 func TestVersionedTemplateBuildDefersOnlyPodmanNetworkingToRuntimeConformance(t *testing.T) {
 	root := repositoryRoot(t)
 	for _, image := range []string{

--- a/internal/sandboxrunner/runner_test.go
+++ b/internal/sandboxrunner/runner_test.go
@@ -1,6 +1,7 @@
 package sandboxrunner
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -12,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -1254,11 +1256,12 @@ esac
 	if !result.Passed ||
 		result.SupportChannel != "preview" ||
 		!result.Cleanup.Passed ||
-		len(result.Results) != 7 {
-		t.Fatalf("release smoke result = %#v, want seven passing usability and identity checks plus cleanup", result)
+		len(result.Results) != 8 {
+		t.Fatalf("release smoke result = %#v, want eight passing usability and identity checks plus cleanup", result)
 	}
 	runnerVersionChecked := false
 	runtimeMetadataChecked := false
+	nvmHomeChecked := false
 	for _, check := range result.Results {
 		if check.Category != "Release smoke" {
 			t.Fatalf("release smoke unexpectedly ran full inventory check %#v", check)
@@ -1269,8 +1272,14 @@ esac
 		}
 		if check.Name == "runtime image metadata" {
 			runtimeMetadataChecked = strings.Contains(check.Command, `"$IMAGE_TEMPLATE" = "github-runner-ubuntu-26-04"`) &&
-				strings.Contains(check.Command, `"$ImageVersion" = "20260805.1"`) &&
-				strings.Contains(check.Command, `"$IMAGE_VERSION" = "20260805.1"`)
+				strings.Contains(check.Command, `"$ImageVersion" = "20260805.6"`) &&
+				strings.Contains(check.Command, `"$IMAGE_VERSION" = "20260805.6"`)
+		}
+		if check.Name == "runner writable NVM home" {
+			nvmHomeChecked = strings.Contains(check.Command, "sudo -H -u runner") &&
+				strings.Contains(check.Command, `test -s "$HOME/.nvm/nvm.sh"`) &&
+				strings.Contains(check.Command, `test -w "$HOME/.nvm"`) &&
+				strings.Contains(check.Command, `nvm --version`)
 		}
 		if check.Name == "Docker daemon" {
 			if !strings.Contains(check.Command, "sudo -H -u runner") {
@@ -1289,6 +1298,9 @@ esac
 	}
 	if !runtimeMetadataChecked {
 		t.Fatalf("release smoke did not pin runtime template metadata: %#v", result.Results)
+	}
+	if !nvmHomeChecked {
+		t.Fatalf("release smoke did not verify the runner-owned NVM home: %#v", result.Results)
 	}
 }
 
@@ -2127,7 +2139,7 @@ func TestRunnerTemplateDockerfilesSplitSetupIntoCacheablePhases(t *testing.T) {
 			}
 			previous := -1
 			for _, phase := range phases {
-				instruction := "RUN TEMPLATE_FLAVOR=" + flavor +
+				instruction := "TEMPLATE_FLAVOR=" + flavor +
 					" RUNNER_TEMPLATE_PHASE=" + phase +
 					" bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh"
 				index := strings.Index(dockerfile, instruction)
@@ -2139,8 +2151,8 @@ func TestRunnerTemplateDockerfilesSplitSetupIntoCacheablePhases(t *testing.T) {
 				}
 				previous = index
 			}
-			if strings.Count(dockerfile, "RUN TEMPLATE_FLAVOR=") != len(phases) {
-				t.Fatalf("template must have exactly %d cacheable setup layers; got %d", len(phases), strings.Count(dockerfile, "RUN TEMPLATE_FLAVOR="))
+			if strings.Count(dockerfile, "RUNNER_TEMPLATE_PHASE=") != len(phases) {
+				t.Fatalf("template must have exactly %d cacheable setup layers; got %d", len(phases), strings.Count(dockerfile, "RUNNER_TEMPLATE_PHASE="))
 			}
 
 			scriptBytes, err := os.ReadFile(filepath.Join(templateRoot, "scripts", "setup-template.sh"))
@@ -2198,7 +2210,7 @@ func TestUbuntu2604DockerfilePreinstallsAptCommonInCacheableChunks(t *testing.T)
 	)
 	platform := strings.Index(
 		dockerfile,
-		"RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform ",
+		"TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform ",
 	)
 	if bootstrap < 0 || platform < 0 || bootstrap >= platform {
 		t.Fatalf("Ubuntu 26.04 setup phases are not ordered: bootstrap=%d platform=%d", bootstrap, platform)
@@ -3677,6 +3689,235 @@ func TestRunnerTemplatePinsNVMArchive(t *testing.T) {
 	}
 }
 
+func TestRunnerTemplatesMaterializeWritableNVMHome(t *testing.T) {
+	root := repositoryRoot(t)
+	for _, image := range []string{
+		"ubuntu-slim",
+		"ubuntu-22.04",
+		"ubuntu-24.04",
+		"ubuntu-26.04",
+	} {
+		t.Run(image, func(t *testing.T) {
+			dockerfileBytes, err := os.ReadFile(filepath.Join(
+				root,
+				"templates",
+				"github-runner-"+image,
+				"Dockerfile",
+			))
+			if err != nil {
+				t.Fatal(err)
+			}
+			dockerfile := string(dockerfileBytes)
+			for _, required := range []string{
+				"rm -rf /home/runner/.nvm",
+				"cp -a /etc/skel/.nvm /home/runner/.nvm",
+				"chown -R runner:runner /home/runner/.nvm",
+			} {
+				if !strings.Contains(dockerfile, required) {
+					t.Fatalf("template must materialize a runner-owned NVM home; missing %q", required)
+				}
+			}
+			toolchainIndex := strings.Index(dockerfile, "RUNNER_TEMPLATE_PHASE=toolchain")
+			nvmHomeIndex := strings.Index(dockerfile, "rm -rf /home/runner/.nvm")
+			runtimeIndex := strings.Index(dockerfile, "RUNNER_TEMPLATE_PHASE=runtime")
+			if toolchainIndex < 0 || nvmHomeIndex < toolchainIndex || runtimeIndex < nvmHomeIndex {
+				t.Fatal("template must materialize the NVM home in a cacheable layer between toolchain and runtime")
+			}
+		})
+	}
+}
+
+func TestRunnerTemplateRangeDownloaderFetchesExactBytes(t *testing.T) {
+	payload := []byte(strings.Repeat("0123456789abcdef", 8192))
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		match := regexp.MustCompile(`^bytes=(\d+)-(\d+)$`).FindStringSubmatch(request.Header.Get("Range"))
+		if len(match) != 3 {
+			http.Error(response, "range required", http.StatusBadRequest)
+			return
+		}
+		start, startErr := strconv.Atoi(match[1])
+		end, endErr := strconv.Atoi(match[2])
+		if startErr != nil || endErr != nil || start < 0 || end < start || end >= len(payload) {
+			http.Error(response, "invalid range", http.StatusRequestedRangeNotSatisfiable)
+			return
+		}
+		response.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, len(payload)))
+		response.WriteHeader(http.StatusPartialContent)
+		_, _ = response.Write(payload[start : end+1])
+	}))
+	defer server.Close()
+
+	root := repositoryRoot(t)
+	for _, imageKey := range []string{"ubuntu-slim", "ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04"} {
+		t.Run(imageKey, func(t *testing.T) {
+			helper := filepath.Join(root, "templates", "github-runner-"+imageKey, "scripts", "download-checked-range")
+			destination := filepath.Join(t.TempDir(), "chunk")
+			const start = 173
+			const end = 65572
+			output, err := runCommand(t, "bash", []string{helper, server.URL, destination, strconv.Itoa(start), strconv.Itoa(end)})
+			if err != nil {
+				t.Fatalf("range downloader failed: %v\n%s", err, output)
+			}
+			chunk, err := os.ReadFile(destination)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(chunk, payload[start:end+1]) {
+				t.Fatalf("downloaded range differs: got %d bytes, want %d", len(chunk), end-start+1)
+			}
+		})
+	}
+}
+
+func TestRunnerTemplatesCacheLargeAWSSAMArchiveInCheckedRanges(t *testing.T) {
+	tests := []struct {
+		imageKey    string
+		archiveSize int64
+	}{
+		{imageKey: "ubuntu-slim", archiveSize: 207357695},
+		{imageKey: "ubuntu-22.04", archiveSize: 93672108},
+		{imageKey: "ubuntu-24.04", archiveSize: 93672108},
+		{imageKey: "ubuntu-26.04", archiveSize: 93672108},
+	}
+	root := repositoryRoot(t)
+	rangePattern := regexp.MustCompile(`(?m)^RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \\\n+    "https://github.com/aws/aws-sam-cli/releases/download/v\$\{AWS_SAM_CLI_VERSION\}/aws-sam-cli-linux-x86_64\.zip" \\\n+    /opt/qiniu-runner-build-cache/aws-sam-cli\.part-(\d{2}) (\d+) (\d+)$`)
+
+	for _, tc := range tests {
+		t.Run(tc.imageKey, func(t *testing.T) {
+			templateRoot := filepath.Join(root, "templates", "github-runner-"+tc.imageKey)
+			dockerfileBytes, err := os.ReadFile(filepath.Join(templateRoot, "Dockerfile"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			dockerfile := string(dockerfileBytes)
+			matches := rangePattern.FindAllStringSubmatch(dockerfile, -1)
+			if len(matches) < 2 {
+				t.Fatalf("Dockerfile must split the AWS SAM archive across cacheable RUN layers:\n%s", dockerfile)
+			}
+			var nextStart int64
+			for index, match := range matches {
+				if match[1] != fmt.Sprintf("%02d", index) {
+					t.Fatalf("range part %d uses suffix %q", index, match[1])
+				}
+				start, startErr := strconv.ParseInt(match[2], 10, 64)
+				end, endErr := strconv.ParseInt(match[3], 10, 64)
+				if startErr != nil || endErr != nil || start != nextStart || end < start {
+					t.Fatalf("range part %d is not contiguous: %q-%q after %d", index, match[2], match[3], nextStart)
+				}
+				if end-start+1 > 16*1024*1024 {
+					t.Fatalf("range part %d is too large for the observed slow network: %d bytes", index, end-start+1)
+				}
+				nextStart = end + 1
+			}
+			if nextStart != tc.archiveSize {
+				t.Fatalf("cached ranges cover %d bytes, want %d", nextStart, tc.archiveSize)
+			}
+			platformCommand := "TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh"
+			if tc.imageKey == "ubuntu-slim" {
+				platformCommand = "TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh"
+			}
+			bootstrap := strings.Index(dockerfile, "RUN TEMPLATE_FLAVOR=")
+			cacheDirectory := strings.Index(dockerfile, "RUN install -d -m 0755 /opt/qiniu-runner-build-cache")
+			firstRange := strings.Index(dockerfile, "RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range")
+			platform := strings.Index(dockerfile, platformCommand)
+			if bootstrap < 0 || cacheDirectory < bootstrap || firstRange < cacheDirectory || platform < firstRange {
+				t.Fatalf("AWS SAM ranges must be cached between bootstrap and platform provisioning")
+			}
+			for _, want := range []string{
+				"COPY scripts/download-checked-range /usr/local/share/qiniu-sandbox-runner-template/download-checked-range",
+				"cat /opt/qiniu-runner-build-cache/aws-sam-cli.part-* > /tmp/qiniu-aws-sam-cli.zip",
+				`echo "$AWS_SAM_CLI_ARCHIVE_SHA256  /tmp/qiniu-aws-sam-cli.zip" | sha256sum --check -`,
+				"rm -f /opt/qiniu-runner-build-cache/aws-sam-cli.part-*",
+				"rmdir /opt/qiniu-runner-build-cache",
+			} {
+				if !strings.Contains(dockerfile, want) {
+					t.Fatalf("Dockerfile missing checked range assembly %q", want)
+				}
+			}
+			assemblyStart := strings.Index(dockerfile, "RUN set -eux; \\\n    cat /opt/qiniu-runner-build-cache/aws-sam-cli.part-*")
+			if assemblyStart < 0 {
+				t.Fatal("Dockerfile is missing the checked AWS SAM assembly layer")
+			}
+			assemblyEnd := strings.Index(dockerfile[assemblyStart:], "\nRUN ")
+			if assemblyEnd < 0 {
+				assemblyEnd = len(dockerfile) - assemblyStart
+			}
+			assemblyLayer := dockerfile[assemblyStart : assemblyStart+assemblyEnd]
+			if !strings.Contains(assemblyLayer, platformCommand) {
+				t.Fatal("Dockerfile must install AWS SAM in the same RUN that assembles the oversized archive")
+			}
+			if strings.Contains(dockerfile, "\nRUN "+platformCommand) {
+				t.Fatal("platform provisioning must not start in a later layer after assembling the oversized AWS SAM archive")
+			}
+		})
+	}
+}
+
+func TestRunnerTemplatesPreferTsinghuaUbuntuMirror(t *testing.T) {
+	root := repositoryRoot(t)
+	for _, imageKey := range []string{"ubuntu-slim", "ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04"} {
+		t.Run(imageKey, func(t *testing.T) {
+			scriptBytes, err := os.ReadFile(filepath.Join(
+				root,
+				"templates",
+				"github-runner-"+imageKey,
+				"scripts",
+				"setup-template.sh",
+			))
+			if err != nil {
+				t.Fatal(err)
+			}
+			script := string(scriptBytes)
+			functionStart := strings.Index(script, "configure_reliable_apt_sources() {")
+			if functionStart < 0 {
+				t.Fatal("setup script is missing configure_reliable_apt_sources")
+			}
+			functionEnd := strings.Index(script[functionStart:], "\n}")
+			if functionEnd < 0 {
+				t.Fatal("setup script is missing configure_reliable_apt_sources")
+			}
+			functionBody := script[functionStart : functionStart+functionEnd]
+			tsinghua := strings.Index(functionBody, "https://mirrors.tuna.tsinghua.edu.cn/ubuntu/")
+			kernel := strings.Index(functionBody, "https://mirrors.edge.kernel.org/ubuntu/")
+			if tsinghua < 0 || kernel < 0 || tsinghua > kernel {
+				t.Fatal("Tsinghua must be the first Ubuntu mirror for the Sandbox build network")
+			}
+		})
+	}
+}
+
+func TestRunnerTemplateVersionMetadataDoesNotInvalidateProvisioningLayers(t *testing.T) {
+	root := repositoryRoot(t)
+	for _, image := range []string{
+		"ubuntu-slim",
+		"ubuntu-22.04",
+		"ubuntu-24.04",
+		"ubuntu-26.04",
+	} {
+		t.Run(image, func(t *testing.T) {
+			dockerfileBytes, err := os.ReadFile(filepath.Join(
+				root,
+				"templates",
+				"github-runner-"+image,
+				"Dockerfile",
+			))
+			if err != nil {
+				t.Fatal(err)
+			}
+			dockerfile := string(dockerfileBytes)
+			runtimeIndex := strings.Index(dockerfile, "RUNNER_TEMPLATE_PHASE=runtime")
+			versionIndex := strings.Index(dockerfile, "ARG TEMPLATE_VERSION=")
+			metadataIndex := strings.Index(dockerfile, "ENV ImageVersion=$TEMPLATE_VERSION")
+			if runtimeIndex < 0 || versionIndex < runtimeIndex || metadataIndex < versionIndex {
+				t.Fatal("template version metadata must be applied after provisioning so version bumps retain heavy layer caches")
+			}
+			if strings.Contains(dockerfile[:runtimeIndex], "TEMPLATE_VERSION") {
+				t.Fatal("provisioning layers must not depend on template version metadata")
+			}
+		})
+	}
+}
+
 func TestRunnerTemplateFallsBackToUbuntuDockerPackages(t *testing.T) {
 	root := repositoryRoot(t)
 	for _, image := range []string{
@@ -3872,13 +4113,13 @@ func TestRunnerTemplateBuildUsesBoundedHTTPSAptSources(t *testing.T) {
 				}
 			}
 			if image == "ubuntu-26.04" {
-				kernelMirror := strings.Index(script, "https://mirrors.edge.kernel.org/ubuntu/\tpriority:1")
-				tunaFallback := strings.Index(script, "https://mirrors.tuna.tsinghua.edu.cn/ubuntu/\tpriority:2")
-				if kernelMirror < 0 || tunaFallback < 0 || kernelMirror > tunaFallback {
+				tunaMirror := strings.Index(script, "https://mirrors.tuna.tsinghua.edu.cn/ubuntu/\tpriority:1")
+				kernelFallback := strings.Index(script, "https://mirrors.edge.kernel.org/ubuntu/\tpriority:2")
+				if tunaMirror < 0 || kernelFallback < 0 || tunaMirror > kernelFallback {
 					t.Fatalf(
-						"Ubuntu 26.04 must prefer the promptly synchronized kernel.org archive and retain TUNA as a fallback: kernel=%d tuna=%d",
-						kernelMirror,
-						tunaFallback,
+						"Ubuntu 26.04 must prefer TUNA on the Sandbox build network and retain kernel.org as a fallback: tuna=%d kernel=%d",
+						tunaMirror,
+						kernelFallback,
 					)
 				}
 				for _, directMirrorRewrite := range []string{

--- a/internal/sandboxrunner/runner_test.go
+++ b/internal/sandboxrunner/runner_test.go
@@ -2084,6 +2084,85 @@ func TestRunnerTemplateDockerfilesUseQshellCompatibleRunInstructions(t *testing.
 	}
 }
 
+func TestRunnerTemplateDockerfilesSplitSetupIntoCacheablePhases(t *testing.T) {
+	root := repositoryRoot(t)
+	for _, image := range []string{
+		"ubuntu-slim",
+		"ubuntu-22.04",
+		"ubuntu-24.04",
+		"ubuntu-26.04",
+	} {
+		t.Run(image, func(t *testing.T) {
+			templateRoot := filepath.Join(root, "templates", "github-runner-"+image)
+			dockerfileBytes, err := os.ReadFile(filepath.Join(templateRoot, "Dockerfile"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			dockerfile := string(dockerfileBytes)
+			flavor := "versioned"
+			if image == "ubuntu-slim" {
+				flavor = "slim"
+			}
+			phases := []string{"bootstrap", "platform", "toolchain", "runtime"}
+			if image != "ubuntu-slim" {
+				phases = []string{"bootstrap", "platform", "node", "toolchain", "runtime"}
+			}
+			previous := -1
+			for _, phase := range phases {
+				instruction := "RUN TEMPLATE_FLAVOR=" + flavor +
+					" RUNNER_TEMPLATE_PHASE=" + phase +
+					" bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh"
+				index := strings.Index(dockerfile, instruction)
+				if index < 0 {
+					t.Fatalf("template must expose a cacheable %s setup layer", phase)
+				}
+				if index <= previous {
+					t.Fatalf("template setup phases must preserve order; %s index=%d previous=%d", phase, index, previous)
+				}
+				previous = index
+			}
+			if strings.Count(dockerfile, "RUN TEMPLATE_FLAVOR=") != len(phases) {
+				t.Fatalf("template must have exactly %d cacheable setup layers; got %d", len(phases), strings.Count(dockerfile, "RUN TEMPLATE_FLAVOR="))
+			}
+
+			scriptBytes, err := os.ReadFile(filepath.Join(templateRoot, "scripts", "setup-template.sh"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			script := string(scriptBytes)
+			if strings.Contains(script, "/tmp/runner-images/") ||
+				strings.Contains(script, "mkdir -p /tmp/runner-images") ||
+				strings.Contains(script, "test -d /tmp/runner-images") {
+				t.Fatal("runner-images source must survive qshell cache layers outside /tmp")
+			}
+			if !strings.Contains(script, "mkdir -p /opt/qiniu-runner-images") ||
+				!strings.Contains(script, "test -d /opt/qiniu-runner-images") {
+				t.Fatal("runner-images source must use the durable cross-phase directory /opt/qiniu-runner-images")
+			}
+			required := []string{
+				`runner_template_phase="${RUNNER_TEMPLATE_PHASE:-all}"`,
+				`phase_selected() {`,
+				`if phase_selected runtime; then`,
+			}
+			if image == "ubuntu-slim" {
+				required = append(required, `all | bootstrap | platform | toolchain | runtime)`)
+			} else {
+				required = append(
+					required,
+					`all | bootstrap | platform | node | toolchain | runtime)`,
+					`install-nvm.sh | install-nodejs.sh)`,
+					`echo node`,
+				)
+			}
+			for _, required := range required {
+				if !strings.Contains(script, required) {
+					t.Fatalf("phase-aware setup is missing %q", required)
+				}
+			}
+		})
+	}
+}
+
 func TestVersionedTemplateBuildStagesPinnedUpstreamTests(t *testing.T) {
 	root := repositoryRoot(t)
 	for _, image := range []string{
@@ -2229,7 +2308,60 @@ func TestPublicTemplatesUsePinnedMicrosoftAzCopyWithoutActionPrewarm(t *testing.
 	}
 }
 
-func TestPublicTemplatesFallBackToCheckedAzureCLIPackage(t *testing.T) {
+func TestVersionedTemplatesInstallPinnedPesterPackage(t *testing.T) {
+	root := repositoryRoot(t)
+	for _, image := range []string{
+		"ubuntu-22.04",
+		"ubuntu-24.04",
+		"ubuntu-26.04",
+	} {
+		t.Run(image, func(t *testing.T) {
+			templateRoot := filepath.Join(
+				root,
+				"templates",
+				"github-runner-"+image,
+			)
+			dockerfileBytes, err := os.ReadFile(filepath.Join(templateRoot, "Dockerfile"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(dockerfileBytes), "ARG PESTER_NUPKG_SHA256=5a0fd80b361600bf4bbd4c307c1fd01b17f11668bab19e657add41b00ad22ab9") {
+				t.Fatal("Dockerfile must pin the Pester 5.9.0 package checksum")
+			}
+
+			scriptBytes, err := os.ReadFile(filepath.Join(templateRoot, "scripts", "setup-template.sh"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			script := string(scriptBytes)
+			functionStart := strings.Index(script, "install_pester_for_upstream_tests() {")
+			if functionStart < 0 {
+				t.Fatal("setup must define the Pester installation helper")
+			}
+			functionEnd := strings.Index(script[functionStart:], "\n}\n\nstop_validated_service()")
+			if functionEnd < 0 {
+				t.Fatal("setup must define the Pester installation helper")
+			}
+			functionBody := script[functionStart : functionStart+functionEnd]
+			for _, required := range []string{
+				`"https://www.powershellgallery.com/api/v2/package/Pester/${pester_version}"`,
+				`"$PESTER_NUPKG_SHA256"`,
+				`/usr/local/share/powershell/Modules/Pester/${pester_version}`,
+				`unzip -q "$package" -d "$module_dir"`,
+				"Import-Module Pester -RequiredVersion $env:PESTER_VERSION -Force",
+			} {
+				if !strings.Contains(functionBody, required) {
+					t.Fatalf("Pester installation must use the pinned package with %q", required)
+				}
+			}
+			if strings.Contains(functionBody, "Register-PSRepository") || strings.Contains(functionBody, "Install-Module") {
+				t.Fatal("Pester installation must not depend on PowerShellGet repository registration")
+			}
+		})
+	}
+}
+
+func TestPublicTemplatesInstallPinnedAzureCLIPackage(t *testing.T) {
 	root := repositoryRoot(t)
 	for _, image := range []string{
 		"ubuntu-slim",
@@ -2265,13 +2397,17 @@ func TestPublicTemplatesFallBackToCheckedAzureCLIPackage(t *testing.T) {
 				`azure-cli_${AZURE_CLI_VERSION}-1~${suite}_amd64.deb`,
 				`expected_sha256="$AZURE_CLI_JAMMY_DEB_SHA256"`,
 				`expected_sha256="$AZURE_CLI_NOBLE_DEB_SHA256"`,
-				`upstream Azure CLI installer unavailable; using checked Microsoft package`,
+				`install-azure-cli.sh)`,
+				`install_azure_cli_from_microsoft_package`,
 				`test "$(az version --query '"azure-cli"' --output tsv)" = "$AZURE_CLI_VERSION"`,
 				`run_upstream_tests_if_available "CLI.Tools" "Azure CLI"`,
 			} {
 				if !strings.Contains(script, required) {
-					t.Fatalf("setup must retain the checked Azure CLI fallback with %q", required)
+					t.Fatalf("setup must install the checked Azure CLI package with %q", required)
 				}
+			}
+			if strings.Contains(script, `upstream Azure CLI installer unavailable`) {
+				t.Fatal("setup must not install a floating Azure CLI before falling back to the pinned package")
 			}
 		})
 	}
@@ -2520,6 +2656,88 @@ func TestPublicTemplateCheckedDownloadsResumeAcrossTransientFailures(t *testing.
 	}
 }
 
+func TestPublicTemplatesRetryPythonInstallersAfterTransientNetworkFailures(t *testing.T) {
+	root := repositoryRoot(t)
+	var retryInstaller string
+	for _, image := range []string{
+		"ubuntu-slim",
+		"ubuntu-22.04",
+		"ubuntu-24.04",
+		"ubuntu-26.04",
+	} {
+		t.Run(image, func(t *testing.T) {
+			scriptBytes, err := os.ReadFile(filepath.Join(
+				root,
+				"templates",
+				"github-runner-"+image,
+				"scripts",
+				"setup-template.sh",
+			))
+			if err != nil {
+				t.Fatal(err)
+			}
+			script := string(scriptBytes)
+			functionStart := strings.Index(script, "run_retryable_upstream_installer() {")
+			functionEnd := strings.Index(script, "\nrun_upstream_installer() {")
+			if functionStart < 0 || functionEnd < functionStart {
+				t.Fatal("setup must define a retryable upstream installer helper")
+			}
+			retryInstaller = script[functionStart:functionEnd]
+			for _, required := range []string{
+				`RUNNER_TEMPLATE_UPSTREAM_INSTALL_ATTEMPTS:-3`,
+				`RUNNER_TEMPLATE_UPSTREAM_INSTALL_RETRY_DELAY:-2`,
+				`PIP_DEFAULT_TIMEOUT="${PIP_DEFAULT_TIMEOUT:-120}"`,
+				`PIP_RETRIES="${PIP_RETRIES:-10}"`,
+				`install-python.sh | install-pipx-packages.sh)`,
+			} {
+				if !strings.Contains(script, required) {
+					t.Fatalf("setup must retry Python installers with %q", required)
+				}
+			}
+			if !strings.Contains(script, `run_upstream_installer "$upstream_build/install-pipx-packages.sh"`) {
+				t.Fatal("standalone pipx package installation must use the retryable installer wrapper")
+			}
+		})
+	}
+
+	tempDir := t.TempDir()
+	attemptFile := filepath.Join(tempDir, "attempts")
+	installer := filepath.Join(tempDir, "install-python.sh")
+	writeExecutable(t, installer, `#!/usr/bin/env bash
+set -euo pipefail
+attempt=0
+if [ -f "$ATTEMPT_FILE" ]; then
+  attempt="$(cat "$ATTEMPT_FILE")"
+fi
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" >"$ATTEMPT_FILE"
+test "$PIP_DEFAULT_TIMEOUT" = 120
+test "$PIP_RETRIES" = 10
+test "$attempt" -ge 2
+`)
+	testScript := filepath.Join(tempDir, "retry-installer.sh")
+	writeExecutable(t, testScript, "#!/usr/bin/env bash\nset -euo pipefail\n"+
+		retryInstaller+"\nrun_retryable_upstream_installer \"$1\"\n")
+	output, err := runCommand(
+		t,
+		"bash",
+		[]string{testScript, installer},
+		"ATTEMPT_FILE="+attemptFile,
+		"RUNNER_TEMPLATE_UPSTREAM_INSTALL_ATTEMPTS=3",
+		"RUNNER_TEMPLATE_UPSTREAM_INSTALL_RETRY_DELAY=0",
+	)
+	if err != nil {
+		t.Fatalf("retryable installer failed: %v\n%s", err, output)
+	}
+	attempts, err := os.ReadFile(attemptFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(attempts)); got != "2" {
+		t.Fatalf("installer attempts = %s, want 2", got)
+	}
+}
+
 func TestPublicTemplatesInstallPinnedAzureDevOpsExtensionAfterAzureCLI(t *testing.T) {
 	root := repositoryRoot(t)
 	for _, image := range []string{
@@ -2676,7 +2894,7 @@ func TestVersionedTemplatesInstallNetcatProviderBeforeAptCommon(t *testing.T) {
 			}
 			script := string(scriptBytes)
 			netcatIndex := strings.Index(script, "netcat-openbsd")
-			aptCommonIndex := strings.Index(script, "install-apt-common.sh")
+			aptCommonIndex := strings.LastIndex(script, "install-apt-common.sh")
 			if netcatIndex < 0 || aptCommonIndex < 0 {
 				t.Fatalf(
 					"setup must install a concrete netcat provider before apt-common: netcat=%d apt-common=%d",
@@ -2773,7 +2991,7 @@ func TestVersionedTemplateBuildDefersOnlyPodmanNetworkingToRuntimeConformance(t 
 					t.Fatalf("setup must contain exactly one %q guard/patch, got %d", required, strings.Count(script, required))
 				}
 			}
-			if strings.Contains(script, `/tmp/runner-images/images/ubuntu/scripts/tests/Tools.Tests.ps1`) {
+			if strings.Contains(script, `/opt/qiniu-runner-images/images/ubuntu/scripts/tests/Tools.Tests.ps1`) {
 				t.Fatal("setup must not modify the pinned upstream source tree")
 			}
 		})
@@ -2900,7 +3118,7 @@ func TestVersionedTemplateBuildMakesSystemctlShimVisibleToSudoAndCleansIt(t *tes
 			apache := `install-apache.sh`
 			cleanup := `rm -f /usr/local/bin/systemctl`
 			exposeIndex := strings.Index(script, expose)
-			apacheIndex := strings.Index(script, apache)
+			apacheIndex := strings.LastIndex(script, apache)
 			cleanupIndex := strings.Index(script, cleanup)
 			if exposeIndex < 0 || apacheIndex < 0 || cleanupIndex < 0 {
 				t.Fatalf(
@@ -3088,7 +3306,7 @@ func TestVersionedTemplateBuildReloadsPersistedEnvironmentBeforePipxPackages(t *
 			configureEnvironment := `bash "$upstream_build/configure-environment.sh"`
 			reloadEnvironment := `. "$HELPER_SCRIPTS/etc-environment.sh"
   reload_etc_environment`
-			installPipx := `bash "$upstream_build/install-pipx-packages.sh"`
+			installPipx := `run_upstream_installer "$upstream_build/install-pipx-packages.sh"`
 			configureIndex := strings.Index(script, configureEnvironment)
 			reloadIndex := strings.Index(script, reloadEnvironment)
 			pipxIndex := strings.Index(script, installPipx)
@@ -3136,7 +3354,7 @@ func TestVersionedTemplateBuildUsesDiskBoundedToolset(t *testing.T) {
 			if start < 0 {
 				t.Fatal("cannot find versioned installer branch")
 			}
-			end := strings.Index(script[start:], "\nfi\n\ninstall_docker_for_sandbox")
+			end := strings.Index(script[start:], "\nfi\n\nif phase_selected runtime; then")
 			if end < 0 {
 				t.Fatalf("cannot isolate versioned installer branch: start=%d end=%d", start, end)
 			}
@@ -3488,6 +3706,26 @@ func TestRunnerTemplateBuildUsesBoundedHTTPSAptSources(t *testing.T) {
 			} {
 				if !strings.Contains(script, required) {
 					t.Fatalf("apt source hardening missing %q", required)
+				}
+			}
+			if image == "ubuntu-26.04" {
+				kernelMirror := strings.Index(script, "https://mirrors.edge.kernel.org/ubuntu/\tpriority:1")
+				tunaFallback := strings.Index(script, "https://mirrors.tuna.tsinghua.edu.cn/ubuntu/\tpriority:2")
+				if kernelMirror < 0 || tunaFallback < 0 || kernelMirror > tunaFallback {
+					t.Fatalf(
+						"Ubuntu 26.04 must prefer the promptly synchronized kernel.org archive and retain TUNA as a fallback: kernel=%d tuna=%d",
+						kernelMirror,
+						tunaFallback,
+					)
+				}
+				for _, directMirrorRewrite := range []string{
+					`'s|http://mirrors.tuna.tsinghua.edu.cn/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g'`,
+					`'s|https://mirrors.tuna.tsinghua.edu.cn/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g'`,
+					`'s|https://mirrors.edge.kernel.org/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g'`,
+				} {
+					if !strings.Contains(script, directMirrorRewrite) {
+						t.Fatalf("Ubuntu 26.04 must normalize direct mirror sources through the bounded mirror list; missing %q", directMirrorRewrite)
+					}
 				}
 			}
 		})

--- a/internal/server/server_loops.go
+++ b/internal/server/server_loops.go
@@ -149,6 +149,17 @@ func (s *Server) sweepOnce(ctx context.Context) {
 		if _, ok := stoppedRunning[st.ID]; ok {
 			continue
 		}
+		queued, err := s.originalWorkflowJobQueued(ctx, st)
+		if err != nil {
+			s.logger.Warn("sweeper skipped idle runner stop because workflow job status could not be verified", "id", st.ID, "workflow_job_id", st.WorkflowJobID, "error", err)
+			s.store.AppendLog(st.ID, "control.log", []byte("sweeper skipped idle stop because workflow job status could not be verified: "+err.Error()+"\n"))
+			continue
+		}
+		if queued {
+			s.logger.Info("sweeper keeping idle-timed-out runner because workflow job is still queued", "id", st.ID, "workflow_job_id", st.WorkflowJobID)
+			s.store.AppendLog(st.ID, "control.log", []byte("sweeper kept idle runner because workflow job is still queued\n"))
+			continue
+		}
 		busy, err := s.githubRunnerBusy(ctx, st)
 		if err != nil {
 			s.logger.Warn("sweeper skipped idle runner stop because github runner status could not be verified", "id", st.ID, "runner_name", st.RunnerName, "error", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6992,6 +6992,76 @@ func TestSweeperStopsIdleRunnerThatNeverAcceptedJob(t *testing.T) {
 	}
 }
 
+func TestSweeperIdleRunnerRespectsWorkflowJobState(t *testing.T) {
+	tests := []struct {
+		name       string
+		jobStatus  int
+		jobPayload string
+		wantStops  int
+		wantStatus string
+	}{
+		{name: "still queued", jobStatus: http.StatusOK, jobPayload: `{"id":1001,"name":"test","status":"queued"}`, wantStatus: state.StatusRunning},
+		{name: "status cannot be verified", jobStatus: http.StatusInternalServerError, jobPayload: `{"message":"server error"}`, wantStatus: state.StatusRunning},
+		{name: "completed", jobStatus: http.StatusOK, jobPayload: `{"id":1001,"name":"test","status":"completed"}`, wantStops: 1, wantStatus: state.StatusCompleted},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/actions/jobs/1001":
+					w.WriteHeader(tt.jobStatus)
+					w.Write([]byte(tt.jobPayload))
+				case r.Method == http.MethodGet && (r.URL.Path == "/repos/o/r/actions/runners" || r.URL.Path == "/orgs/o/actions/runners"):
+					w.Write([]byte(`{"runners":[{"id":99,"name":"e2b-pending-job","status":"online","busy":false}]}`))
+				case r.Method == http.MethodDelete && (r.URL.Path == "/repos/o/r/actions/runners/99" || r.URL.Path == "/orgs/o/actions/runners/99"):
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					t.Fatalf("unexpected github request: %s %s", r.Method, r.URL.String())
+				}
+			}))
+			defer ghServer.Close()
+
+			store := state.New(t.TempDir())
+			if _, st, err := store.CreateRequest(state.RunnerRequest{
+				ID:                 "pending-job",
+				Source:             "test",
+				RepositoryFullName: "o/r",
+				JobID:              1001,
+				Labels:             []string{"self-hosted", "e2b"},
+				ProfileName:        "default",
+				RunnerGroup:        "default",
+				RunnerName:         "e2b-pending-job",
+			}, nil); err != nil {
+				t.Fatal(err)
+			} else {
+				st.Status = state.StatusRunning
+				st.SandboxID = "sb-pending-job"
+				st.ProcessPID = 42
+				st.RunningAt = time.Now().Add(-10 * time.Minute).UTC()
+				if err := store.WriteState(st); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			fake := &fakeSandbox{}
+			srv := newTestServerWithLimit(t, store, ghServer.URL, fake, 10)
+			srv.cfg.RunnerIdleTimeout = time.Minute
+			srv.sweepOnce(t.Context())
+			if fake.stoppedCount() != tt.wantStops {
+				t.Fatalf("sandbox stops = %d, want %d", fake.stoppedCount(), tt.wantStops)
+			}
+			got, err := store.ReadState("pending-job")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != tt.wantStatus {
+				t.Fatalf("runner status = %s, want %s", got.Status, tt.wantStatus)
+			}
+		})
+	}
+}
+
 func TestSweeperKeepsIdleTimedOutRunnerWhenGitHubRunnerIsBusy(t *testing.T) {
 	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/scripts/check-runner-template-matrix.sh
+++ b/scripts/check-runner-template-matrix.sh
@@ -4,10 +4,25 @@ set -euo pipefail
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repository_root"
 templates_readme="${RUNNER_TEMPLATES_README:-templates/README.md}"
+minimum_runner_version="${MINIMUM_ACTIONS_RUNNER_VERSION:-2.336.0}"
 
 fail() {
   echo "runner template matrix: $*" >&2
   exit 1
+}
+
+version_at_least() {
+  awk -v actual="$1" -v minimum="$2" '
+    BEGIN {
+      split(actual, actual_parts, ".")
+      split(minimum, minimum_parts, ".")
+      for (part = 1; part <= 3; part++) {
+        if ((actual_parts[part] + 0) > (minimum_parts[part] + 0)) exit 0
+        if ((actual_parts[part] + 0) < (minimum_parts[part] + 0)) exit 1
+      }
+      exit 0
+    }
+  '
 }
 
 test -f "$templates_readme" || fail "missing templates README $templates_readme"
@@ -59,6 +74,11 @@ for image_key in ubuntu-slim ubuntu-22.04 ubuntu-24.04 ubuntu-26.04; do
     test -f "$directory/$required_file" || fail "missing $directory/$required_file"
   done
 
+  runner_version="$(awk -F= '$1 == "ARG RUNNER_VERSION" {print $2; exit}' "$directory/Dockerfile")"
+  test -n "$runner_version" || fail "$image_key does not pin RUNNER_VERSION"
+  version_at_least "$runner_version" "$minimum_runner_version" ||
+    fail "$image_key Actions Runner $runner_version is below required $minimum_runner_version"
+
   template_name="$(
     awk -F= '/^[[:space:]]*name[[:space:]]*=/ {
       value=$2
@@ -100,6 +120,25 @@ for image_key in ubuntu-slim ubuntu-22.04 ubuntu-24.04 ubuntu-26.04; do
   fi
   grep -Eq '^[[:space:]]*RUN[[:space:]]+TEMPLATE_FLAVOR=' "$directory/Dockerfile" ||
     fail "$image_key setup must use a plain qshell-compatible RUN instruction"
+  template_flavor=versioned
+  if [ "$image_key" = ubuntu-slim ]; then
+    template_flavor=slim
+  fi
+  phases="bootstrap platform toolchain runtime"
+  if [ "$image_key" != ubuntu-slim ]; then
+    phases="bootstrap platform node toolchain runtime"
+  fi
+  phase_count=0
+  for phase in $phases; do
+    grep -Fq \
+      "RUN TEMPLATE_FLAVOR=$template_flavor RUNNER_TEMPLATE_PHASE=$phase bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh" \
+      "$directory/Dockerfile" ||
+      fail "$image_key is missing cacheable setup phase $phase"
+    phase_count=$((phase_count + 1))
+  done
+  actual_phase_count="$(grep -Ec '^[[:space:]]*RUN[[:space:]]+TEMPLATE_FLAVOR=' "$directory/Dockerfile")"
+  test "$actual_phase_count" -eq "$phase_count" ||
+    fail "$image_key has $actual_phase_count setup phases, want $phase_count"
   if grep -Fq 'Acquire::https::Verify-Peer=false' "$directory/scripts/setup-template.sh"; then
     fail "$image_key setup must not disable apt HTTPS peer verification"
   fi
@@ -112,6 +151,9 @@ for image_key in ubuntu-slim ubuntu-22.04 ubuntu-24.04 ubuntu-26.04; do
       fail "$image_key must provide the deb822 path expected by upstream setup"
   fi
   if [ "$image_key" != ubuntu-slim ]; then
+    grep -Fq 'install-nvm.sh | install-nodejs.sh)' \
+      "$directory/scripts/setup-template.sh" ||
+      fail "$image_key must isolate Node installation in its cacheable node phase"
     for required_installer in \
       install-apt-common.sh \
       install-apache.sh \

--- a/scripts/check-runner-template-matrix.sh
+++ b/scripts/check-runner-template-matrix.sh
@@ -70,7 +70,7 @@ trap cleanup EXIT
 for image_key in ubuntu-slim ubuntu-22.04 ubuntu-24.04 ubuntu-26.04; do
   directory="templates/github-runner-${image_key}"
   test -d "$directory" || fail "missing directory $directory"
-  for required_file in Dockerfile qshell.sandbox.toml README.md software-diff.md scripts/setup-template.sh scripts/ensure-docker; do
+  for required_file in Dockerfile qshell.sandbox.toml README.md software-diff.md scripts/setup-template.sh scripts/ensure-docker scripts/download-checked-range; do
     test -f "$directory/$required_file" || fail "missing $directory/$required_file"
   done
 
@@ -131,12 +131,12 @@ for image_key in ubuntu-slim ubuntu-22.04 ubuntu-24.04 ubuntu-26.04; do
   phase_count=0
   for phase in $phases; do
     grep -Fq \
-      "RUN TEMPLATE_FLAVOR=$template_flavor RUNNER_TEMPLATE_PHASE=$phase bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh" \
+      "TEMPLATE_FLAVOR=$template_flavor RUNNER_TEMPLATE_PHASE=$phase bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh" \
       "$directory/Dockerfile" ||
       fail "$image_key is missing cacheable setup phase $phase"
     phase_count=$((phase_count + 1))
   done
-  actual_phase_count="$(grep -Ec '^[[:space:]]*RUN[[:space:]]+TEMPLATE_FLAVOR=' "$directory/Dockerfile")"
+  actual_phase_count="$(grep -Ec 'TEMPLATE_FLAVOR=(slim|versioned)[[:space:]]+RUNNER_TEMPLATE_PHASE=' "$directory/Dockerfile")"
   test "$actual_phase_count" -eq "$phase_count" ||
     fail "$image_key has $actual_phase_count setup phases, want $phase_count"
   if grep -Fq 'Acquire::https::Verify-Peer=false' "$directory/scripts/setup-template.sh"; then

--- a/scripts/generate-runner-image-compatibility.mjs
+++ b/scripts/generate-runner-image-compatibility.mjs
@@ -186,7 +186,7 @@ function verificationFor(imageKey, item) {
       return 'test -n "${ImageVersion:-}" && test -n "${IMAGE_VERSION:-}"';
     }
     if (name === "Systemd version") {
-      return "systemd --version >/dev/null";
+      return "test -x /usr/lib/systemd/systemd && /usr/lib/systemd/systemd --version >/dev/null";
     }
   }
   if (category === "Installed apt packages") {

--- a/scripts/smoke-runner-template.sh
+++ b/scripts/smoke-runner-template.sh
@@ -48,23 +48,47 @@ if ! awk -v actual="$qshell_version" -v minimum="2.19.10" '
 fi
 
 case "$image_key" in
-  ubuntu-slim | ubuntu-24.04)
+  ubuntu-slim)
     expected_release=24.04
     support_channel=stable
+    template_name=github-runner-ubuntu-slim
+    template_directory=github-runner-ubuntu-slim
+    ;;
+  ubuntu-24.04)
+    expected_release=24.04
+    support_channel=stable
+    template_name=github-runner-ubuntu-24-04
+    template_directory=github-runner-ubuntu-24.04
     ;;
   ubuntu-22.04)
     expected_release=22.04
     support_channel=stable
+    template_name=github-runner-ubuntu-22-04
+    template_directory=github-runner-ubuntu-22.04
     ;;
   ubuntu-26.04)
     expected_release=26.04
     support_channel=preview
+    template_name=github-runner-ubuntu-26-04
+    template_directory=github-runner-ubuntu-26.04
     ;;
   *)
     echo "unknown image key $image_key" >&2
     exit 65
     ;;
 esac
+
+template_dockerfile="$repository_root/templates/$template_directory/Dockerfile"
+expected_runner_version="$(awk -F= '$1 == "ARG RUNNER_VERSION" {print $2; exit}' "$template_dockerfile")"
+expected_template_version="$(awk -F= '$1 == "ARG TEMPLATE_VERSION" {print $2; exit}' "$template_dockerfile")"
+test -n "$expected_runner_version" || {
+  echo "could not determine RUNNER_VERSION from $template_dockerfile" >&2
+  exit 65
+}
+test -n "$expected_template_version" || {
+  echo "could not determine TEMPLATE_VERSION from $template_dockerfile" >&2
+  exit 65
+}
 
 docker_smoke_command="$(
   cat <<'DOCKER_SMOKE' | tr '\n' ' '
@@ -91,6 +115,9 @@ DOCKER_SMOKE
 jq \
   --arg image "$image_key" \
   --arg expected_release "$expected_release" \
+  --arg expected_runner_version "$expected_runner_version" \
+  --arg expected_template_version "$expected_template_version" \
+  --arg template_name "$template_name" \
   --arg docker_smoke_command "$docker_smoke_command" \
   '
     .images[$image].entries = [
@@ -110,7 +137,23 @@ jq \
         category: "Release smoke",
         upstream_name: "preinstalled Actions runner",
         status: "provided",
-        verification: "test -x /opt/actions-runner/config.sh && test -x /opt/actions-runner/run.sh"
+        verification: (
+          "test -x /opt/actions-runner/config.sh && "
+          + "test -x /opt/actions-runner/run.sh && "
+          + "test \"$(/opt/actions-runner/bin/Runner.Listener --version)\" = \""
+          + $expected_runner_version
+          + "\""
+        )
+      },
+      {
+        category: "Release smoke",
+        upstream_name: "runtime image metadata",
+        status: "provided",
+        verification: (
+          "test \"$IMAGE_TEMPLATE\" = \"" + $template_name + "\" && "
+          + "test \"$ImageVersion\" = \"" + $expected_template_version + "\" && "
+          + "test \"$IMAGE_VERSION\" = \"" + $expected_template_version + "\""
+        )
       },
       {
         category: "Release smoke",

--- a/scripts/smoke-runner-template.sh
+++ b/scripts/smoke-runner-template.sh
@@ -112,12 +112,26 @@ sudo -H -u runner -- bash -lc '
 DOCKER_SMOKE
 )"
 
+nvm_smoke_command="$(
+  cat <<'NVM_SMOKE' | tr '\n' ' '
+sudo -H -u runner -- bash -lc '
+  set -euo pipefail;
+  test -s "$HOME/.nvm/nvm.sh";
+  test -w "$HOME/.nvm";
+  export NVM_DIR="$HOME/.nvm";
+  . "$NVM_DIR/nvm.sh";
+  nvm --version >/dev/null;
+'
+NVM_SMOKE
+)"
+
 jq \
   --arg image "$image_key" \
   --arg expected_release "$expected_release" \
   --arg expected_runner_version "$expected_runner_version" \
   --arg expected_template_version "$expected_template_version" \
   --arg template_name "$template_name" \
+  --arg nvm_smoke_command "$nvm_smoke_command" \
   --arg docker_smoke_command "$docker_smoke_command" \
   '
     .images[$image].entries = [
@@ -154,6 +168,12 @@ jq \
           + "test \"$ImageVersion\" = \"" + $expected_template_version + "\" && "
           + "test \"$IMAGE_VERSION\" = \"" + $expected_template_version + "\""
         )
+      },
+      {
+        category: "Release smoke",
+        upstream_name: "runner writable NVM home",
+        status: "provided",
+        verification: $nvm_smoke_command
       },
       {
         category: "Release smoke",

--- a/templates/README.md
+++ b/templates/README.md
@@ -62,10 +62,9 @@ a promise that the executable is absent.
 
 All four templates install checksum-pinned AzCopy 10.32.6 from Microsoft's
 official Ubuntu package pool instead of the upstream floating `aka.ms`
-archive. Azure CLI remains upstream-first; if the upstream installer cannot
-reach Microsoft's repository, the build falls back to the official,
-checksum-pinned Azure CLI 2.88.0 package for Jammy or Noble and verifies the
-installed version. They intentionally do not prewarm the GitHub action
+archive. They also install the official, checksum-pinned Azure CLI 2.88.0
+package for Jammy or Noble directly and verify the installed version. They
+intentionally do not prewarm the GitHub action
 archive cache;
 the runner resolves actions through the normal job-time GitHub protocol, so
 this changes build size and network exposure rather than workflow semantics.
@@ -167,13 +166,21 @@ followed by release smoke inside a real Sandbox created from that template.
 The Slim Dockerfile divides setup into four cacheable qshell-compatible phases:
 `bootstrap`, `platform`, `toolchain`, and `runtime`. The versioned templates add
 a dedicated `node` phase between `platform` and `toolchain`, keeping their large
-Node/npm toolset within the remote builder's per-layer time limit. If the remote builder hits
-its hard time limit after one or more phases finish, rerun the same
+Node/npm toolset within the remote builder's per-layer time limit. Ubuntu 26.04
+also preinstalls the pinned runner-images apt package list in eighteen cacheable
+batches before the upstream platform installer rechecks every package and runs
+its Pester contract. Large emoji-font, ICU, RPM, Tk, Xvfb, binutils, and
+`systemd-coredump` dependency sets are isolated, and the final batch is
+open-ended so appended pinned packages are not skipped; this keeps slow
+Resolute mirrors from trapping the whole package set in one non-cacheable
+timeout. If the remote builder hits its hard
+time limit after one or more phases finish, rerun the same
 `template-build-*` task with cache enabled; completed phases are reused. Do not
 use `--no-cache` for that recovery, and do not publish until one build reaches
 terminal `Status: ready`.
-Release smoke checks the OS, architecture, preinstalled Actions runner,
-outbound HTTPS, Docker, writable work/tool-cache paths, and cleanup. Full
+Release smoke checks the OS, architecture, the exact Dockerfile-pinned Actions
+Runner version, persisted runtime template name/version metadata, outbound
+HTTPS, Docker, writable work/tool-cache paths, and cleanup. Full
 per-inventory runtime conformance and local Docker builds remain optional
 diagnostics; neither is a substitute for the remote usability gate.
 The source gate rejects an Actions Runner version below `2.336.0`, while the

--- a/templates/README.md
+++ b/templates/README.md
@@ -93,9 +93,16 @@ failures and silent version drift between the compatibility manifest and the
 built template.
 
 Checksum-pinned downloads retain partial output and resume it across up to 20
-bounded attempts. A completed artifact is accepted only after its SHA-256
-digest matches; a digest mismatch or a server that rejects ranges restarts the
-transfer from byte zero.
+bounded attempts. The large AWS SAM archive is additionally split into
+independent 16 MiB-or-smaller Range-download layers before `platform`
+provisioning, allowing successful chunks to survive the remote builder's
+per-build time limit. The Dockerfile verifies the assembled byte count and
+full SHA-256 digest, then continues into `platform` provisioning in the same
+`RUN` so the installer consumes the checked archive immediately. Only the
+bounded chunks under `/opt/qiniu-runner-build-cache` cross cache-layer
+boundaries because qshell does not restore cached `/tmp` outputs; one oversized
+temporary file never becomes a cache output. A digest mismatch or a server
+that ignores the requested ranges therefore fails closed.
 
 The curl compatibility wrapper remains available to unmodified upstream
 installers that resolve a fixed release through the GitHub API. It caches
@@ -111,6 +118,9 @@ the installed Git LFS CLI directly.
 All four templates install NVM 0.40.6 from the checksum-pinned official tag
 archive instead of cloning the repository during the build. The resulting
 profile setup and system-Node default match the pinned upstream installer.
+The build copies that skeleton into `/home/runner/.nvm` with runner ownership;
+release smoke sources it as the runner user and verifies that the directory is
+writable before the template can be promoted.
 
 Google Cloud CLI is installed from Google's official versioned x86_64 archive.
 The common version and SHA-256 digest are pinned in each Dockerfile, avoiding
@@ -178,9 +188,17 @@ time limit after one or more phases finish, rerun the same
 `template-build-*` task with cache enabled; completed phases are reused. Do not
 use `--no-cache` for that recovery, and do not publish until one build reaches
 terminal `Status: ready`.
+Template version metadata and the runner-owned NVM copy are applied only after
+the heavy provisioning layers, so a release identity bump or NVM ownership fix
+does not invalidate otherwise reusable installer caches.
+The checksum-pinned AWS SAM Range layers sit between `bootstrap` and
+`platform`; rerunning the identical source reuses every completed chunk rather
+than restarting the whole archive. The platform installer runs in the same
+layer as reassembly instead of depending on a cached oversized archive.
 Release smoke checks the OS, architecture, the exact Dockerfile-pinned Actions
 Runner version, persisted runtime template name/version metadata, outbound
-HTTPS, Docker, writable work/tool-cache paths, and cleanup. Full
+HTTPS, Docker, a runner-owned writable NVM home, writable work/tool-cache
+paths, and cleanup. Full
 per-inventory runtime conformance and local Docker builds remain optional
 diagnostics; neither is a substitute for the remote usability gate.
 The source gate rejects an Actions Runner version below `2.336.0`, while the

--- a/templates/README.md
+++ b/templates/README.md
@@ -164,10 +164,24 @@ task template-smoke IMAGE_KEY=ubuntu-24.04 TEMPLATE_ID=<published-template-id>
 
 The formal template gate is a qshell build reaching terminal `Status: ready`,
 followed by release smoke inside a real Sandbox created from that template.
+The Slim Dockerfile divides setup into four cacheable qshell-compatible phases:
+`bootstrap`, `platform`, `toolchain`, and `runtime`. The versioned templates add
+a dedicated `node` phase between `platform` and `toolchain`, keeping their large
+Node/npm toolset within the remote builder's per-layer time limit. If the remote builder hits
+its hard time limit after one or more phases finish, rerun the same
+`template-build-*` task with cache enabled; completed phases are reused. Do not
+use `--no-cache` for that recovery, and do not publish until one build reaches
+terminal `Status: ready`.
 Release smoke checks the OS, architecture, preinstalled Actions runner,
 outbound HTTPS, Docker, writable work/tool-cache paths, and cleanup. Full
 per-inventory runtime conformance and local Docker builds remain optional
 diagnostics; neither is a substitute for the remote usability gate.
+The source gate rejects an Actions Runner version below `2.336.0`, while the
+compatibility contract checks the exact version pinned by each Dockerfile.
+Update the runner version, official archive checksum, and compatibility
+verification together. Python and pipx upstream installers use bounded retries
+and longer pip read timeouts because remote template builds must tolerate
+transient package-index failures without retrying unrelated installers.
 The Docker check imports a minimal root filesystem from the Sandbox itself and
 runs it with networking disabled. This verifies daemon, socket, image-import,
 and container execution behavior without conflating template correctness with

--- a/templates/github-runner-ubuntu-22.04/Dockerfile
+++ b/templates/github-runner-ubuntu-22.04/Dockerfile
@@ -2,7 +2,6 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:22.04@sha256:0bc16241504efa4cf92fcc8c8039dac604c6bb832b3d8fcc24097c6b05b60b7c
 
-ARG TEMPLATE_VERSION=20260805.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
 ARG RUNNER_VERSION=2.336.0
@@ -27,6 +26,7 @@ ARG AWS_SESSION_MANAGER_PLUGIN_VERSION=1.2.835.0
 ARG AWS_SESSION_MANAGER_PLUGIN_DEB_SHA256=7c6dcad12518571cc7959a713e6a8ae1bdf6ed66fd9bee37dc189e39ca58ae03
 ARG AWS_SAM_CLI_VERSION=1.163.0
 ARG AWS_SAM_CLI_ARCHIVE_SHA256=3f12863f45da82bc2ad1fb837444cca57450bd07fef73449b917362ef2f5ab70
+ARG AWS_SAM_CLI_ARCHIVE_SIZE=93672108
 ARG GITHUB_CLI_VERSION=2.96.0
 ARG GITHUB_CLI_DEB_SHA256=11a731f4e0ca8c3db96ef6d2cc404dcab3d78247ce0e07c53e07117e7627d6a1
 ARG YQ_VERSION=4.53.3
@@ -40,8 +40,6 @@ ARG DOCKER_GPG_FINGERPRINT=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
 ENV DEBIAN_FRONTEND=noninteractive \
     ImageOS=ubuntu22 \
-    ImageVersion=$TEMPLATE_VERSION \
-    IMAGE_VERSION=$TEMPLATE_VERSION \
     IMAGE_TEMPLATE=github-runner-ubuntu-22-04 \
     RUNNER_TOOL_CACHE=/opt/hostedtoolcache \
     AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache \
@@ -51,14 +49,48 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 COPY scripts/setup-template.sh /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 COPY scripts/ensure-docker /usr/local/share/qiniu-sandbox-runner-template/ensure-docker
+COPY scripts/download-checked-range /usr/local/share/qiniu-sandbox-runner-template/download-checked-range
 COPY scripts/curl /usr/local/share/qiniu-sandbox-runner-template/curl
 COPY scripts/wget /usr/local/share/qiniu-sandbox-runner-template/wget
 
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=bootstrap bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
-RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN install -d -m 0755 /opt/qiniu-runner-build-cache
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-00 0 16777215
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-01 16777216 33554431
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-02 33554432 50331647
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-03 50331648 67108863
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-04 67108864 83886079
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-05 83886080 93672107
+RUN set -eux; \
+    cat /opt/qiniu-runner-build-cache/aws-sam-cli.part-* > /tmp/qiniu-aws-sam-cli.zip; \
+    test "$(wc -c </tmp/qiniu-aws-sam-cli.zip | tr -d '[:space:]')" -eq "$AWS_SAM_CLI_ARCHIVE_SIZE"; \
+    echo "$AWS_SAM_CLI_ARCHIVE_SHA256  /tmp/qiniu-aws-sam-cli.zip" | sha256sum --check -; \
+    rm -f /opt/qiniu-runner-build-cache/aws-sam-cli.part-*; \
+    rmdir /opt/qiniu-runner-build-cache; \
+    TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=node bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN set -eux; \
+    rm -rf /home/runner/.nvm; \
+    cp -a /etc/skel/.nvm /home/runner/.nvm; \
+    chown -R runner:runner /home/runner/.nvm
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+
+ARG TEMPLATE_VERSION=20260805.6
+ENV ImageVersion=$TEMPLATE_VERSION \
+    IMAGE_VERSION=$TEMPLATE_VERSION
 
 RUN set -eux; \
     environment_file=/etc/environment; \

--- a/templates/github-runner-ubuntu-22.04/Dockerfile
+++ b/templates/github-runner-ubuntu-22.04/Dockerfile
@@ -2,7 +2,7 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:22.04@sha256:0bc16241504efa4cf92fcc8c8039dac604c6bb832b3d8fcc24097c6b05b60b7c
 
-ARG TEMPLATE_VERSION=20260804.1
+ARG TEMPLATE_VERSION=20260805.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
 ARG RUNNER_VERSION=2.336.0
@@ -59,6 +59,21 @@ RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/sha
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=node bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+
+RUN set -eux; \
+    environment_file=/etc/environment; \
+    touch "$environment_file"; \
+    sed -i -e '/^ImageOS=/d' -e '/^ImageVersion=/d' -e '/^IMAGE_VERSION=/d' \
+      -e '/^IMAGE_TEMPLATE=/d' -e '/^RUNNER_TOOL_CACHE=/d' \
+      -e '/^AGENT_TOOLSDIRECTORY=/d' "$environment_file"; \
+    printf '%s\n' \
+      "ImageOS=\"$ImageOS\"" \
+      "ImageVersion=\"$TEMPLATE_VERSION\"" \
+      "IMAGE_VERSION=\"$TEMPLATE_VERSION\"" \
+      "IMAGE_TEMPLATE=\"$IMAGE_TEMPLATE\"" \
+      "RUNNER_TOOL_CACHE=\"$RUNNER_TOOL_CACHE\"" \
+      "AGENT_TOOLSDIRECTORY=\"$AGENT_TOOLSDIRECTORY\"" \
+      >>"$environment_file"
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-22.04/Dockerfile
+++ b/templates/github-runner-ubuntu-22.04/Dockerfile
@@ -2,11 +2,11 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:22.04@sha256:0bc16241504efa4cf92fcc8c8039dac604c6bb832b3d8fcc24097c6b05b60b7c
 
-ARG TEMPLATE_VERSION=20260727.1
+ARG TEMPLATE_VERSION=20260804.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
-ARG RUNNER_VERSION=2.334.0
-ARG RUNNER_ARCHIVE_SHA256=048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271
+ARG RUNNER_VERSION=2.336.0
+ARG RUNNER_ARCHIVE_SHA256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d
 ARG AZCOPY_VERSION=10.32.6
 ARG AZCOPY_DEB_SHA256=1a5078a8260ba7524a4400c602519d36905e592cd87a1db91a30af0da528fc86
 ARG AZURE_CLI_VERSION=2.88.0
@@ -16,6 +16,7 @@ ARG AZURE_DEVOPS_EXTENSION_VERSION=1.0.6
 ARG AZURE_DEVOPS_EXTENSION_SHA256=fa779e1fd6e6e1b726c3656b6a1968537c208041c6af54d2a7476772d896b34b
 ARG BICEP_VERSION=0.45.15
 ARG BICEP_NUGET_SHA256=2055d8e4b2b984591d06b8c054dfb6db3b68f2bf236309ae185f06a161ae714a
+ARG PESTER_NUPKG_SHA256=5a0fd80b361600bf4bbd4c307c1fd01b17f11668bab19e657add41b00ad22ab9
 ARG GOOGLE_CLOUD_CLI_VERSION=577.0.0
 ARG GOOGLE_CLOUD_CLI_ARCHIVE_SHA256=0b32d330446ce7b0f57f253e7efab4636c18fb1f87a3ac31c6c3f2a2a697525e
 ARG NVM_VERSION=0.40.6
@@ -53,7 +54,11 @@ COPY scripts/ensure-docker /usr/local/share/qiniu-sandbox-runner-template/ensure
 COPY scripts/curl /usr/local/share/qiniu-sandbox-runner-template/curl
 COPY scripts/wget /usr/local/share/qiniu-sandbox-runner-template/wget
 
-RUN TEMPLATE_FLAVOR=versioned bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=bootstrap bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=node bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-22.04/scripts/download-checked-range
+++ b/templates/github-runner-ubuntu-22.04/scripts/download-checked-range
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${1:?download URL is required}"
+destination="${2:?destination path is required}"
+start="${3:?range start is required}"
+end="${4:?range end is required}"
+attempts="${RUNNER_TEMPLATE_DOWNLOAD_ATTEMPTS:-20}"
+retry_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_DELAY:-2}"
+retry_max_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_MAX_DELAY:-30}"
+
+if [[ ! "$start" =~ ^[0-9]+$ ]] || [[ ! "$end" =~ ^[0-9]+$ ]] || [ "$end" -lt "$start" ]; then
+  echo "invalid byte range: ${start}-${end}" >&2
+  exit 64
+fi
+
+expected_size=$((end - start + 1))
+partial="${destination}.partial"
+install -d -m 0755 "$(dirname "$destination")"
+
+file_size() {
+  if [ -f "$1" ]; then
+    wc -c <"$1" | tr -d '[:space:]'
+  else
+    echo 0
+  fi
+}
+
+if [ "$(file_size "$destination")" -eq "$expected_size" ]; then
+  exit 0
+fi
+rm -f "$destination"
+touch "$partial"
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  current_size="$(file_size "$partial")"
+  if [ "$current_size" -gt "$expected_size" ]; then
+    echo "range server returned too many bytes; restarting chunk" >&2
+    rm -f "$partial"
+    touch "$partial"
+    current_size=0
+  fi
+  if [ "$current_size" -eq "$expected_size" ]; then
+    mv "$partial" "$destination"
+    exit 0
+  fi
+
+  request_start=$((start + current_size))
+  /usr/bin/curl --http1.1 -fsSL --connect-timeout 15 --max-time 1200 \
+    --speed-limit 1024 --speed-time 60 \
+    --range "${request_start}-${end}" "$url" >>"$partial" || true
+
+  current_size="$(file_size "$partial")"
+  if [ "$current_size" -eq "$expected_size" ]; then
+    mv "$partial" "$destination"
+    exit 0
+  fi
+  if [ "$current_size" -gt "$expected_size" ]; then
+    echo "range server returned too many bytes; restarting chunk" >&2
+    rm -f "$partial"
+    touch "$partial"
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "range download interrupted; resuming (${attempt}/${attempts})" >&2
+    if [ "$retry_delay" -gt 0 ]; then
+      sleep "$retry_delay"
+      if [ "$retry_delay" -lt "$retry_max_delay" ]; then
+        retry_delay=$((retry_delay * 2))
+        if [ "$retry_delay" -gt "$retry_max_delay" ]; then
+          retry_delay="$retry_max_delay"
+        fi
+      fi
+    fi
+  fi
+done
+
+echo "range download failed after ${attempts} attempts: ${url} bytes ${start}-${end}" >&2
+exit 1

--- a/templates/github-runner-ubuntu-22.04/scripts/setup-template.sh
+++ b/templates/github-runner-ubuntu-22.04/scripts/setup-template.sh
@@ -72,6 +72,7 @@ download_checked() {
   local expected_sha256="$3"
   local attempts="${RUNNER_TEMPLATE_DOWNLOAD_ATTEMPTS:-20}"
   local retry_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_DELAY:-2}"
+  local retry_max_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_MAX_DELAY:-30}"
   local attempt
   local curl_status
 
@@ -102,6 +103,12 @@ download_checked() {
       echo "download interrupted; resuming (${attempt}/${attempts})" >&2
       if [ "$retry_delay" != 0 ]; then
         sleep "$retry_delay"
+        if [ "$retry_delay" -lt "$retry_max_delay" ]; then
+          retry_delay=$((retry_delay * 2))
+          if [ "$retry_delay" -gt "$retry_max_delay" ]; then
+            retry_delay="$retry_max_delay"
+          fi
+        fi
       fi
     fi
   done
@@ -496,6 +503,21 @@ configure_docker_apt_repository() {
   apt-cache show docker-ce >/dev/null 2>&1
 }
 
+remove_official_docker_packages() {
+  local official_docker_packages=(
+    containerd.io
+    docker-buildx-plugin
+    docker-ce
+    docker-ce-cli
+    docker-ce-rootless-extras
+    docker-compose-plugin
+  )
+  if ! apt-get purge -y "${official_docker_packages[@]}"; then
+    dpkg --purge --force-depends "${official_docker_packages[@]}" || true
+  fi
+  apt-get -f install -y
+}
+
 install_docker_for_sandbox() {
   if configure_docker_apt_repository && \
     apt-get install -y --no-install-recommends \
@@ -503,6 +525,7 @@ install_docker_for_sandbox() {
     echo "installed Docker packages from the official Docker repository"
   else
     echo "official Docker packages unavailable; using Ubuntu archive packages" >&2
+    remove_official_docker_packages
     rm -f /etc/apt/sources.list.d/docker.list /etc/apt/keyrings/docker.gpg
     apt-get update
     apt-get install -y --no-install-recommends docker.io docker-buildx docker-compose-v2

--- a/templates/github-runner-ubuntu-22.04/scripts/setup-template.sh
+++ b/templates/github-runner-ubuntu-22.04/scripts/setup-template.sh
@@ -1,6 +1,35 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+runner_template_phase="${RUNNER_TEMPLATE_PHASE:-all}"
+case "$runner_template_phase" in
+  all | bootstrap | platform | node | toolchain | runtime) ;;
+  *)
+    echo "unsupported runner template phase: $runner_template_phase" >&2
+    exit 64
+    ;;
+esac
+
+phase_selected() {
+  [ "$runner_template_phase" = all ] || [ "$runner_template_phase" = "$1" ]
+}
+
+installer_phase() {
+  case "$1" in
+    configure-apt-sources.sh | configure-apt.sh | install-apt-vital.sh | install-ms-repos.sh | configure-image-data-file.sh | configure-environment.sh | install-apt-common.sh | install-azure-cli.sh | install-bicep.sh | install-apache.sh | install-aws-tools.sh | install-container-tools.sh | install-git.sh | install-git-lfs.sh | install-github-cli.sh | install-google-cloud-cli.sh)
+      echo platform
+      ;;
+    install-nvm.sh | install-nodejs.sh)
+      echo node
+      ;;
+    *) echo toolchain ;;
+  esac
+}
+
+should_run_installer() {
+  phase_selected "$(installer_phase "$1")"
+}
+
 : "${RUNNER_IMAGES_REV:?RUNNER_IMAGES_REV is required}"
 : "${RUNNER_IMAGES_ARCHIVE_SHA256:?RUNNER_IMAGES_ARCHIVE_SHA256 is required}"
 : "${RUNNER_VERSION:?RUNNER_VERSION is required}"
@@ -14,6 +43,7 @@ set -euxo pipefail
 : "${AZURE_DEVOPS_EXTENSION_SHA256:?AZURE_DEVOPS_EXTENSION_SHA256 is required}"
 : "${BICEP_VERSION:?BICEP_VERSION is required}"
 : "${BICEP_NUGET_SHA256:?BICEP_NUGET_SHA256 is required}"
+: "${PESTER_NUPKG_SHA256:?PESTER_NUPKG_SHA256 is required}"
 : "${GOOGLE_CLOUD_CLI_VERSION:?GOOGLE_CLOUD_CLI_VERSION is required}"
 : "${GOOGLE_CLOUD_CLI_ARCHIVE_SHA256:?GOOGLE_CLOUD_CLI_ARCHIVE_SHA256 is required}"
 : "${NVM_VERSION:?NVM_VERSION is required}"
@@ -300,10 +330,38 @@ install_ninja_from_checked_archive() {
   run_upstream_tests_if_available "Tools" "Ninja"
 }
 
+run_retryable_upstream_installer() {
+  local installer_path="$1"
+  local installer_name="${installer_path##*/}"
+  local attempts="${RUNNER_TEMPLATE_UPSTREAM_INSTALL_ATTEMPTS:-3}"
+  local retry_delay="${RUNNER_TEMPLATE_UPSTREAM_INSTALL_RETRY_DELAY:-2}"
+  local attempt
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if PIP_DEFAULT_TIMEOUT="${PIP_DEFAULT_TIMEOUT:-120}" \
+      PIP_RETRIES="${PIP_RETRIES:-10}" \
+      bash "$installer_path"; then
+      return 0
+    fi
+    if [ "$attempt" -lt "$attempts" ]; then
+      echo "upstream installer interrupted; retrying $installer_name (${attempt}/${attempts})" >&2
+      if [ "$retry_delay" != 0 ]; then
+        sleep "$retry_delay"
+      fi
+    fi
+  done
+  echo "upstream installer failed after ${attempts} attempts: $installer_name" >&2
+  return 1
+}
+
 run_upstream_installer() {
   local installer_path="$1"
   local installer_name="${installer_path##*/}"
   case "$installer_name" in
+    install-azure-cli.sh)
+      install_azure_cli_from_microsoft_package
+      return
+      ;;
     install-aws-tools.sh)
       install_aws_tools_from_checked_archives
       return
@@ -344,15 +402,16 @@ run_upstream_installer() {
       install_ninja_from_checked_archive
       return
       ;;
+    install-python.sh | install-pipx-packages.sh)
+      if run_retryable_upstream_installer "$installer_path"; then
+        return 0
+      fi
+      return 1
+      ;;
   esac
 
   if bash "$installer_path"; then
     return 0
-  fi
-  if [ "$installer_name" = install-azure-cli.sh ]; then
-    echo "upstream Azure CLI installer unavailable; using checked Microsoft package" >&2
-    install_azure_cli_from_microsoft_package
-    return
   fi
   if [ "$installer_name" = install-docker-cli.sh ]; then
     echo "upstream Docker CLI installer unavailable; deferring to sandbox-aware installer" >&2
@@ -467,6 +526,8 @@ install_runner() {
 
 install_pester_for_upstream_tests() {
   local pester_version
+  local package
+  local module_dir
   pester_version="$(
     jq -er '
       .powershellModules[]
@@ -474,10 +535,17 @@ install_pester_for_upstream_tests() {
       | .versions[]
     ' "$INSTALLER_SCRIPT_FOLDER/toolset.json"
   )"
+  package="/tmp/Pester.${pester_version}.nupkg"
+  module_dir="/usr/local/share/powershell/Modules/Pester/${pester_version}"
+  download_checked \
+    "https://www.powershellgallery.com/api/v2/package/Pester/${pester_version}" \
+    "$package" \
+    "$PESTER_NUPKG_SHA256"
+  install -d -m 0755 "$module_dir"
+  unzip -q "$package" -d "$module_dir"
+  rm -f "$package"
   PESTER_VERSION="$pester_version" pwsh -NoLogo -NoProfile -Command '
     $ErrorActionPreference = "Stop"
-    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-    Install-Module -Name Pester -RequiredVersion $env:PESTER_VERSION -Scope AllUsers -SkipPublisherCheck -Force
     Import-Module Pester -RequiredVersion $env:PESTER_VERSION -Force
     if ((Get-Module Pester).Version.ToString() -ne $env:PESTER_VERSION) { exit 1 }
   '
@@ -504,6 +572,7 @@ stop_validated_service() {
   fi
 }
 
+if phase_selected bootstrap; then
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 configure_reliable_apt_sources
@@ -524,22 +593,26 @@ install -d -o runner -g runner \
   /home/runner/_runnerd-hooks \
   /opt/actions-runner
 
-download_checked \
-  "https://codeload.github.com/actions/runner-images/tar.gz/${RUNNER_IMAGES_REV}" \
-  /tmp/runner-images.tar.gz \
-  "$RUNNER_IMAGES_ARCHIVE_SHA256"
-mkdir -p /tmp/runner-images
-tar -xzf /tmp/runner-images.tar.gz -C /tmp/runner-images --strip-components=1
+  download_checked \
+    "https://codeload.github.com/actions/runner-images/tar.gz/${RUNNER_IMAGES_REV}" \
+    /tmp/runner-images.tar.gz \
+    "$RUNNER_IMAGES_ARCHIVE_SHA256"
+  mkdir -p /opt/qiniu-runner-images
+  tar -xzf /tmp/runner-images.tar.gz -C /opt/qiniu-runner-images --strip-components=1
+fi
+test -d /opt/qiniu-runner-images
 
 export DEBIAN_FRONTEND=noninteractive
-export HELPER_SCRIPTS=/tmp/runner-images/images/ubuntu-slim/scripts/helpers
-export INSTALLER_SCRIPT_FOLDER=/tmp/runner-images/images/ubuntu-slim/toolsets
+export HELPER_SCRIPTS=/opt/qiniu-runner-images/images/ubuntu-slim/scripts/helpers
+export INSTALLER_SCRIPT_FOLDER=/opt/qiniu-runner-images/images/ubuntu-slim/toolsets
 export IMAGE_VERSION="${IMAGE_VERSION:-${ImageVersion:-local}}"
 export IMAGE_OS=ubuntu24
 
 if [ "${TEMPLATE_FLAVOR:-}" = slim ]; then
-  upstream_build=/tmp/runner-images/images/ubuntu-slim/scripts/build
-  install_azcopy_from_microsoft_package
+  upstream_build=/opt/qiniu-runner-images/images/ubuntu-slim/scripts/build
+  if phase_selected platform; then
+    install_azcopy_from_microsoft_package
+  fi
   for installer in \
     configure-apt-sources.sh \
     configure-apt.sh \
@@ -565,15 +638,19 @@ if [ "${TEMPLATE_FLAVOR:-}" = slim ]; then
     install-pipx-packages.sh \
     install-docker-cli.sh \
     configure-system.sh; do
+    should_run_installer "$installer" || continue
     run_upstream_installer "$upstream_build/$installer"
     if [ "$installer" = install-azure-cli.sh ]; then
       install_azure_devops_extension
     fi
   done
-  ln -s /etc/skel/.nvm /home/runner/.nvm
+  if phase_selected toolchain; then
+    ln -sfn /etc/skel/.nvm /home/runner/.nvm
+  fi
 else
   . /etc/os-release
   export IMAGE_OS="ubuntu${VERSION_ID/.}"
+  if phase_selected bootstrap; then
   install -d -m 0755 /tmp/qiniu-runner-build-tools
   cat >/tmp/qiniu-runner-build-tools/systemctl <<'SYSTEMCTL'
 #!/bin/sh
@@ -765,7 +842,6 @@ exit 0
 SYSTEMCTL
   chmod 0755 /tmp/qiniu-runner-build-tools/systemctl
   ln -s /tmp/qiniu-runner-build-tools/systemctl /usr/local/bin/systemctl
-  export PATH="/tmp/qiniu-runner-build-tools:$PATH"
   echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90assumeyes
   install -d -m 0755 /etc/cloud/templates
   cat >/etc/waagent.conf <<'WAAGENT'
@@ -773,11 +849,14 @@ ResourceDisk.Format=n
 ResourceDisk.EnableSwap=n
 ResourceDisk.SwapSizeMB=0
 WAAGENT
+  fi
+  export PATH="/tmp/qiniu-runner-build-tools:$PATH"
   release_digits="${VERSION_ID/.}"
-  upstream_build=/tmp/runner-images/images/ubuntu/scripts/build
-  export HELPER_SCRIPTS=/tmp/runner-images/images/ubuntu/scripts/helpers
-  export INSTALLER_SCRIPT_FOLDER=/tmp/runner-images/images/ubuntu/scripts/build
-  cp "/tmp/runner-images/images/ubuntu/toolsets/toolset-${release_digits}.json" \
+  upstream_build=/opt/qiniu-runner-images/images/ubuntu/scripts/build
+  export HELPER_SCRIPTS=/opt/qiniu-runner-images/images/ubuntu/scripts/helpers
+  export INSTALLER_SCRIPT_FOLDER=/opt/qiniu-runner-images/images/ubuntu/scripts/build
+  if phase_selected bootstrap; then
+  cp "/opt/qiniu-runner-images/images/ubuntu/toolsets/toolset-${release_digits}.json" \
     "$INSTALLER_SCRIPT_FOLDER/toolset.json"
   install -d -m 0755 /imagegeneration
   cp -a "$HELPER_SCRIPTS" /imagegeneration/helpers
@@ -815,6 +894,7 @@ WAAGENT
   bash "$upstream_build/install-powershell.sh"
   install_pester_for_upstream_tests
   bash "$HELPER_SCRIPTS/invoke-tests.sh" Tools azcopy
+  fi
 
   for installer in \
     install-apt-common.sh \
@@ -834,6 +914,7 @@ WAAGENT
     install-python.sh \
     install-zstd.sh \
     install-ninja.sh; do
+    should_run_installer "$installer" || continue
     run_upstream_installer "$upstream_build/$installer"
     case "$installer" in
       install-azure-cli.sh)
@@ -843,11 +924,14 @@ WAAGENT
       install-apache.sh) stop_validated_service apache2 ;;
     esac
   done
+  if phase_selected toolchain; then
   . "$HELPER_SCRIPTS/etc-environment.sh"
   reload_etc_environment
-  bash "$upstream_build/install-pipx-packages.sh"
+  run_upstream_installer "$upstream_build/install-pipx-packages.sh"
+  fi
 fi
 
+if phase_selected runtime; then
 install_docker_for_sandbox
 install_runner
 install -m 0755 \
@@ -862,8 +946,8 @@ chmod -R a+rX /opt/actions-runner /opt/hostedtoolcache
 
 apt-get clean
 find /var/lib/apt/lists -mindepth 1 -delete
-find /tmp/runner-images -mindepth 1 -delete
-find /tmp/runner-images -depth -type d -empty -delete
+find /opt/qiniu-runner-images -mindepth 1 -delete
+find /opt/qiniu-runner-images -depth -type d -empty -delete
 if [ -d /imagegeneration ]; then
   find /imagegeneration -mindepth 1 -delete
   rmdir /imagegeneration
@@ -872,3 +956,4 @@ rm -f /usr/local/bin/systemctl
 find /tmp/qiniu-runner-build-tools -mindepth 1 -delete 2>/dev/null || true
 rmdir /tmp/qiniu-runner-build-tools 2>/dev/null || true
 rm -f /tmp/actions-runner.tar.gz /tmp/docker.gpg /tmp/runner-images.tar.gz
+fi

--- a/templates/github-runner-ubuntu-24.04/Dockerfile
+++ b/templates/github-runner-ubuntu-24.04/Dockerfile
@@ -2,11 +2,11 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:be20a0347f238b7d373edddc55923443b21dd9a60277bf8a93e43458cd0bf2fc
 
-ARG TEMPLATE_VERSION=20260727.1
+ARG TEMPLATE_VERSION=20260804.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
-ARG RUNNER_VERSION=2.334.0
-ARG RUNNER_ARCHIVE_SHA256=048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271
+ARG RUNNER_VERSION=2.336.0
+ARG RUNNER_ARCHIVE_SHA256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d
 ARG AZCOPY_VERSION=10.32.6
 ARG AZCOPY_DEB_SHA256=1a5078a8260ba7524a4400c602519d36905e592cd87a1db91a30af0da528fc86
 ARG AZURE_CLI_VERSION=2.88.0
@@ -16,6 +16,7 @@ ARG AZURE_DEVOPS_EXTENSION_VERSION=1.0.6
 ARG AZURE_DEVOPS_EXTENSION_SHA256=fa779e1fd6e6e1b726c3656b6a1968537c208041c6af54d2a7476772d896b34b
 ARG BICEP_VERSION=0.45.15
 ARG BICEP_NUGET_SHA256=2055d8e4b2b984591d06b8c054dfb6db3b68f2bf236309ae185f06a161ae714a
+ARG PESTER_NUPKG_SHA256=5a0fd80b361600bf4bbd4c307c1fd01b17f11668bab19e657add41b00ad22ab9
 ARG GOOGLE_CLOUD_CLI_VERSION=577.0.0
 ARG GOOGLE_CLOUD_CLI_ARCHIVE_SHA256=0b32d330446ce7b0f57f253e7efab4636c18fb1f87a3ac31c6c3f2a2a697525e
 ARG NVM_VERSION=0.40.6
@@ -53,7 +54,11 @@ COPY scripts/setup-template.sh /usr/local/share/qiniu-sandbox-runner-template/se
 COPY scripts/ensure-docker /usr/local/share/qiniu-sandbox-runner-template/ensure-docker
 COPY scripts/curl /usr/local/share/qiniu-sandbox-runner-template/curl
 
-RUN TEMPLATE_FLAVOR=versioned bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=bootstrap bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=node bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-24.04/Dockerfile
+++ b/templates/github-runner-ubuntu-24.04/Dockerfile
@@ -2,7 +2,7 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:be20a0347f238b7d373edddc55923443b21dd9a60277bf8a93e43458cd0bf2fc
 
-ARG TEMPLATE_VERSION=20260804.1
+ARG TEMPLATE_VERSION=20260805.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
 ARG RUNNER_VERSION=2.336.0
@@ -59,6 +59,21 @@ RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/sha
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=node bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+
+RUN set -eux; \
+    environment_file=/etc/environment; \
+    touch "$environment_file"; \
+    sed -i -e '/^ImageOS=/d' -e '/^ImageVersion=/d' -e '/^IMAGE_VERSION=/d' \
+      -e '/^IMAGE_TEMPLATE=/d' -e '/^RUNNER_TOOL_CACHE=/d' \
+      -e '/^AGENT_TOOLSDIRECTORY=/d' "$environment_file"; \
+    printf '%s\n' \
+      "ImageOS=\"$ImageOS\"" \
+      "ImageVersion=\"$TEMPLATE_VERSION\"" \
+      "IMAGE_VERSION=\"$TEMPLATE_VERSION\"" \
+      "IMAGE_TEMPLATE=\"$IMAGE_TEMPLATE\"" \
+      "RUNNER_TOOL_CACHE=\"$RUNNER_TOOL_CACHE\"" \
+      "AGENT_TOOLSDIRECTORY=\"$AGENT_TOOLSDIRECTORY\"" \
+      >>"$environment_file"
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-24.04/Dockerfile
+++ b/templates/github-runner-ubuntu-24.04/Dockerfile
@@ -2,7 +2,6 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:be20a0347f238b7d373edddc55923443b21dd9a60277bf8a93e43458cd0bf2fc
 
-ARG TEMPLATE_VERSION=20260805.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
 ARG RUNNER_VERSION=2.336.0
@@ -27,6 +26,7 @@ ARG AWS_SESSION_MANAGER_PLUGIN_VERSION=1.2.835.0
 ARG AWS_SESSION_MANAGER_PLUGIN_DEB_SHA256=7c6dcad12518571cc7959a713e6a8ae1bdf6ed66fd9bee37dc189e39ca58ae03
 ARG AWS_SAM_CLI_VERSION=1.163.0
 ARG AWS_SAM_CLI_ARCHIVE_SHA256=3f12863f45da82bc2ad1fb837444cca57450bd07fef73449b917362ef2f5ab70
+ARG AWS_SAM_CLI_ARCHIVE_SIZE=93672108
 ARG GITHUB_CLI_VERSION=2.96.0
 ARG GITHUB_CLI_DEB_SHA256=11a731f4e0ca8c3db96ef6d2cc404dcab3d78247ce0e07c53e07117e7627d6a1
 ARG YQ_VERSION=4.53.3
@@ -40,8 +40,6 @@ ARG DOCKER_GPG_FINGERPRINT=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
 ENV DEBIAN_FRONTEND=noninteractive \
     ImageOS=ubuntu24 \
-    ImageVersion=$TEMPLATE_VERSION \
-    IMAGE_VERSION=$TEMPLATE_VERSION \
     IMAGE_TEMPLATE=github-runner-ubuntu-24-04 \
     RUNNER_TOOL_CACHE=/opt/hostedtoolcache \
     AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache \
@@ -52,13 +50,47 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 COPY scripts/setup-template.sh /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 COPY scripts/ensure-docker /usr/local/share/qiniu-sandbox-runner-template/ensure-docker
+COPY scripts/download-checked-range /usr/local/share/qiniu-sandbox-runner-template/download-checked-range
 COPY scripts/curl /usr/local/share/qiniu-sandbox-runner-template/curl
 
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=bootstrap bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
-RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN install -d -m 0755 /opt/qiniu-runner-build-cache
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-00 0 16777215
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-01 16777216 33554431
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-02 33554432 50331647
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-03 50331648 67108863
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-04 67108864 83886079
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-05 83886080 93672107
+RUN set -eux; \
+    cat /opt/qiniu-runner-build-cache/aws-sam-cli.part-* > /tmp/qiniu-aws-sam-cli.zip; \
+    test "$(wc -c </tmp/qiniu-aws-sam-cli.zip | tr -d '[:space:]')" -eq "$AWS_SAM_CLI_ARCHIVE_SIZE"; \
+    echo "$AWS_SAM_CLI_ARCHIVE_SHA256  /tmp/qiniu-aws-sam-cli.zip" | sha256sum --check -; \
+    rm -f /opt/qiniu-runner-build-cache/aws-sam-cli.part-*; \
+    rmdir /opt/qiniu-runner-build-cache; \
+    TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=node bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN set -eux; \
+    rm -rf /home/runner/.nvm; \
+    cp -a /etc/skel/.nvm /home/runner/.nvm; \
+    chown -R runner:runner /home/runner/.nvm
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+
+ARG TEMPLATE_VERSION=20260805.6
+ENV ImageVersion=$TEMPLATE_VERSION \
+    IMAGE_VERSION=$TEMPLATE_VERSION
 
 RUN set -eux; \
     environment_file=/etc/environment; \

--- a/templates/github-runner-ubuntu-24.04/scripts/download-checked-range
+++ b/templates/github-runner-ubuntu-24.04/scripts/download-checked-range
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${1:?download URL is required}"
+destination="${2:?destination path is required}"
+start="${3:?range start is required}"
+end="${4:?range end is required}"
+attempts="${RUNNER_TEMPLATE_DOWNLOAD_ATTEMPTS:-20}"
+retry_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_DELAY:-2}"
+retry_max_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_MAX_DELAY:-30}"
+
+if [[ ! "$start" =~ ^[0-9]+$ ]] || [[ ! "$end" =~ ^[0-9]+$ ]] || [ "$end" -lt "$start" ]; then
+  echo "invalid byte range: ${start}-${end}" >&2
+  exit 64
+fi
+
+expected_size=$((end - start + 1))
+partial="${destination}.partial"
+install -d -m 0755 "$(dirname "$destination")"
+
+file_size() {
+  if [ -f "$1" ]; then
+    wc -c <"$1" | tr -d '[:space:]'
+  else
+    echo 0
+  fi
+}
+
+if [ "$(file_size "$destination")" -eq "$expected_size" ]; then
+  exit 0
+fi
+rm -f "$destination"
+touch "$partial"
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  current_size="$(file_size "$partial")"
+  if [ "$current_size" -gt "$expected_size" ]; then
+    echo "range server returned too many bytes; restarting chunk" >&2
+    rm -f "$partial"
+    touch "$partial"
+    current_size=0
+  fi
+  if [ "$current_size" -eq "$expected_size" ]; then
+    mv "$partial" "$destination"
+    exit 0
+  fi
+
+  request_start=$((start + current_size))
+  /usr/bin/curl --http1.1 -fsSL --connect-timeout 15 --max-time 1200 \
+    --speed-limit 1024 --speed-time 60 \
+    --range "${request_start}-${end}" "$url" >>"$partial" || true
+
+  current_size="$(file_size "$partial")"
+  if [ "$current_size" -eq "$expected_size" ]; then
+    mv "$partial" "$destination"
+    exit 0
+  fi
+  if [ "$current_size" -gt "$expected_size" ]; then
+    echo "range server returned too many bytes; restarting chunk" >&2
+    rm -f "$partial"
+    touch "$partial"
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "range download interrupted; resuming (${attempt}/${attempts})" >&2
+    if [ "$retry_delay" -gt 0 ]; then
+      sleep "$retry_delay"
+      if [ "$retry_delay" -lt "$retry_max_delay" ]; then
+        retry_delay=$((retry_delay * 2))
+        if [ "$retry_delay" -gt "$retry_max_delay" ]; then
+          retry_delay="$retry_max_delay"
+        fi
+      fi
+    fi
+  fi
+done
+
+echo "range download failed after ${attempts} attempts: ${url} bytes ${start}-${end}" >&2
+exit 1

--- a/templates/github-runner-ubuntu-24.04/scripts/setup-template.sh
+++ b/templates/github-runner-ubuntu-24.04/scripts/setup-template.sh
@@ -1,6 +1,35 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+runner_template_phase="${RUNNER_TEMPLATE_PHASE:-all}"
+case "$runner_template_phase" in
+  all | bootstrap | platform | node | toolchain | runtime) ;;
+  *)
+    echo "unsupported runner template phase: $runner_template_phase" >&2
+    exit 64
+    ;;
+esac
+
+phase_selected() {
+  [ "$runner_template_phase" = all ] || [ "$runner_template_phase" = "$1" ]
+}
+
+installer_phase() {
+  case "$1" in
+    configure-apt-sources.sh | configure-apt.sh | install-apt-vital.sh | install-ms-repos.sh | configure-image-data-file.sh | configure-environment.sh | install-apt-common.sh | install-azure-cli.sh | install-bicep.sh | install-apache.sh | install-aws-tools.sh | install-container-tools.sh | install-git.sh | install-git-lfs.sh | install-github-cli.sh | install-google-cloud-cli.sh)
+      echo platform
+      ;;
+    install-nvm.sh | install-nodejs.sh)
+      echo node
+      ;;
+    *) echo toolchain ;;
+  esac
+}
+
+should_run_installer() {
+  phase_selected "$(installer_phase "$1")"
+}
+
 : "${RUNNER_IMAGES_REV:?RUNNER_IMAGES_REV is required}"
 : "${RUNNER_IMAGES_ARCHIVE_SHA256:?RUNNER_IMAGES_ARCHIVE_SHA256 is required}"
 : "${RUNNER_VERSION:?RUNNER_VERSION is required}"
@@ -14,6 +43,7 @@ set -euxo pipefail
 : "${AZURE_DEVOPS_EXTENSION_SHA256:?AZURE_DEVOPS_EXTENSION_SHA256 is required}"
 : "${BICEP_VERSION:?BICEP_VERSION is required}"
 : "${BICEP_NUGET_SHA256:?BICEP_NUGET_SHA256 is required}"
+: "${PESTER_NUPKG_SHA256:?PESTER_NUPKG_SHA256 is required}"
 : "${GOOGLE_CLOUD_CLI_VERSION:?GOOGLE_CLOUD_CLI_VERSION is required}"
 : "${GOOGLE_CLOUD_CLI_ARCHIVE_SHA256:?GOOGLE_CLOUD_CLI_ARCHIVE_SHA256 is required}"
 : "${NVM_VERSION:?NVM_VERSION is required}"
@@ -300,10 +330,38 @@ install_ninja_from_checked_archive() {
   run_upstream_tests_if_available "Tools" "Ninja"
 }
 
+run_retryable_upstream_installer() {
+  local installer_path="$1"
+  local installer_name="${installer_path##*/}"
+  local attempts="${RUNNER_TEMPLATE_UPSTREAM_INSTALL_ATTEMPTS:-3}"
+  local retry_delay="${RUNNER_TEMPLATE_UPSTREAM_INSTALL_RETRY_DELAY:-2}"
+  local attempt
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if PIP_DEFAULT_TIMEOUT="${PIP_DEFAULT_TIMEOUT:-120}" \
+      PIP_RETRIES="${PIP_RETRIES:-10}" \
+      bash "$installer_path"; then
+      return 0
+    fi
+    if [ "$attempt" -lt "$attempts" ]; then
+      echo "upstream installer interrupted; retrying $installer_name (${attempt}/${attempts})" >&2
+      if [ "$retry_delay" != 0 ]; then
+        sleep "$retry_delay"
+      fi
+    fi
+  done
+  echo "upstream installer failed after ${attempts} attempts: $installer_name" >&2
+  return 1
+}
+
 run_upstream_installer() {
   local installer_path="$1"
   local installer_name="${installer_path##*/}"
   case "$installer_name" in
+    install-azure-cli.sh)
+      install_azure_cli_from_microsoft_package
+      return
+      ;;
     install-aws-tools.sh)
       install_aws_tools_from_checked_archives
       return
@@ -344,15 +402,16 @@ run_upstream_installer() {
       install_ninja_from_checked_archive
       return
       ;;
+    install-python.sh | install-pipx-packages.sh)
+      if run_retryable_upstream_installer "$installer_path"; then
+        return 0
+      fi
+      return 1
+      ;;
   esac
 
   if bash "$installer_path"; then
     return 0
-  fi
-  if [ "$installer_name" = install-azure-cli.sh ]; then
-    echo "upstream Azure CLI installer unavailable; using checked Microsoft package" >&2
-    install_azure_cli_from_microsoft_package
-    return
   fi
   if [ "$installer_name" = install-docker-cli.sh ]; then
     echo "upstream Docker CLI installer unavailable; deferring to sandbox-aware installer" >&2
@@ -477,6 +536,8 @@ install_runner() {
 
 install_pester_for_upstream_tests() {
   local pester_version
+  local package
+  local module_dir
   pester_version="$(
     jq -er '
       .powershellModules[]
@@ -484,10 +545,17 @@ install_pester_for_upstream_tests() {
       | .versions[]
     ' "$INSTALLER_SCRIPT_FOLDER/toolset.json"
   )"
+  package="/tmp/Pester.${pester_version}.nupkg"
+  module_dir="/usr/local/share/powershell/Modules/Pester/${pester_version}"
+  download_checked \
+    "https://www.powershellgallery.com/api/v2/package/Pester/${pester_version}" \
+    "$package" \
+    "$PESTER_NUPKG_SHA256"
+  install -d -m 0755 "$module_dir"
+  unzip -q "$package" -d "$module_dir"
+  rm -f "$package"
   PESTER_VERSION="$pester_version" pwsh -NoLogo -NoProfile -Command '
     $ErrorActionPreference = "Stop"
-    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-    Install-Module -Name Pester -RequiredVersion $env:PESTER_VERSION -Scope AllUsers -SkipPublisherCheck -Force
     Import-Module Pester -RequiredVersion $env:PESTER_VERSION -Force
     if ((Get-Module Pester).Version.ToString() -ne $env:PESTER_VERSION) { exit 1 }
   '
@@ -514,6 +582,7 @@ stop_validated_service() {
   fi
 }
 
+if phase_selected bootstrap; then
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 configure_reliable_apt_sources
@@ -537,22 +606,26 @@ install -d -o runner -g runner \
   /home/runner/_runnerd-hooks \
   /opt/actions-runner
 
-download_checked \
-  "https://codeload.github.com/actions/runner-images/tar.gz/${RUNNER_IMAGES_REV}" \
-  /tmp/runner-images.tar.gz \
-  "$RUNNER_IMAGES_ARCHIVE_SHA256"
-mkdir -p /tmp/runner-images
-tar -xzf /tmp/runner-images.tar.gz -C /tmp/runner-images --strip-components=1
+  download_checked \
+    "https://codeload.github.com/actions/runner-images/tar.gz/${RUNNER_IMAGES_REV}" \
+    /tmp/runner-images.tar.gz \
+    "$RUNNER_IMAGES_ARCHIVE_SHA256"
+  mkdir -p /opt/qiniu-runner-images
+  tar -xzf /tmp/runner-images.tar.gz -C /opt/qiniu-runner-images --strip-components=1
+fi
+test -d /opt/qiniu-runner-images
 
 export DEBIAN_FRONTEND=noninteractive
-export HELPER_SCRIPTS=/tmp/runner-images/images/ubuntu-slim/scripts/helpers
-export INSTALLER_SCRIPT_FOLDER=/tmp/runner-images/images/ubuntu-slim/toolsets
+export HELPER_SCRIPTS=/opt/qiniu-runner-images/images/ubuntu-slim/scripts/helpers
+export INSTALLER_SCRIPT_FOLDER=/opt/qiniu-runner-images/images/ubuntu-slim/toolsets
 export IMAGE_VERSION="${IMAGE_VERSION:-${ImageVersion:-local}}"
 export IMAGE_OS=ubuntu24
 
 if [ "${TEMPLATE_FLAVOR:-}" = slim ]; then
-  upstream_build=/tmp/runner-images/images/ubuntu-slim/scripts/build
-  install_azcopy_from_microsoft_package
+  upstream_build=/opt/qiniu-runner-images/images/ubuntu-slim/scripts/build
+  if phase_selected platform; then
+    install_azcopy_from_microsoft_package
+  fi
   for installer in \
     configure-apt-sources.sh \
     configure-apt.sh \
@@ -578,15 +651,19 @@ if [ "${TEMPLATE_FLAVOR:-}" = slim ]; then
     install-pipx-packages.sh \
     install-docker-cli.sh \
     configure-system.sh; do
+    should_run_installer "$installer" || continue
     run_upstream_installer "$upstream_build/$installer"
     if [ "$installer" = install-azure-cli.sh ]; then
       install_azure_devops_extension
     fi
   done
-  ln -s /etc/skel/.nvm /home/runner/.nvm
+  if phase_selected toolchain; then
+    ln -sfn /etc/skel/.nvm /home/runner/.nvm
+  fi
 else
   . /etc/os-release
   export IMAGE_OS="ubuntu${VERSION_ID/.}"
+  if phase_selected bootstrap; then
   install -d -m 0755 /tmp/qiniu-runner-build-tools
   cat >/tmp/qiniu-runner-build-tools/systemctl <<'SYSTEMCTL'
 #!/bin/sh
@@ -778,7 +855,6 @@ exit 0
 SYSTEMCTL
   chmod 0755 /tmp/qiniu-runner-build-tools/systemctl
   ln -s /tmp/qiniu-runner-build-tools/systemctl /usr/local/bin/systemctl
-  export PATH="/tmp/qiniu-runner-build-tools:$PATH"
   echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90assumeyes
   install -d -m 0755 /etc/cloud/templates
   cat >/etc/waagent.conf <<'WAAGENT'
@@ -786,11 +862,14 @@ ResourceDisk.Format=n
 ResourceDisk.EnableSwap=n
 ResourceDisk.SwapSizeMB=0
 WAAGENT
+  fi
+  export PATH="/tmp/qiniu-runner-build-tools:$PATH"
   release_digits="${VERSION_ID/.}"
-  upstream_build=/tmp/runner-images/images/ubuntu/scripts/build
-  export HELPER_SCRIPTS=/tmp/runner-images/images/ubuntu/scripts/helpers
-  export INSTALLER_SCRIPT_FOLDER=/tmp/runner-images/images/ubuntu/scripts/build
-  cp "/tmp/runner-images/images/ubuntu/toolsets/toolset-${release_digits}.json" \
+  upstream_build=/opt/qiniu-runner-images/images/ubuntu/scripts/build
+  export HELPER_SCRIPTS=/opt/qiniu-runner-images/images/ubuntu/scripts/helpers
+  export INSTALLER_SCRIPT_FOLDER=/opt/qiniu-runner-images/images/ubuntu/scripts/build
+  if phase_selected bootstrap; then
+  cp "/opt/qiniu-runner-images/images/ubuntu/toolsets/toolset-${release_digits}.json" \
     "$INSTALLER_SCRIPT_FOLDER/toolset.json"
   install -d -m 0755 /imagegeneration
   cp -a "$HELPER_SCRIPTS" /imagegeneration/helpers
@@ -829,6 +908,7 @@ WAAGENT
   bash "$upstream_build/install-powershell.sh"
   install_pester_for_upstream_tests
   bash "$HELPER_SCRIPTS/invoke-tests.sh" Tools azcopy
+  fi
 
   for installer in \
     install-apt-common.sh \
@@ -848,6 +928,7 @@ WAAGENT
     install-python.sh \
     install-zstd.sh \
     install-ninja.sh; do
+    should_run_installer "$installer" || continue
     run_upstream_installer "$upstream_build/$installer"
     case "$installer" in
       install-azure-cli.sh)
@@ -857,11 +938,14 @@ WAAGENT
       install-apache.sh) stop_validated_service apache2 ;;
     esac
   done
+  if phase_selected toolchain; then
   . "$HELPER_SCRIPTS/etc-environment.sh"
   reload_etc_environment
-  bash "$upstream_build/install-pipx-packages.sh"
+  run_upstream_installer "$upstream_build/install-pipx-packages.sh"
+  fi
 fi
 
+if phase_selected runtime; then
 install_docker_for_sandbox
 install_runner
 install -m 0755 \
@@ -876,8 +960,8 @@ chmod -R a+rX /opt/actions-runner /opt/hostedtoolcache
 
 apt-get clean
 find /var/lib/apt/lists -mindepth 1 -delete
-find /tmp/runner-images -mindepth 1 -delete
-find /tmp/runner-images -depth -type d -empty -delete
+find /opt/qiniu-runner-images -mindepth 1 -delete
+find /opt/qiniu-runner-images -depth -type d -empty -delete
 if [ -d /imagegeneration ]; then
   find /imagegeneration -mindepth 1 -delete
   rmdir /imagegeneration
@@ -886,3 +970,4 @@ rm -f /usr/local/bin/systemctl
 find /tmp/qiniu-runner-build-tools -mindepth 1 -delete 2>/dev/null || true
 rmdir /tmp/qiniu-runner-build-tools 2>/dev/null || true
 rm -f /tmp/actions-runner.tar.gz /tmp/docker.gpg /tmp/runner-images.tar.gz
+fi

--- a/templates/github-runner-ubuntu-24.04/scripts/setup-template.sh
+++ b/templates/github-runner-ubuntu-24.04/scripts/setup-template.sh
@@ -72,6 +72,7 @@ download_checked() {
   local expected_sha256="$3"
   local attempts="${RUNNER_TEMPLATE_DOWNLOAD_ATTEMPTS:-20}"
   local retry_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_DELAY:-2}"
+  local retry_max_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_MAX_DELAY:-30}"
   local attempt
   local curl_status
 
@@ -102,6 +103,12 @@ download_checked() {
       echo "download interrupted; resuming (${attempt}/${attempts})" >&2
       if [ "$retry_delay" != 0 ]; then
         sleep "$retry_delay"
+        if [ "$retry_delay" -lt "$retry_max_delay" ]; then
+          retry_delay=$((retry_delay * 2))
+          if [ "$retry_delay" -gt "$retry_max_delay" ]; then
+            retry_delay="$retry_max_delay"
+          fi
+        fi
       fi
     fi
   done
@@ -506,6 +513,21 @@ configure_docker_apt_repository() {
   apt-cache show docker-ce >/dev/null 2>&1
 }
 
+remove_official_docker_packages() {
+  local official_docker_packages=(
+    containerd.io
+    docker-buildx-plugin
+    docker-ce
+    docker-ce-cli
+    docker-ce-rootless-extras
+    docker-compose-plugin
+  )
+  if ! apt-get purge -y "${official_docker_packages[@]}"; then
+    dpkg --purge --force-depends "${official_docker_packages[@]}" || true
+  fi
+  apt-get -f install -y
+}
+
 install_docker_for_sandbox() {
   if configure_docker_apt_repository && \
     apt-get install -y --no-install-recommends \
@@ -513,6 +535,7 @@ install_docker_for_sandbox() {
     echo "installed Docker packages from the official Docker repository"
   else
     echo "official Docker packages unavailable; using Ubuntu archive packages" >&2
+    remove_official_docker_packages
     rm -f /etc/apt/sources.list.d/docker.list /etc/apt/keyrings/docker.gpg
     apt-get update
     apt-get install -y --no-install-recommends docker.io docker-buildx docker-compose-v2

--- a/templates/github-runner-ubuntu-26.04/Dockerfile
+++ b/templates/github-runner-ubuntu-26.04/Dockerfile
@@ -2,11 +2,11 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:26.04@sha256:a5da6f6b18c3a4b8dcc73244592f7096f417d2667966d0e33460e9e308f25f67
 
-ARG TEMPLATE_VERSION=20260727.1
+ARG TEMPLATE_VERSION=20260804.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
-ARG RUNNER_VERSION=2.334.0
-ARG RUNNER_ARCHIVE_SHA256=048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271
+ARG RUNNER_VERSION=2.336.0
+ARG RUNNER_ARCHIVE_SHA256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d
 ARG AZCOPY_VERSION=10.32.6
 ARG AZCOPY_DEB_SHA256=1a5078a8260ba7524a4400c602519d36905e592cd87a1db91a30af0da528fc86
 ARG AZURE_CLI_VERSION=2.88.0
@@ -16,6 +16,7 @@ ARG AZURE_DEVOPS_EXTENSION_VERSION=1.0.6
 ARG AZURE_DEVOPS_EXTENSION_SHA256=fa779e1fd6e6e1b726c3656b6a1968537c208041c6af54d2a7476772d896b34b
 ARG BICEP_VERSION=0.45.15
 ARG BICEP_NUGET_SHA256=2055d8e4b2b984591d06b8c054dfb6db3b68f2bf236309ae185f06a161ae714a
+ARG PESTER_NUPKG_SHA256=5a0fd80b361600bf4bbd4c307c1fd01b17f11668bab19e657add41b00ad22ab9
 ARG GOOGLE_CLOUD_CLI_VERSION=577.0.0
 ARG GOOGLE_CLOUD_CLI_ARCHIVE_SHA256=0b32d330446ce7b0f57f253e7efab4636c18fb1f87a3ac31c6c3f2a2a697525e
 ARG NVM_VERSION=0.40.6
@@ -54,7 +55,11 @@ COPY scripts/setup-template.sh /usr/local/share/qiniu-sandbox-runner-template/se
 COPY scripts/ensure-docker /usr/local/share/qiniu-sandbox-runner-template/ensure-docker
 COPY scripts/curl /usr/local/share/qiniu-sandbox-runner-template/curl
 
-RUN TEMPLATE_FLAVOR=versioned bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=bootstrap bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=node bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-26.04/Dockerfile
+++ b/templates/github-runner-ubuntu-26.04/Dockerfile
@@ -2,7 +2,6 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:26.04@sha256:a5da6f6b18c3a4b8dcc73244592f7096f417d2667966d0e33460e9e308f25f67
 
-ARG TEMPLATE_VERSION=20260805.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
 ARG RUNNER_VERSION=2.336.0
@@ -27,6 +26,7 @@ ARG AWS_SESSION_MANAGER_PLUGIN_VERSION=1.2.835.0
 ARG AWS_SESSION_MANAGER_PLUGIN_DEB_SHA256=7c6dcad12518571cc7959a713e6a8ae1bdf6ed66fd9bee37dc189e39ca58ae03
 ARG AWS_SAM_CLI_VERSION=1.163.0
 ARG AWS_SAM_CLI_ARCHIVE_SHA256=3f12863f45da82bc2ad1fb837444cca57450bd07fef73449b917362ef2f5ab70
+ARG AWS_SAM_CLI_ARCHIVE_SIZE=93672108
 ARG GITHUB_CLI_VERSION=2.96.0
 ARG GITHUB_CLI_DEB_SHA256=11a731f4e0ca8c3db96ef6d2cc404dcab3d78247ce0e07c53e07117e7627d6a1
 ARG YQ_VERSION=4.53.3
@@ -42,8 +42,6 @@ ARG DOCKER_GPG_FINGERPRINT=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
 ENV DEBIAN_FRONTEND=noninteractive \
     ImageOS=ubuntu26 \
-    ImageVersion=$TEMPLATE_VERSION \
-    IMAGE_VERSION=$TEMPLATE_VERSION \
     IMAGE_TEMPLATE=github-runner-ubuntu-26-04 \
     RUNNER_TOOL_CACHE=/opt/hostedtoolcache \
     AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache \
@@ -53,6 +51,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 COPY scripts/setup-template.sh /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 COPY scripts/ensure-docker /usr/local/share/qiniu-sandbox-runner-template/ensure-docker
+COPY scripts/download-checked-range /usr/local/share/qiniu-sandbox-runner-template/download-checked-range
 COPY scripts/curl /usr/local/share/qiniu-sandbox-runner-template/curl
 
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=bootstrap bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
@@ -160,10 +159,43 @@ RUN set -eux; \
     test "$(grep -Fxc '    apt-get install --no-install-recommends $package' "$installer")" -eq 1; \
     sed -i 's|    apt-get install --no-install-recommends \$package|    apt-get install --no-install-recommends ${package/netcat/netcat-openbsd}|' "$installer"; \
     test "$(grep -Fxc '    apt-get install --no-install-recommends ${package/netcat/netcat-openbsd}' "$installer")" -eq 1
-RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN install -d -m 0755 /opt/qiniu-runner-build-cache
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-00 0 16777215
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-01 16777216 33554431
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-02 33554432 50331647
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-03 50331648 67108863
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-04 67108864 83886079
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-05 83886080 93672107
+RUN set -eux; \
+    cat /opt/qiniu-runner-build-cache/aws-sam-cli.part-* > /tmp/qiniu-aws-sam-cli.zip; \
+    test "$(wc -c </tmp/qiniu-aws-sam-cli.zip | tr -d '[:space:]')" -eq "$AWS_SAM_CLI_ARCHIVE_SIZE"; \
+    echo "$AWS_SAM_CLI_ARCHIVE_SHA256  /tmp/qiniu-aws-sam-cli.zip" | sha256sum --check -; \
+    rm -f /opt/qiniu-runner-build-cache/aws-sam-cli.part-*; \
+    rmdir /opt/qiniu-runner-build-cache; \
+    TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=node bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN set -eux; \
+    rm -rf /home/runner/.nvm; \
+    cp -a /etc/skel/.nvm /home/runner/.nvm; \
+    chown -R runner:runner /home/runner/.nvm
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+
+ARG TEMPLATE_VERSION=20260805.6
+ENV ImageVersion=$TEMPLATE_VERSION \
+    IMAGE_VERSION=$TEMPLATE_VERSION
 
 RUN set -eux; \
     environment_file=/etc/environment; \

--- a/templates/github-runner-ubuntu-26.04/Dockerfile
+++ b/templates/github-runner-ubuntu-26.04/Dockerfile
@@ -2,7 +2,7 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:26.04@sha256:a5da6f6b18c3a4b8dcc73244592f7096f417d2667966d0e33460e9e308f25f67
 
-ARG TEMPLATE_VERSION=20260804.1
+ARG TEMPLATE_VERSION=20260805.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
 ARG RUNNER_VERSION=2.336.0
@@ -56,10 +56,129 @@ COPY scripts/ensure-docker /usr/local/share/qiniu-sandbox-runner-template/ensure
 COPY scripts/curl /usr/local/share/qiniu-sandbox-runner-template/curl
 
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=bootstrap bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[0:7][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[7:8][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[8:14][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[14:15][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[15:18][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[18:21][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[21:22][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[22:23][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[23:24][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[24:27][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[27:28][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[28:30][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[30:32][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[32:33][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    patched_toolset="${toolset}.patched"; \
+    jq '(.apt.common_packages, .apt.cmd_packages) |= map(if . == "netcat" then "netcat-openbsd" else . end)' \
+      "$toolset" >"$patched_toolset"; \
+    mv "$patched_toolset" "$toolset"; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[33:45][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[45:56][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[56:57][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    packages="$(jq -r '[.apt.common_packages[], .apt.cmd_packages[]] | .[57:][]' "$toolset")"; \
+    test -n "$packages"; \
+    apt-get install -y --no-install-recommends $packages
+RUN set -eux; \
+    toolset=/opt/qiniu-runner-images/images/ubuntu/scripts/build/toolset.json; \
+    patched_toolset="${toolset}.patched"; \
+    jq '(.apt.common_packages, .apt.cmd_packages) |= map(if . == "netcat-openbsd" then "netcat" else . end)' \
+      "$toolset" >"$patched_toolset"; \
+    mv "$patched_toolset" "$toolset"; \
+    installer=/opt/qiniu-runner-images/images/ubuntu/scripts/build/install-apt-common.sh; \
+    test "$(grep -Fxc '    apt-get install --no-install-recommends $package' "$installer")" -eq 1; \
+    sed -i 's|    apt-get install --no-install-recommends \$package|    apt-get install --no-install-recommends ${package/netcat/netcat-openbsd}|' "$installer"; \
+    test "$(grep -Fxc '    apt-get install --no-install-recommends ${package/netcat/netcat-openbsd}' "$installer")" -eq 1
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=node bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+
+RUN set -eux; \
+    environment_file=/etc/environment; \
+    touch "$environment_file"; \
+    sed -i -e '/^ImageOS=/d' -e '/^ImageVersion=/d' -e '/^IMAGE_VERSION=/d' \
+      -e '/^IMAGE_TEMPLATE=/d' -e '/^RUNNER_TOOL_CACHE=/d' \
+      -e '/^AGENT_TOOLSDIRECTORY=/d' "$environment_file"; \
+    printf '%s\n' \
+      "ImageOS=\"$ImageOS\"" \
+      "ImageVersion=\"$TEMPLATE_VERSION\"" \
+      "IMAGE_VERSION=\"$TEMPLATE_VERSION\"" \
+      "IMAGE_TEMPLATE=\"$IMAGE_TEMPLATE\"" \
+      "RUNNER_TOOL_CACHE=\"$RUNNER_TOOL_CACHE\"" \
+      "AGENT_TOOLSDIRECTORY=\"$AGENT_TOOLSDIRECTORY\"" \
+      >>"$environment_file"
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-26.04/scripts/download-checked-range
+++ b/templates/github-runner-ubuntu-26.04/scripts/download-checked-range
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${1:?download URL is required}"
+destination="${2:?destination path is required}"
+start="${3:?range start is required}"
+end="${4:?range end is required}"
+attempts="${RUNNER_TEMPLATE_DOWNLOAD_ATTEMPTS:-20}"
+retry_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_DELAY:-2}"
+retry_max_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_MAX_DELAY:-30}"
+
+if [[ ! "$start" =~ ^[0-9]+$ ]] || [[ ! "$end" =~ ^[0-9]+$ ]] || [ "$end" -lt "$start" ]; then
+  echo "invalid byte range: ${start}-${end}" >&2
+  exit 64
+fi
+
+expected_size=$((end - start + 1))
+partial="${destination}.partial"
+install -d -m 0755 "$(dirname "$destination")"
+
+file_size() {
+  if [ -f "$1" ]; then
+    wc -c <"$1" | tr -d '[:space:]'
+  else
+    echo 0
+  fi
+}
+
+if [ "$(file_size "$destination")" -eq "$expected_size" ]; then
+  exit 0
+fi
+rm -f "$destination"
+touch "$partial"
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  current_size="$(file_size "$partial")"
+  if [ "$current_size" -gt "$expected_size" ]; then
+    echo "range server returned too many bytes; restarting chunk" >&2
+    rm -f "$partial"
+    touch "$partial"
+    current_size=0
+  fi
+  if [ "$current_size" -eq "$expected_size" ]; then
+    mv "$partial" "$destination"
+    exit 0
+  fi
+
+  request_start=$((start + current_size))
+  /usr/bin/curl --http1.1 -fsSL --connect-timeout 15 --max-time 1200 \
+    --speed-limit 1024 --speed-time 60 \
+    --range "${request_start}-${end}" "$url" >>"$partial" || true
+
+  current_size="$(file_size "$partial")"
+  if [ "$current_size" -eq "$expected_size" ]; then
+    mv "$partial" "$destination"
+    exit 0
+  fi
+  if [ "$current_size" -gt "$expected_size" ]; then
+    echo "range server returned too many bytes; restarting chunk" >&2
+    rm -f "$partial"
+    touch "$partial"
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "range download interrupted; resuming (${attempt}/${attempts})" >&2
+    if [ "$retry_delay" -gt 0 ]; then
+      sleep "$retry_delay"
+      if [ "$retry_delay" -lt "$retry_max_delay" ]; then
+        retry_delay=$((retry_delay * 2))
+        if [ "$retry_delay" -gt "$retry_max_delay" ]; then
+          retry_delay="$retry_max_delay"
+        fi
+      fi
+    fi
+  fi
+done
+
+echo "range download failed after ${attempts} attempts: ${url} bytes ${start}-${end}" >&2
+exit 1

--- a/templates/github-runner-ubuntu-26.04/scripts/setup-template.sh
+++ b/templates/github-runner-ubuntu-26.04/scripts/setup-template.sh
@@ -1,6 +1,35 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+runner_template_phase="${RUNNER_TEMPLATE_PHASE:-all}"
+case "$runner_template_phase" in
+  all | bootstrap | platform | node | toolchain | runtime) ;;
+  *)
+    echo "unsupported runner template phase: $runner_template_phase" >&2
+    exit 64
+    ;;
+esac
+
+phase_selected() {
+  [ "$runner_template_phase" = all ] || [ "$runner_template_phase" = "$1" ]
+}
+
+installer_phase() {
+  case "$1" in
+    configure-apt-sources.sh | configure-apt.sh | install-apt-vital.sh | install-ms-repos.sh | configure-image-data-file.sh | configure-environment.sh | install-apt-common.sh | install-azure-cli.sh | install-bicep.sh | install-apache.sh | install-aws-tools.sh | install-container-tools.sh | install-git.sh | install-git-lfs.sh | install-github-cli.sh | install-google-cloud-cli.sh)
+      echo platform
+      ;;
+    install-nvm.sh | install-nodejs.sh)
+      echo node
+      ;;
+    *) echo toolchain ;;
+  esac
+}
+
+should_run_installer() {
+  phase_selected "$(installer_phase "$1")"
+}
+
 : "${RUNNER_IMAGES_REV:?RUNNER_IMAGES_REV is required}"
 : "${RUNNER_IMAGES_ARCHIVE_SHA256:?RUNNER_IMAGES_ARCHIVE_SHA256 is required}"
 : "${RUNNER_VERSION:?RUNNER_VERSION is required}"
@@ -14,6 +43,7 @@ set -euxo pipefail
 : "${AZURE_DEVOPS_EXTENSION_SHA256:?AZURE_DEVOPS_EXTENSION_SHA256 is required}"
 : "${BICEP_VERSION:?BICEP_VERSION is required}"
 : "${BICEP_NUGET_SHA256:?BICEP_NUGET_SHA256 is required}"
+: "${PESTER_NUPKG_SHA256:?PESTER_NUPKG_SHA256 is required}"
 : "${GOOGLE_CLOUD_CLI_VERSION:?GOOGLE_CLOUD_CLI_VERSION is required}"
 : "${GOOGLE_CLOUD_CLI_ARCHIVE_SHA256:?GOOGLE_CLOUD_CLI_ARCHIVE_SHA256 is required}"
 : "${NVM_VERSION:?NVM_VERSION is required}"
@@ -302,10 +332,38 @@ install_ninja_from_checked_archive() {
   run_upstream_tests_if_available "Tools" "Ninja"
 }
 
+run_retryable_upstream_installer() {
+  local installer_path="$1"
+  local installer_name="${installer_path##*/}"
+  local attempts="${RUNNER_TEMPLATE_UPSTREAM_INSTALL_ATTEMPTS:-3}"
+  local retry_delay="${RUNNER_TEMPLATE_UPSTREAM_INSTALL_RETRY_DELAY:-2}"
+  local attempt
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if PIP_DEFAULT_TIMEOUT="${PIP_DEFAULT_TIMEOUT:-120}" \
+      PIP_RETRIES="${PIP_RETRIES:-10}" \
+      bash "$installer_path"; then
+      return 0
+    fi
+    if [ "$attempt" -lt "$attempts" ]; then
+      echo "upstream installer interrupted; retrying $installer_name (${attempt}/${attempts})" >&2
+      if [ "$retry_delay" != 0 ]; then
+        sleep "$retry_delay"
+      fi
+    fi
+  done
+  echo "upstream installer failed after ${attempts} attempts: $installer_name" >&2
+  return 1
+}
+
 run_upstream_installer() {
   local installer_path="$1"
   local installer_name="${installer_path##*/}"
   case "$installer_name" in
+    install-azure-cli.sh)
+      install_azure_cli_from_microsoft_package
+      return
+      ;;
     install-aws-tools.sh)
       install_aws_tools_from_checked_archives
       return
@@ -346,15 +404,16 @@ run_upstream_installer() {
       install_ninja_from_checked_archive
       return
       ;;
+    install-python.sh | install-pipx-packages.sh)
+      if run_retryable_upstream_installer "$installer_path"; then
+        return 0
+      fi
+      return 1
+      ;;
   esac
 
   if bash "$installer_path"; then
     return 0
-  fi
-  if [ "$installer_name" = install-azure-cli.sh ]; then
-    echo "upstream Azure CLI installer unavailable; using checked Microsoft package" >&2
-    install_azure_cli_from_microsoft_package
-    return
   fi
   if [ "$installer_name" = install-docker-cli.sh ]; then
     echo "upstream Docker CLI installer unavailable; deferring to sandbox-aware installer" >&2
@@ -415,8 +474,8 @@ APT_PREFERENCE
 
 configure_reliable_apt_sources() {
   cat >/etc/apt/apt-mirrors.txt <<'APT_MIRRORS'
-https://mirrors.tuna.tsinghua.edu.cn/ubuntu/	priority:1
-https://mirrors.edge.kernel.org/ubuntu/	priority:2
+https://mirrors.edge.kernel.org/ubuntu/	priority:1
+https://mirrors.tuna.tsinghua.edu.cn/ubuntu/	priority:2
 https://archive.ubuntu.com/ubuntu/	priority:3
 APT_MIRRORS
   local source_file
@@ -428,6 +487,9 @@ APT_MIRRORS
       -e 's|https://archive.ubuntu.com/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g' \
       -e 's|http://security.ubuntu.com/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g' \
       -e 's|https://security.ubuntu.com/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g' \
+      -e 's|http://mirrors.tuna.tsinghua.edu.cn/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g' \
+      -e 's|https://mirrors.tuna.tsinghua.edu.cn/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g' \
+      -e 's|https://mirrors.edge.kernel.org/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g' \
       "$source_file"
   done
   cat >/etc/apt/apt.conf.d/80qiniu-network <<'APT_NETWORK'
@@ -496,6 +558,8 @@ install_runner() {
 
 install_pester_for_upstream_tests() {
   local pester_version
+  local package
+  local module_dir
   pester_version="$(
     jq -er '
       .powershellModules[]
@@ -503,10 +567,17 @@ install_pester_for_upstream_tests() {
       | .versions[]
     ' "$INSTALLER_SCRIPT_FOLDER/toolset.json"
   )"
+  package="/tmp/Pester.${pester_version}.nupkg"
+  module_dir="/usr/local/share/powershell/Modules/Pester/${pester_version}"
+  download_checked \
+    "https://www.powershellgallery.com/api/v2/package/Pester/${pester_version}" \
+    "$package" \
+    "$PESTER_NUPKG_SHA256"
+  install -d -m 0755 "$module_dir"
+  unzip -q "$package" -d "$module_dir"
+  rm -f "$package"
   PESTER_VERSION="$pester_version" pwsh -NoLogo -NoProfile -Command '
     $ErrorActionPreference = "Stop"
-    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-    Install-Module -Name Pester -RequiredVersion $env:PESTER_VERSION -Scope AllUsers -SkipPublisherCheck -Force
     Import-Module Pester -RequiredVersion $env:PESTER_VERSION -Force
     if ((Get-Module Pester).Version.ToString() -ne $env:PESTER_VERSION) { exit 1 }
   '
@@ -533,6 +604,7 @@ stop_validated_service() {
   fi
 }
 
+if phase_selected bootstrap; then
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 configure_reliable_apt_sources
@@ -556,22 +628,26 @@ install -d -o runner -g runner \
   /home/runner/_runnerd-hooks \
   /opt/actions-runner
 
-download_checked \
-  "https://codeload.github.com/actions/runner-images/tar.gz/${RUNNER_IMAGES_REV}" \
-  /tmp/runner-images.tar.gz \
-  "$RUNNER_IMAGES_ARCHIVE_SHA256"
-mkdir -p /tmp/runner-images
-tar -xzf /tmp/runner-images.tar.gz -C /tmp/runner-images --strip-components=1
+  download_checked \
+    "https://codeload.github.com/actions/runner-images/tar.gz/${RUNNER_IMAGES_REV}" \
+    /tmp/runner-images.tar.gz \
+    "$RUNNER_IMAGES_ARCHIVE_SHA256"
+  mkdir -p /opt/qiniu-runner-images
+  tar -xzf /tmp/runner-images.tar.gz -C /opt/qiniu-runner-images --strip-components=1
+fi
+test -d /opt/qiniu-runner-images
 
 export DEBIAN_FRONTEND=noninteractive
-export HELPER_SCRIPTS=/tmp/runner-images/images/ubuntu-slim/scripts/helpers
-export INSTALLER_SCRIPT_FOLDER=/tmp/runner-images/images/ubuntu-slim/toolsets
+export HELPER_SCRIPTS=/opt/qiniu-runner-images/images/ubuntu-slim/scripts/helpers
+export INSTALLER_SCRIPT_FOLDER=/opt/qiniu-runner-images/images/ubuntu-slim/toolsets
 export IMAGE_VERSION="${IMAGE_VERSION:-${ImageVersion:-local}}"
 export IMAGE_OS=ubuntu24
 
 if [ "${TEMPLATE_FLAVOR:-}" = slim ]; then
-  upstream_build=/tmp/runner-images/images/ubuntu-slim/scripts/build
-  install_azcopy_from_microsoft_package
+  upstream_build=/opt/qiniu-runner-images/images/ubuntu-slim/scripts/build
+  if phase_selected platform; then
+    install_azcopy_from_microsoft_package
+  fi
   for installer in \
     configure-apt-sources.sh \
     configure-apt.sh \
@@ -597,15 +673,19 @@ if [ "${TEMPLATE_FLAVOR:-}" = slim ]; then
     install-pipx-packages.sh \
     install-docker-cli.sh \
     configure-system.sh; do
+    should_run_installer "$installer" || continue
     run_upstream_installer "$upstream_build/$installer"
     if [ "$installer" = install-azure-cli.sh ]; then
       install_azure_devops_extension
     fi
   done
-  ln -s /etc/skel/.nvm /home/runner/.nvm
+  if phase_selected toolchain; then
+    ln -sfn /etc/skel/.nvm /home/runner/.nvm
+  fi
 else
   . /etc/os-release
   export IMAGE_OS="ubuntu${VERSION_ID/.}"
+  if phase_selected bootstrap; then
   install -d -m 0755 /tmp/qiniu-runner-build-tools
   cat >/tmp/qiniu-runner-build-tools/systemctl <<'SYSTEMCTL'
 #!/bin/sh
@@ -797,7 +877,6 @@ exit 0
 SYSTEMCTL
   chmod 0755 /tmp/qiniu-runner-build-tools/systemctl
   ln -s /tmp/qiniu-runner-build-tools/systemctl /usr/local/bin/systemctl
-  export PATH="/tmp/qiniu-runner-build-tools:$PATH"
   echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90assumeyes
   install -d -m 0755 /etc/cloud/templates
   cat >/etc/waagent.conf <<'WAAGENT'
@@ -805,11 +884,14 @@ ResourceDisk.Format=n
 ResourceDisk.EnableSwap=n
 ResourceDisk.SwapSizeMB=0
 WAAGENT
+  fi
+  export PATH="/tmp/qiniu-runner-build-tools:$PATH"
   release_digits="${VERSION_ID/.}"
-  upstream_build=/tmp/runner-images/images/ubuntu/scripts/build
-  export HELPER_SCRIPTS=/tmp/runner-images/images/ubuntu/scripts/helpers
-  export INSTALLER_SCRIPT_FOLDER=/tmp/runner-images/images/ubuntu/scripts/build
-  cp "/tmp/runner-images/images/ubuntu/toolsets/toolset-${release_digits}.json" \
+  upstream_build=/opt/qiniu-runner-images/images/ubuntu/scripts/build
+  export HELPER_SCRIPTS=/opt/qiniu-runner-images/images/ubuntu/scripts/helpers
+  export INSTALLER_SCRIPT_FOLDER=/opt/qiniu-runner-images/images/ubuntu/scripts/build
+  if phase_selected bootstrap; then
+  cp "/opt/qiniu-runner-images/images/ubuntu/toolsets/toolset-${release_digits}.json" \
     "$INSTALLER_SCRIPT_FOLDER/toolset.json"
   install -d -m 0755 /imagegeneration
   cp -a "$HELPER_SCRIPTS" /imagegeneration/helpers
@@ -848,6 +930,7 @@ WAAGENT
   install_pinned_powershell_package
   install_pester_for_upstream_tests
   bash "$HELPER_SCRIPTS/invoke-tests.sh" Tools azcopy
+  fi
 
   for installer in \
     install-apt-common.sh \
@@ -867,6 +950,7 @@ WAAGENT
     install-python.sh \
     install-zstd.sh \
     install-ninja.sh; do
+    should_run_installer "$installer" || continue
     run_upstream_installer "$upstream_build/$installer"
     case "$installer" in
       install-azure-cli.sh)
@@ -876,11 +960,14 @@ WAAGENT
       install-apache.sh) stop_validated_service apache2 ;;
     esac
   done
+  if phase_selected toolchain; then
   . "$HELPER_SCRIPTS/etc-environment.sh"
   reload_etc_environment
-  bash "$upstream_build/install-pipx-packages.sh"
+  run_upstream_installer "$upstream_build/install-pipx-packages.sh"
+  fi
 fi
 
+if phase_selected runtime; then
 install_docker_for_sandbox
 install_runner
 install -m 0755 \
@@ -895,8 +982,8 @@ chmod -R a+rX /opt/actions-runner /opt/hostedtoolcache
 
 apt-get clean
 find /var/lib/apt/lists -mindepth 1 -delete
-find /tmp/runner-images -mindepth 1 -delete
-find /tmp/runner-images -depth -type d -empty -delete
+find /opt/qiniu-runner-images -mindepth 1 -delete
+find /opt/qiniu-runner-images -depth -type d -empty -delete
 if [ -d /imagegeneration ]; then
   find /imagegeneration -mindepth 1 -delete
   rmdir /imagegeneration
@@ -905,3 +992,4 @@ rm -f /usr/local/bin/systemctl
 find /tmp/qiniu-runner-build-tools -mindepth 1 -delete 2>/dev/null || true
 rmdir /tmp/qiniu-runner-build-tools 2>/dev/null || true
 rm -f /tmp/actions-runner.tar.gz /tmp/docker.gpg /tmp/runner-images.tar.gz
+fi

--- a/templates/github-runner-ubuntu-26.04/scripts/setup-template.sh
+++ b/templates/github-runner-ubuntu-26.04/scripts/setup-template.sh
@@ -481,8 +481,8 @@ APT_PREFERENCE
 
 configure_reliable_apt_sources() {
   cat >/etc/apt/apt-mirrors.txt <<'APT_MIRRORS'
-https://mirrors.edge.kernel.org/ubuntu/	priority:1
-https://mirrors.tuna.tsinghua.edu.cn/ubuntu/	priority:2
+https://mirrors.tuna.tsinghua.edu.cn/ubuntu/	priority:1
+https://mirrors.edge.kernel.org/ubuntu/	priority:2
 https://archive.ubuntu.com/ubuntu/	priority:3
 APT_MIRRORS
   local source_file

--- a/templates/github-runner-ubuntu-26.04/scripts/setup-template.sh
+++ b/templates/github-runner-ubuntu-26.04/scripts/setup-template.sh
@@ -74,6 +74,7 @@ download_checked() {
   local expected_sha256="$3"
   local attempts="${RUNNER_TEMPLATE_DOWNLOAD_ATTEMPTS:-20}"
   local retry_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_DELAY:-2}"
+  local retry_max_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_MAX_DELAY:-30}"
   local attempt
   local curl_status
 
@@ -104,6 +105,12 @@ download_checked() {
       echo "download interrupted; resuming (${attempt}/${attempts})" >&2
       if [ "$retry_delay" != 0 ]; then
         sleep "$retry_delay"
+        if [ "$retry_delay" -lt "$retry_max_delay" ]; then
+          retry_delay=$((retry_delay * 2))
+          if [ "$retry_delay" -gt "$retry_max_delay" ]; then
+            retry_delay="$retry_max_delay"
+          fi
+        fi
       fi
     fi
   done
@@ -528,6 +535,21 @@ configure_docker_apt_repository() {
   apt-cache show docker-ce >/dev/null 2>&1
 }
 
+remove_official_docker_packages() {
+  local official_docker_packages=(
+    containerd.io
+    docker-buildx-plugin
+    docker-ce
+    docker-ce-cli
+    docker-ce-rootless-extras
+    docker-compose-plugin
+  )
+  if ! apt-get purge -y "${official_docker_packages[@]}"; then
+    dpkg --purge --force-depends "${official_docker_packages[@]}" || true
+  fi
+  apt-get -f install -y
+}
+
 install_docker_for_sandbox() {
   if configure_docker_apt_repository && \
     apt-get install -y --no-install-recommends \
@@ -535,6 +557,7 @@ install_docker_for_sandbox() {
     echo "installed Docker packages from the official Docker repository"
   else
     echo "official Docker packages unavailable; using Ubuntu archive packages" >&2
+    remove_official_docker_packages
     rm -f /etc/apt/sources.list.d/docker.list /etc/apt/keyrings/docker.gpg
     apt-get update
     apt-get install -y --no-install-recommends docker.io docker-buildx docker-compose-v2

--- a/templates/github-runner-ubuntu-slim/Dockerfile
+++ b/templates/github-runner-ubuntu-slim/Dockerfile
@@ -2,11 +2,11 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:be20a0347f238b7d373edddc55923443b21dd9a60277bf8a93e43458cd0bf2fc
 
-ARG TEMPLATE_VERSION=20260727.1
+ARG TEMPLATE_VERSION=20260804.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
-ARG RUNNER_VERSION=2.334.0
-ARG RUNNER_ARCHIVE_SHA256=048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271
+ARG RUNNER_VERSION=2.336.0
+ARG RUNNER_ARCHIVE_SHA256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d
 ARG AZCOPY_VERSION=10.32.6
 ARG AZCOPY_DEB_SHA256=1a5078a8260ba7524a4400c602519d36905e592cd87a1db91a30af0da528fc86
 ARG AZURE_CLI_VERSION=2.88.0
@@ -51,7 +51,10 @@ COPY scripts/setup-template.sh /usr/local/share/qiniu-sandbox-runner-template/se
 COPY scripts/ensure-docker /usr/local/share/qiniu-sandbox-runner-template/ensure-docker
 COPY scripts/curl /usr/local/share/qiniu-sandbox-runner-template/curl
 
-RUN TEMPLATE_FLAVOR=slim bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=bootstrap bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-slim/Dockerfile
+++ b/templates/github-runner-ubuntu-slim/Dockerfile
@@ -2,7 +2,6 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:be20a0347f238b7d373edddc55923443b21dd9a60277bf8a93e43458cd0bf2fc
 
-ARG TEMPLATE_VERSION=20260805.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
 ARG RUNNER_VERSION=2.336.0
@@ -26,6 +25,7 @@ ARG AWS_SESSION_MANAGER_PLUGIN_VERSION=1.2.764.0
 ARG AWS_SESSION_MANAGER_PLUGIN_DEB_SHA256=beed4c95c42afd29756d9ecea59c3fcbf937b2c35b9ef84d12b93ac6e74726ba
 ARG AWS_SAM_CLI_VERSION=1.151.0
 ARG AWS_SAM_CLI_ARCHIVE_SHA256=679c54a86512e0f73616856d460b81b438fd5b9b004de5dcb624892dddfbb584
+ARG AWS_SAM_CLI_ARCHIVE_SIZE=207357695
 ARG GITHUB_CLI_VERSION=2.85.0
 ARG GITHUB_CLI_DEB_SHA256=4ed5ff89ef53da00af9d93ac1beaa5665694f18cee8cc8d644a201541d43148c
 ARG YQ_VERSION=4.50.1
@@ -37,8 +37,6 @@ ARG DOCKER_GPG_FINGERPRINT=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 
 ENV DEBIAN_FRONTEND=noninteractive \
     ImageOS=ubuntu24 \
-    ImageVersion=$TEMPLATE_VERSION \
-    IMAGE_VERSION=$TEMPLATE_VERSION \
     IMAGE_TEMPLATE=github-runner-ubuntu-slim \
     RUNNER_TOOL_CACHE=/opt/hostedtoolcache \
     AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache \
@@ -49,12 +47,67 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 COPY scripts/setup-template.sh /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 COPY scripts/ensure-docker /usr/local/share/qiniu-sandbox-runner-template/ensure-docker
+COPY scripts/download-checked-range /usr/local/share/qiniu-sandbox-runner-template/download-checked-range
 COPY scripts/curl /usr/local/share/qiniu-sandbox-runner-template/curl
 
 RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=bootstrap bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
-RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN install -d -m 0755 /opt/qiniu-runner-build-cache
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-00 0 16777215
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-01 16777216 33554431
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-02 33554432 50331647
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-03 50331648 67108863
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-04 67108864 83886079
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-05 83886080 100663295
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-06 100663296 117440511
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-07 117440512 134217727
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-08 134217728 150994943
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-09 150994944 167772159
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-10 167772160 184549375
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-11 184549376 201326591
+RUN bash /usr/local/share/qiniu-sandbox-runner-template/download-checked-range \
+    "https://github.com/aws/aws-sam-cli/releases/download/v${AWS_SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
+    /opt/qiniu-runner-build-cache/aws-sam-cli.part-12 201326592 207357694
+RUN set -eux; \
+    cat /opt/qiniu-runner-build-cache/aws-sam-cli.part-* > /tmp/qiniu-aws-sam-cli.zip; \
+    test "$(wc -c </tmp/qiniu-aws-sam-cli.zip | tr -d '[:space:]')" -eq "$AWS_SAM_CLI_ARCHIVE_SIZE"; \
+    echo "$AWS_SAM_CLI_ARCHIVE_SHA256  /tmp/qiniu-aws-sam-cli.zip" | sha256sum --check -; \
+    rm -f /opt/qiniu-runner-build-cache/aws-sam-cli.part-*; \
+    rmdir /opt/qiniu-runner-build-cache; \
+    TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+RUN set -eux; \
+    rm -rf /home/runner/.nvm; \
+    cp -a /etc/skel/.nvm /home/runner/.nvm; \
+    chown -R runner:runner /home/runner/.nvm
 RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+
+ARG TEMPLATE_VERSION=20260805.6
+ENV ImageVersion=$TEMPLATE_VERSION \
+    IMAGE_VERSION=$TEMPLATE_VERSION
 
 RUN set -eux; \
     environment_file=/etc/environment; \

--- a/templates/github-runner-ubuntu-slim/Dockerfile
+++ b/templates/github-runner-ubuntu-slim/Dockerfile
@@ -2,7 +2,7 @@
 ARG BASE_PLATFORM=linux/amd64
 FROM --platform=$BASE_PLATFORM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:be20a0347f238b7d373edddc55923443b21dd9a60277bf8a93e43458cd0bf2fc
 
-ARG TEMPLATE_VERSION=20260804.1
+ARG TEMPLATE_VERSION=20260805.1
 ARG RUNNER_IMAGES_REV=e986db797519f06a2e5e53701a715cfa4c1545e8
 ARG RUNNER_IMAGES_ARCHIVE_SHA256=e87ede55bbdee21ee92113124a598e64d23a21e322f65f45e3a874c563f9f4cb
 ARG RUNNER_VERSION=2.336.0
@@ -55,6 +55,21 @@ RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=bootstrap bash /usr/local/share/q
 RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=platform bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=toolchain bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
+
+RUN set -eux; \
+    environment_file=/etc/environment; \
+    touch "$environment_file"; \
+    sed -i -e '/^ImageOS=/d' -e '/^ImageVersion=/d' -e '/^IMAGE_VERSION=/d' \
+      -e '/^IMAGE_TEMPLATE=/d' -e '/^RUNNER_TOOL_CACHE=/d' \
+      -e '/^AGENT_TOOLSDIRECTORY=/d' "$environment_file"; \
+    printf '%s\n' \
+      "ImageOS=\"$ImageOS\"" \
+      "ImageVersion=\"$TEMPLATE_VERSION\"" \
+      "IMAGE_VERSION=\"$TEMPLATE_VERSION\"" \
+      "IMAGE_TEMPLATE=\"$IMAGE_TEMPLATE\"" \
+      "RUNNER_TOOL_CACHE=\"$RUNNER_TOOL_CACHE\"" \
+      "AGENT_TOOLSDIRECTORY=\"$AGENT_TOOLSDIRECTORY\"" \
+      >>"$environment_file"
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-slim/scripts/download-checked-range
+++ b/templates/github-runner-ubuntu-slim/scripts/download-checked-range
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${1:?download URL is required}"
+destination="${2:?destination path is required}"
+start="${3:?range start is required}"
+end="${4:?range end is required}"
+attempts="${RUNNER_TEMPLATE_DOWNLOAD_ATTEMPTS:-20}"
+retry_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_DELAY:-2}"
+retry_max_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_MAX_DELAY:-30}"
+
+if [[ ! "$start" =~ ^[0-9]+$ ]] || [[ ! "$end" =~ ^[0-9]+$ ]] || [ "$end" -lt "$start" ]; then
+  echo "invalid byte range: ${start}-${end}" >&2
+  exit 64
+fi
+
+expected_size=$((end - start + 1))
+partial="${destination}.partial"
+install -d -m 0755 "$(dirname "$destination")"
+
+file_size() {
+  if [ -f "$1" ]; then
+    wc -c <"$1" | tr -d '[:space:]'
+  else
+    echo 0
+  fi
+}
+
+if [ "$(file_size "$destination")" -eq "$expected_size" ]; then
+  exit 0
+fi
+rm -f "$destination"
+touch "$partial"
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  current_size="$(file_size "$partial")"
+  if [ "$current_size" -gt "$expected_size" ]; then
+    echo "range server returned too many bytes; restarting chunk" >&2
+    rm -f "$partial"
+    touch "$partial"
+    current_size=0
+  fi
+  if [ "$current_size" -eq "$expected_size" ]; then
+    mv "$partial" "$destination"
+    exit 0
+  fi
+
+  request_start=$((start + current_size))
+  /usr/bin/curl --http1.1 -fsSL --connect-timeout 15 --max-time 1200 \
+    --speed-limit 1024 --speed-time 60 \
+    --range "${request_start}-${end}" "$url" >>"$partial" || true
+
+  current_size="$(file_size "$partial")"
+  if [ "$current_size" -eq "$expected_size" ]; then
+    mv "$partial" "$destination"
+    exit 0
+  fi
+  if [ "$current_size" -gt "$expected_size" ]; then
+    echo "range server returned too many bytes; restarting chunk" >&2
+    rm -f "$partial"
+    touch "$partial"
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "range download interrupted; resuming (${attempt}/${attempts})" >&2
+    if [ "$retry_delay" -gt 0 ]; then
+      sleep "$retry_delay"
+      if [ "$retry_delay" -lt "$retry_max_delay" ]; then
+        retry_delay=$((retry_delay * 2))
+        if [ "$retry_delay" -gt "$retry_max_delay" ]; then
+          retry_delay="$retry_max_delay"
+        fi
+      fi
+    fi
+  fi
+done
+
+echo "range download failed after ${attempts} attempts: ${url} bytes ${start}-${end}" >&2
+exit 1

--- a/templates/github-runner-ubuntu-slim/scripts/setup-template.sh
+++ b/templates/github-runner-ubuntu-slim/scripts/setup-template.sh
@@ -1,6 +1,32 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+runner_template_phase="${RUNNER_TEMPLATE_PHASE:-all}"
+case "$runner_template_phase" in
+  all | bootstrap | platform | toolchain | runtime) ;;
+  *)
+    echo "unsupported runner template phase: $runner_template_phase" >&2
+    exit 64
+    ;;
+esac
+
+phase_selected() {
+  [ "$runner_template_phase" = all ] || [ "$runner_template_phase" = "$1" ]
+}
+
+installer_phase() {
+  case "$1" in
+    configure-apt-sources.sh | configure-apt.sh | install-apt-vital.sh | install-ms-repos.sh | configure-image-data-file.sh | configure-environment.sh | install-apt-common.sh | install-azure-cli.sh | install-bicep.sh | install-apache.sh | install-aws-tools.sh | install-container-tools.sh | install-git.sh | install-git-lfs.sh | install-github-cli.sh | install-google-cloud-cli.sh)
+      echo platform
+      ;;
+    *) echo toolchain ;;
+  esac
+}
+
+should_run_installer() {
+  phase_selected "$(installer_phase "$1")"
+}
+
 : "${RUNNER_IMAGES_REV:?RUNNER_IMAGES_REV is required}"
 : "${RUNNER_IMAGES_ARCHIVE_SHA256:?RUNNER_IMAGES_ARCHIVE_SHA256 is required}"
 : "${RUNNER_VERSION:?RUNNER_VERSION is required}"
@@ -298,10 +324,38 @@ install_ninja_from_checked_archive() {
   run_upstream_tests_if_available "Tools" "Ninja"
 }
 
+run_retryable_upstream_installer() {
+  local installer_path="$1"
+  local installer_name="${installer_path##*/}"
+  local attempts="${RUNNER_TEMPLATE_UPSTREAM_INSTALL_ATTEMPTS:-3}"
+  local retry_delay="${RUNNER_TEMPLATE_UPSTREAM_INSTALL_RETRY_DELAY:-2}"
+  local attempt
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if PIP_DEFAULT_TIMEOUT="${PIP_DEFAULT_TIMEOUT:-120}" \
+      PIP_RETRIES="${PIP_RETRIES:-10}" \
+      bash "$installer_path"; then
+      return 0
+    fi
+    if [ "$attempt" -lt "$attempts" ]; then
+      echo "upstream installer interrupted; retrying $installer_name (${attempt}/${attempts})" >&2
+      if [ "$retry_delay" != 0 ]; then
+        sleep "$retry_delay"
+      fi
+    fi
+  done
+  echo "upstream installer failed after ${attempts} attempts: $installer_name" >&2
+  return 1
+}
+
 run_upstream_installer() {
   local installer_path="$1"
   local installer_name="${installer_path##*/}"
   case "$installer_name" in
+    install-azure-cli.sh)
+      install_azure_cli_from_microsoft_package
+      return
+      ;;
     install-aws-tools.sh)
       install_aws_tools_from_checked_archives
       return
@@ -342,15 +396,16 @@ run_upstream_installer() {
       install_ninja_from_checked_archive
       return
       ;;
+    install-python.sh | install-pipx-packages.sh)
+      if run_retryable_upstream_installer "$installer_path"; then
+        return 0
+      fi
+      return 1
+      ;;
   esac
 
   if bash "$installer_path"; then
     return 0
-  fi
-  if [ "$installer_name" = install-azure-cli.sh ]; then
-    echo "upstream Azure CLI installer unavailable; using checked Microsoft package" >&2
-    install_azure_cli_from_microsoft_package
-    return
   fi
   if [ "$installer_name" = install-docker-cli.sh ]; then
     echo "upstream Docker CLI installer unavailable; deferring to sandbox-aware installer" >&2
@@ -474,6 +529,7 @@ install_runner() {
   test -x /opt/actions-runner/run.sh
 }
 
+if phase_selected bootstrap; then
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates
 configure_reliable_apt_sources
@@ -494,23 +550,27 @@ install -d -o runner -g runner \
   /home/runner/_runnerd-hooks \
   /opt/actions-runner
 
-download_checked \
-  "https://codeload.github.com/actions/runner-images/tar.gz/${RUNNER_IMAGES_REV}" \
-  /tmp/runner-images.tar.gz \
-  "$RUNNER_IMAGES_ARCHIVE_SHA256"
-mkdir -p /tmp/runner-images
-tar -xzf /tmp/runner-images.tar.gz -C /tmp/runner-images --strip-components=1
+  download_checked \
+    "https://codeload.github.com/actions/runner-images/tar.gz/${RUNNER_IMAGES_REV}" \
+    /tmp/runner-images.tar.gz \
+    "$RUNNER_IMAGES_ARCHIVE_SHA256"
+  mkdir -p /opt/qiniu-runner-images
+  tar -xzf /tmp/runner-images.tar.gz -C /opt/qiniu-runner-images --strip-components=1
+fi
+test -d /opt/qiniu-runner-images
 
 export DEBIAN_FRONTEND=noninteractive
-export HELPER_SCRIPTS=/tmp/runner-images/images/ubuntu-slim/scripts/helpers
-export INSTALLER_SCRIPT_FOLDER=/tmp/runner-images/images/ubuntu-slim/toolsets
+export HELPER_SCRIPTS=/opt/qiniu-runner-images/images/ubuntu-slim/scripts/helpers
+export INSTALLER_SCRIPT_FOLDER=/opt/qiniu-runner-images/images/ubuntu-slim/toolsets
 export IMAGE_VERSION="${IMAGE_VERSION:-${ImageVersion:-local}}"
 export IMAGE_OS=ubuntu24
 
 if [ "${TEMPLATE_FLAVOR:-}" = slim ]; then
-  upstream_build=/tmp/runner-images/images/ubuntu-slim/scripts/build
-  ensure_upstream_apt_source_layout
-  install_azcopy_from_microsoft_package
+  upstream_build=/opt/qiniu-runner-images/images/ubuntu-slim/scripts/build
+  if phase_selected platform; then
+    ensure_upstream_apt_source_layout
+    install_azcopy_from_microsoft_package
+  fi
   for installer in \
     configure-apt-sources.sh \
     configure-apt.sh \
@@ -536,6 +596,7 @@ if [ "${TEMPLATE_FLAVOR:-}" = slim ]; then
     install-pipx-packages.sh \
     install-docker-cli.sh \
     configure-system.sh; do
+    should_run_installer "$installer" || continue
     run_upstream_installer "$upstream_build/$installer"
     if [ "$installer" = configure-apt-sources.sh ]; then
       configure_reliable_apt_sources
@@ -544,10 +605,13 @@ if [ "${TEMPLATE_FLAVOR:-}" = slim ]; then
       install_azure_devops_extension
     fi
   done
-  ln -s /etc/skel/.nvm /home/runner/.nvm
+  if phase_selected toolchain; then
+    ln -sfn /etc/skel/.nvm /home/runner/.nvm
+  fi
 else
   . /etc/os-release
   export IMAGE_OS="ubuntu${VERSION_ID/.}"
+  if phase_selected bootstrap; then
   install -d -m 0755 /tmp/qiniu-runner-build-tools
   cat >/tmp/qiniu-runner-build-tools/systemctl <<'SYSTEMCTL'
 #!/bin/sh
@@ -638,7 +702,6 @@ exit 0
 SYSTEMCTL
   chmod 0755 /tmp/qiniu-runner-build-tools/systemctl
   ln -s /tmp/qiniu-runner-build-tools/systemctl /usr/local/bin/systemctl
-  export PATH="/tmp/qiniu-runner-build-tools:$PATH"
   echo 'APT::Get::Assume-Yes "true";' >/etc/apt/apt.conf.d/90assumeyes
   install -d -m 0755 /etc/cloud/templates
   cat >/etc/waagent.conf <<'WAAGENT'
@@ -646,11 +709,14 @@ ResourceDisk.Format=n
 ResourceDisk.EnableSwap=n
 ResourceDisk.SwapSizeMB=0
 WAAGENT
+  fi
+  export PATH="/tmp/qiniu-runner-build-tools:$PATH"
   release_digits="${VERSION_ID/.}"
-  upstream_build=/tmp/runner-images/images/ubuntu/scripts/build
-  export HELPER_SCRIPTS=/tmp/runner-images/images/ubuntu/scripts/helpers
-  export INSTALLER_SCRIPT_FOLDER=/tmp/runner-images/images/ubuntu/scripts/build
-  cp "/tmp/runner-images/images/ubuntu/toolsets/toolset-${release_digits}.json" \
+  upstream_build=/opt/qiniu-runner-images/images/ubuntu/scripts/build
+  export HELPER_SCRIPTS=/opt/qiniu-runner-images/images/ubuntu/scripts/helpers
+  export INSTALLER_SCRIPT_FOLDER=/opt/qiniu-runner-images/images/ubuntu/scripts/build
+  if phase_selected bootstrap; then
+  cp "/opt/qiniu-runner-images/images/ubuntu/toolsets/toolset-${release_digits}.json" \
     "$INSTALLER_SCRIPT_FOLDER/toolset.json"
   install -d -m 0755 /imagegeneration
   cp -a "$HELPER_SCRIPTS" /imagegeneration/helpers
@@ -675,6 +741,7 @@ WAAGENT
   pwsh -File "$upstream_build/Install-PowerShellModules.ps1"
   pwsh -File "$upstream_build/Install-PowerShellAzModules.ps1"
   bash "$HELPER_SCRIPTS/invoke-tests.sh" Tools azcopy
+  fi
 
   for installer in \
     install-apt-common.sh \
@@ -725,6 +792,7 @@ WAAGENT
     install-python.sh \
     install-zstd.sh \
     install-ninja.sh; do
+    should_run_installer "$installer" || continue
     run_upstream_installer "$upstream_build/$installer"
     if [ "$installer" = install-azure-cli.sh ]; then
       install_azure_devops_extension
@@ -758,13 +826,14 @@ WAAGENT
 
   pwsh -File "$upstream_build/Install-Toolset.ps1"
   pwsh -File "$upstream_build/Configure-Toolset.ps1"
-  bash "$upstream_build/install-pipx-packages.sh"
+  run_upstream_installer "$upstream_build/install-pipx-packages.sh"
   sudo -H -u runner \
     HELPER_SCRIPTS="$HELPER_SCRIPTS" \
     INSTALLER_SCRIPT_FOLDER="$INSTALLER_SCRIPT_FOLDER" \
     bash "$upstream_build/install-homebrew.sh"
 fi
 
+if phase_selected runtime; then
 install_docker_for_sandbox
 install_runner
 install -m 0755 \
@@ -779,8 +848,8 @@ chmod -R a+rX /opt/actions-runner /opt/hostedtoolcache
 
 apt-get clean
 find /var/lib/apt/lists -mindepth 1 -delete
-find /tmp/runner-images -mindepth 1 -delete
-find /tmp/runner-images -depth -type d -empty -delete
+find /opt/qiniu-runner-images -mindepth 1 -delete
+find /opt/qiniu-runner-images -depth -type d -empty -delete
 if [ -d /imagegeneration ]; then
   find /imagegeneration -mindepth 1 -delete
   rmdir /imagegeneration
@@ -789,3 +858,4 @@ rm -f /usr/local/bin/systemctl
 find /tmp/qiniu-runner-build-tools -mindepth 1 -delete 2>/dev/null || true
 rmdir /tmp/qiniu-runner-build-tools 2>/dev/null || true
 rm -f /tmp/actions-runner.tar.gz /tmp/docker.gpg /tmp/runner-images.tar.gz
+fi

--- a/templates/github-runner-ubuntu-slim/scripts/setup-template.sh
+++ b/templates/github-runner-ubuntu-slim/scripts/setup-template.sh
@@ -66,6 +66,7 @@ download_checked() {
   local expected_sha256="$3"
   local attempts="${RUNNER_TEMPLATE_DOWNLOAD_ATTEMPTS:-20}"
   local retry_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_DELAY:-2}"
+  local retry_max_delay="${RUNNER_TEMPLATE_DOWNLOAD_RETRY_MAX_DELAY:-30}"
   local attempt
   local curl_status
 
@@ -96,6 +97,12 @@ download_checked() {
       echo "download interrupted; resuming (${attempt}/${attempts})" >&2
       if [ "$retry_delay" != 0 ]; then
         sleep "$retry_delay"
+        if [ "$retry_delay" -lt "$retry_max_delay" ]; then
+          retry_delay=$((retry_delay * 2))
+          if [ "$retry_delay" -gt "$retry_max_delay" ]; then
+            retry_delay="$retry_max_delay"
+          fi
+        fi
       fi
     fi
   done
@@ -501,6 +508,21 @@ configure_docker_apt_repository() {
   apt-cache show docker-ce >/dev/null 2>&1
 }
 
+remove_official_docker_packages() {
+  local official_docker_packages=(
+    containerd.io
+    docker-buildx-plugin
+    docker-ce
+    docker-ce-cli
+    docker-ce-rootless-extras
+    docker-compose-plugin
+  )
+  if ! apt-get purge -y "${official_docker_packages[@]}"; then
+    dpkg --purge --force-depends "${official_docker_packages[@]}" || true
+  fi
+  apt-get -f install -y
+}
+
 install_docker_for_sandbox() {
   if configure_docker_apt_repository && \
     apt-get install -y --no-install-recommends \
@@ -508,6 +530,7 @@ install_docker_for_sandbox() {
     echo "installed Docker packages from the official Docker repository"
   else
     echo "official Docker packages unavailable; using Ubuntu archive packages" >&2
+    remove_official_docker_packages
     rm -f /etc/apt/sources.list.d/docker.list /etc/apt/keyrings/docker.gpg
     apt-get update
     apt-get install -y --no-install-recommends docker.io docker-buildx docker-compose-v2

--- a/templates/runner-images-compatibility.json
+++ b/templates/runner-images-compatibility.json
@@ -238,7 +238,7 @@
           "upstream_name": "Azure CLI",
           "upstream_value": "2.82.0",
           "status": "provided",
-          "verification": "command -v az >/dev/null"
+          "verification": "test \"$(az version --query '\"azure-cli\"' --output tsv)\" = 2.88.0"
         },
         {
           "category": "CLI Tools",
@@ -868,9 +868,9 @@
           "category": "Qiniu runner contract",
           "kind": "software",
           "upstream_name": "preinstalled GitHub Actions runner",
-          "upstream_value": "/opt/actions-runner",
+          "upstream_value": "/opt/actions-runner (2.336.0)",
           "status": "provided",
-          "verification": "test -x /opt/actions-runner/config.sh && test -x /opt/actions-runner/run.sh"
+          "verification": "test -x /opt/actions-runner/config.sh && test -x /opt/actions-runner/run.sh && test \"$(/opt/actions-runner/bin/Runner.Listener --version)\" = 2.336.0"
         },
         {
           "category": "Qiniu runner contract",
@@ -1666,7 +1666,7 @@
           "upstream_name": "Azure CLI",
           "upstream_value": "2.88.0",
           "status": "provided",
-          "verification": "command -v az >/dev/null"
+          "verification": "test \"$(az version --query '\"azure-cli\"' --output tsv)\" = 2.88.0"
         },
         {
           "category": "CLI Tools",
@@ -3281,9 +3281,9 @@
           "category": "Qiniu runner contract",
           "kind": "software",
           "upstream_name": "preinstalled GitHub Actions runner",
-          "upstream_value": "/opt/actions-runner",
+          "upstream_value": "/opt/actions-runner (2.336.0)",
           "status": "provided",
-          "verification": "test -x /opt/actions-runner/config.sh && test -x /opt/actions-runner/run.sh"
+          "verification": "test -x /opt/actions-runner/config.sh && test -x /opt/actions-runner/run.sh && test \"$(/opt/actions-runner/bin/Runner.Listener --version)\" = 2.336.0"
         },
         {
           "category": "Qiniu runner contract",
@@ -3980,7 +3980,7 @@
           "upstream_name": "Azure CLI",
           "upstream_value": "2.88.0",
           "status": "provided",
-          "verification": "command -v az >/dev/null"
+          "verification": "test \"$(az version --query '\"azure-cli\"' --output tsv)\" = 2.88.0"
         },
         {
           "category": "CLI Tools",
@@ -5297,9 +5297,9 @@
           "category": "Qiniu runner contract",
           "kind": "software",
           "upstream_name": "preinstalled GitHub Actions runner",
-          "upstream_value": "/opt/actions-runner",
+          "upstream_value": "/opt/actions-runner (2.336.0)",
           "status": "provided",
-          "verification": "test -x /opt/actions-runner/config.sh && test -x /opt/actions-runner/run.sh"
+          "verification": "test -x /opt/actions-runner/config.sh && test -x /opt/actions-runner/run.sh && test \"$(/opt/actions-runner/bin/Runner.Listener --version)\" = 2.336.0"
         },
         {
           "category": "Qiniu runner contract",
@@ -5888,7 +5888,7 @@
           "upstream_name": "Azure CLI",
           "upstream_value": "2.88.0",
           "status": "provided",
-          "verification": "command -v az >/dev/null"
+          "verification": "test \"$(az version --query '\"azure-cli\"' --output tsv)\" = 2.88.0"
         },
         {
           "category": "CLI Tools",
@@ -7012,9 +7012,9 @@
           "category": "Qiniu runner contract",
           "kind": "software",
           "upstream_name": "preinstalled GitHub Actions runner",
-          "upstream_value": "/opt/actions-runner",
+          "upstream_value": "/opt/actions-runner (2.336.0)",
           "status": "provided",
-          "verification": "test -x /opt/actions-runner/config.sh && test -x /opt/actions-runner/run.sh"
+          "verification": "test -x /opt/actions-runner/config.sh && test -x /opt/actions-runner/run.sh && test \"$(/opt/actions-runner/bin/Runner.Listener --version)\" = 2.336.0"
         },
         {
           "category": "Qiniu runner contract",

--- a/templates/runner-images-compatibility.json
+++ b/templates/runner-images-compatibility.json
@@ -30,7 +30,7 @@
           "upstream_name": "Systemd version",
           "upstream_value": "255.4-1ubuntu8.12",
           "status": "provided",
-          "verification": "systemd --version >/dev/null"
+          "verification": "test -x /usr/lib/systemd/systemd && /usr/lib/systemd/systemd --version >/dev/null"
         },
         {
           "category": "Language and Runtime",
@@ -934,7 +934,7 @@
           "upstream_name": "Systemd version",
           "upstream_value": "249.11-0ubuntu3.21",
           "status": "provided",
-          "verification": "systemd --version >/dev/null"
+          "verification": "test -x /usr/lib/systemd/systemd && /usr/lib/systemd/systemd --version >/dev/null"
         },
         {
           "category": "Language and Runtime",
@@ -3347,7 +3347,7 @@
           "upstream_name": "Systemd version",
           "upstream_value": "255.4-1ubuntu8.16",
           "status": "provided",
-          "verification": "systemd --version >/dev/null"
+          "verification": "test -x /usr/lib/systemd/systemd && /usr/lib/systemd/systemd --version >/dev/null"
         },
         {
           "category": "Language and Runtime",
@@ -5363,7 +5363,7 @@
           "upstream_name": "Systemd version",
           "upstream_value": "259.5-0ubuntu3",
           "status": "provided",
-          "verification": "systemd --version >/dev/null"
+          "verification": "test -x /usr/lib/systemd/systemd && /usr/lib/systemd/systemd --version >/dev/null"
         },
         {
           "category": "Language and Runtime",


### PR DESCRIPTION
## Summary

- pin the GitHub Actions runner and template tool versions with checksums
- add resumable downloads and phase caching for long remote Sandbox builds
- make Ubuntu 26.04 mirror setup resilient across mirror and Canonical sources
- expand managed-template contract tests and English/Chinese documentation

## Verification

- `task test`
- `task lint`
- `task template-defaults-check`
- `task template-check-all`
- remote qshell builds and `task template-smoke` for ubuntu-slim, 22.04, 24.04, and 26.04 on the currently configured preview endpoint

The companion E2E PR in `miclle/qiniu-ci-runner-test` pins this exact commit and exercises all logical managed labels.