### PR TITLE
fix(templates): use Cloudflare DNS

### DIFF
--- a/docs/default-runner-templates.md
+++ b/docs/default-runner-templates.md
@@ -166,6 +166,11 @@ The Dockerfiles keep `bootstrap`, `platform`, `node`, `toolchain`, and
 Template version metadata is applied after provisioning, and the runner-owned
 NVM copy is isolated between `toolchain` and `runtime`, so either change keeps
 the heavy installer layers reusable.
+After those layers, each Dockerfile writes the final `/etc/resolv.conf` with
+Cloudflare `1.1.1.1` and `1.0.0.1` before switching to the unprivileged runner
+user. Keeping this override late avoids invalidating the heavy provisioning
+layers. Release smoke checks the exact two-line resolver file in a real
+Sandbox before publication.
 Before `platform`, each Dockerfile downloads the checksum-pinned AWS SAM
 archive in independent 16 MiB-or-smaller Range layers. Completed chunks remain
 cacheable across a service timeout under `/opt/qiniu-runner-build-cache`;

--- a/docs/zh/default-runner-templates.md
+++ b/docs/zh/default-runner-templates.md
@@ -152,6 +152,10 @@ Dockerfile 会按需将 `bootstrap`、`platform`、`node`、`toolchain` 和
 `runtime` 工作保留为独立的 qshell 兼容缓存层。模板版本元数据会在预置工作
 结束后才写入，runner 所有的 NVM 副本则独立放在 `toolchain` 与 `runtime` 之间，
 因此两类变更都不会让重型安装层的缓存失效。
+这些层结束后，每个 Dockerfile 都会在切换到非特权 runner 用户前，将最终
+`/etc/resolv.conf` 写为 Cloudflare `1.1.1.1` 和 `1.0.0.1`。把覆盖操作放在
+最后可以避免重型预置层缓存失效。发布前的真实 Sandbox smoke 会检查该文件
+严格包含这两行配置。
 在 `platform` 之前，每个 Dockerfile 还会将固定校验和的 AWS SAM 归档拆成
 不超过 16 MiB 的独立 Range 下载层。服务超时后可复用已经完成的分块；
 这些分块保存在 `/opt/qiniu-runner-build-cache`，因为 qshell 不会恢复缓存层中

--- a/internal/sandboxrunner/runner_test.go
+++ b/internal/sandboxrunner/runner_test.go
@@ -1280,6 +1280,22 @@ esac
 			cloudflareDNSChecked = strings.Contains(check.Command, `nameserver 1.1.1.1`) &&
 				strings.Contains(check.Command, `nameserver 1.0.0.1`) &&
 				strings.Contains(check.Command, `/etc/resolv.conf`)
+			resolvConfPath := filepath.Join(fixture, "resolv.conf")
+			if err := os.WriteFile(
+				resolvConfPath,
+				[]byte("nameserver 1.1.1.1\nnameserver 1.0.0.1\n"),
+				0o644,
+			); err != nil {
+				t.Fatal(err)
+			}
+			resolverCommand := strings.ReplaceAll(
+				check.Command,
+				"/etc/resolv.conf",
+				fmt.Sprintf("%q", resolvConfPath),
+			)
+			if output, err := runCommand(t, "bash", []string{"-c", resolverCommand}); err != nil {
+				t.Fatalf("Cloudflare DNS verification command failed: %v\n%s", err, output)
+			}
 		}
 		if check.Name == "runner writable NVM home" {
 			nvmHomeChecked = strings.Contains(check.Command, "sudo -H -u runner") &&

--- a/internal/sandboxrunner/runner_test.go
+++ b/internal/sandboxrunner/runner_test.go
@@ -1256,12 +1256,13 @@ esac
 	if !result.Passed ||
 		result.SupportChannel != "preview" ||
 		!result.Cleanup.Passed ||
-		len(result.Results) != 8 {
-		t.Fatalf("release smoke result = %#v, want eight passing usability and identity checks plus cleanup", result)
+		len(result.Results) != 9 {
+		t.Fatalf("release smoke result = %#v, want nine passing usability and identity checks plus cleanup", result)
 	}
 	runnerVersionChecked := false
 	runtimeMetadataChecked := false
 	nvmHomeChecked := false
+	cloudflareDNSChecked := false
 	for _, check := range result.Results {
 		if check.Category != "Release smoke" {
 			t.Fatalf("release smoke unexpectedly ran full inventory check %#v", check)
@@ -1272,8 +1273,13 @@ esac
 		}
 		if check.Name == "runtime image metadata" {
 			runtimeMetadataChecked = strings.Contains(check.Command, `"$IMAGE_TEMPLATE" = "github-runner-ubuntu-26-04"`) &&
-				strings.Contains(check.Command, `"$ImageVersion" = "20260805.6"`) &&
-				strings.Contains(check.Command, `"$IMAGE_VERSION" = "20260805.6"`)
+				strings.Contains(check.Command, `"$ImageVersion" = "20260817.1"`) &&
+				strings.Contains(check.Command, `"$IMAGE_VERSION" = "20260817.1"`)
+		}
+		if check.Name == "Cloudflare DNS" {
+			cloudflareDNSChecked = strings.Contains(check.Command, `nameserver 1.1.1.1`) &&
+				strings.Contains(check.Command, `nameserver 1.0.0.1`) &&
+				strings.Contains(check.Command, `/etc/resolv.conf`)
 		}
 		if check.Name == "runner writable NVM home" {
 			nvmHomeChecked = strings.Contains(check.Command, "sudo -H -u runner") &&
@@ -1301,6 +1307,9 @@ esac
 	}
 	if !nvmHomeChecked {
 		t.Fatalf("release smoke did not verify the runner-owned NVM home: %#v", result.Results)
+	}
+	if !cloudflareDNSChecked {
+		t.Fatalf("release smoke did not verify Cloudflare DNS: %#v", result.Results)
 	}
 }
 

--- a/scripts/check-runner-template-matrix.sh
+++ b/scripts/check-runner-template-matrix.sh
@@ -139,6 +139,21 @@ for image_key in ubuntu-slim ubuntu-22.04 ubuntu-24.04 ubuntu-26.04; do
   actual_phase_count="$(grep -Ec 'TEMPLATE_FLAVOR=(slim|versioned)[[:space:]]+RUNNER_TEMPLATE_PHASE=' "$directory/Dockerfile")"
   test "$actual_phase_count" -eq "$phase_count" ||
     fail "$image_key has $actual_phase_count setup phases, want $phase_count"
+  cloudflare_primary_line="$(grep -nF "'nameserver 1.1.1.1'" "$directory/Dockerfile" | cut -d: -f1 || true)"
+  cloudflare_secondary_line="$(grep -nF "'nameserver 1.0.0.1'" "$directory/Dockerfile" | cut -d: -f1 || true)"
+  resolv_conf_line="$(grep -nF '>/etc/resolv.conf' "$directory/Dockerfile" | cut -d: -f1 || true)"
+  runtime_phase_line="$(grep -nF "RUNNER_TEMPLATE_PHASE=runtime" "$directory/Dockerfile" | cut -d: -f1)"
+  user_line="$(grep -nE '^USER[[:space:]]+' "$directory/Dockerfile" | cut -d: -f1)"
+  test -n "$cloudflare_primary_line" && test -n "$cloudflare_secondary_line" && test -n "$resolv_conf_line" ||
+    fail "$image_key must configure Cloudflare nameservers 1.1.1.1 and 1.0.0.1"
+  test "$runtime_phase_line" -lt "$cloudflare_primary_line" &&
+    test "$cloudflare_primary_line" -lt "$cloudflare_secondary_line" &&
+    test "$cloudflare_secondary_line" -le "$resolv_conf_line" &&
+    test "$resolv_conf_line" -lt "$user_line" ||
+    fail "$image_key must configure Cloudflare nameservers after runtime setup and before USER"
+  if grep -Eq "['\"]nameserver[[:space:]]+8\\.8\\.(8\\.8|4\\.4)['\"]" "$directory/Dockerfile"; then
+    fail "$image_key must not retain Google Public DNS in the final template configuration"
+  fi
   if grep -Fq 'Acquire::https::Verify-Peer=false' "$directory/scripts/setup-template.sh"; then
     fail "$image_key setup must not disable apt HTTPS peer verification"
   fi

--- a/scripts/smoke-runner-template.sh
+++ b/scripts/smoke-runner-template.sh
@@ -175,7 +175,7 @@ jq \
         status: "provided",
         verification: (
           "test \"$(cat /etc/resolv.conf)\" = "
-          + "\"$(printf \\\"%s\\\\n\\\" \\\"nameserver 1.1.1.1\\\" \\\"nameserver 1.0.0.1\\\")\""
+          + "\"$(printf \"%s\\n\" \"nameserver 1.1.1.1\" \"nameserver 1.0.0.1\")\""
         )
       },
       {

--- a/scripts/smoke-runner-template.sh
+++ b/scripts/smoke-runner-template.sh
@@ -171,6 +171,15 @@ jq \
       },
       {
         category: "Release smoke",
+        upstream_name: "Cloudflare DNS",
+        status: "provided",
+        verification: (
+          "test \"$(cat /etc/resolv.conf)\" = "
+          + "\"$(printf \\\"%s\\\\n\\\" \\\"nameserver 1.1.1.1\\\" \\\"nameserver 1.0.0.1\\\")\""
+        )
+      },
+      {
+        category: "Release smoke",
         upstream_name: "runner writable NVM home",
         status: "provided",
         verification: $nvm_smoke_command

--- a/templates/README.md
+++ b/templates/README.md
@@ -191,14 +191,18 @@ terminal `Status: ready`.
 Template version metadata and the runner-owned NVM copy are applied only after
 the heavy provisioning layers, so a release identity bump or NVM ownership fix
 does not invalidate otherwise reusable installer caches.
+Each Dockerfile then writes the final `/etc/resolv.conf` with Cloudflare
+`1.1.1.1` and `1.0.0.1` before switching to the unprivileged runner user. This
+late layer overrides the Sandbox builder default without invalidating the
+heavy provisioning layers. Release smoke requires the exact two-line file.
 The checksum-pinned AWS SAM Range layers sit between `bootstrap` and
 `platform`; rerunning the identical source reuses every completed chunk rather
 than restarting the whole archive. The platform installer runs in the same
 layer as reassembly instead of depending on a cached oversized archive.
 Release smoke checks the OS, architecture, the exact Dockerfile-pinned Actions
 Runner version, persisted runtime template name/version metadata, outbound
-HTTPS, Docker, a runner-owned writable NVM home, writable work/tool-cache
-paths, and cleanup. Full
+HTTPS, the exact Cloudflare resolver configuration, Docker, a runner-owned
+writable NVM home, writable work/tool-cache paths, and cleanup. Full
 per-inventory runtime conformance and local Docker builds remain optional
 diagnostics; neither is a substitute for the remote usability gate.
 The source gate rejects an Actions Runner version below `2.336.0`, while the

--- a/templates/github-runner-ubuntu-22.04/Dockerfile
+++ b/templates/github-runner-ubuntu-22.04/Dockerfile
@@ -88,7 +88,7 @@ RUN set -eux; \
     chown -R runner:runner /home/runner/.nvm
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 
-ARG TEMPLATE_VERSION=20260805.6
+ARG TEMPLATE_VERSION=20260817.1
 ENV ImageVersion=$TEMPLATE_VERSION \
     IMAGE_VERSION=$TEMPLATE_VERSION
 
@@ -106,6 +106,12 @@ RUN set -eux; \
       "RUNNER_TOOL_CACHE=\"$RUNNER_TOOL_CACHE\"" \
       "AGENT_TOOLSDIRECTORY=\"$AGENT_TOOLSDIRECTORY\"" \
       >>"$environment_file"
+
+RUN set -eux; \
+    printf '%s\n' \
+      'nameserver 1.1.1.1' \
+      'nameserver 1.0.0.1' \
+      >/etc/resolv.conf
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-24.04/Dockerfile
+++ b/templates/github-runner-ubuntu-24.04/Dockerfile
@@ -88,7 +88,7 @@ RUN set -eux; \
     chown -R runner:runner /home/runner/.nvm
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 
-ARG TEMPLATE_VERSION=20260805.6
+ARG TEMPLATE_VERSION=20260817.1
 ENV ImageVersion=$TEMPLATE_VERSION \
     IMAGE_VERSION=$TEMPLATE_VERSION
 
@@ -106,6 +106,12 @@ RUN set -eux; \
       "RUNNER_TOOL_CACHE=\"$RUNNER_TOOL_CACHE\"" \
       "AGENT_TOOLSDIRECTORY=\"$AGENT_TOOLSDIRECTORY\"" \
       >>"$environment_file"
+
+RUN set -eux; \
+    printf '%s\n' \
+      'nameserver 1.1.1.1' \
+      'nameserver 1.0.0.1' \
+      >/etc/resolv.conf
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-26.04/Dockerfile
+++ b/templates/github-runner-ubuntu-26.04/Dockerfile
@@ -193,7 +193,7 @@ RUN set -eux; \
     chown -R runner:runner /home/runner/.nvm
 RUN TEMPLATE_FLAVOR=versioned RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 
-ARG TEMPLATE_VERSION=20260805.6
+ARG TEMPLATE_VERSION=20260817.1
 ENV ImageVersion=$TEMPLATE_VERSION \
     IMAGE_VERSION=$TEMPLATE_VERSION
 
@@ -211,6 +211,12 @@ RUN set -eux; \
       "RUNNER_TOOL_CACHE=\"$RUNNER_TOOL_CACHE\"" \
       "AGENT_TOOLSDIRECTORY=\"$AGENT_TOOLSDIRECTORY\"" \
       >>"$environment_file"
+
+RUN set -eux; \
+    printf '%s\n' \
+      'nameserver 1.1.1.1' \
+      'nameserver 1.0.0.1' \
+      >/etc/resolv.conf
 
 USER runner
 WORKDIR /home/runner/work

--- a/templates/github-runner-ubuntu-slim/Dockerfile
+++ b/templates/github-runner-ubuntu-slim/Dockerfile
@@ -105,7 +105,7 @@ RUN set -eux; \
     chown -R runner:runner /home/runner/.nvm
 RUN TEMPLATE_FLAVOR=slim RUNNER_TEMPLATE_PHASE=runtime bash /usr/local/share/qiniu-sandbox-runner-template/setup-template.sh
 
-ARG TEMPLATE_VERSION=20260805.6
+ARG TEMPLATE_VERSION=20260817.1
 ENV ImageVersion=$TEMPLATE_VERSION \
     IMAGE_VERSION=$TEMPLATE_VERSION
 
@@ -123,6 +123,12 @@ RUN set -eux; \
       "RUNNER_TOOL_CACHE=\"$RUNNER_TOOL_CACHE\"" \
       "AGENT_TOOLSDIRECTORY=\"$AGENT_TOOLSDIRECTORY\"" \
       >>"$environment_file"
+
+RUN set -eux; \
+    printf '%s\n' \
+      'nameserver 1.1.1.1' \
+      'nameserver 1.0.0.1' \
+      >/etc/resolv.conf
 
 USER runner
 WORKDIR /home/runner/work


### PR DESCRIPTION
## Summary

- configure all managed Ubuntu runner templates to use Cloudflare DNS at `1.1.1.1` and `1.0.0.1`
- bump the template version to `20260817.1`
- enforce resolver placement in source checks and verify the exact resolver file during release smoke
- document the managed template DNS behavior

## Why

Some Sandbox egress paths using Google Public DNS resolve `github.com` to a high-latency Southeast Asia edge. CI verification showed Cloudflare DNS resolving a lower-latency US edge and reducing checkout time substantially. This applies the validated template-scoped mitigation.

## Impact

New Sandbox instances built from these template versions use Cloudflare DNS. Existing published templates and existing Sandboxes remain unchanged until the new templates are built and published.

## Validation

- `go test ./internal/sandboxrunner -count=1`
- `task template-check-all`
- `bash -n scripts/check-runner-template-matrix.sh scripts/smoke-runner-template.sh`
- `git diff --check`

## Follow-up

Remote qshell builds and release smoke must pass in both supported regions before publication.
