### PR TITLE
fix(runner): preserve active job ownership

### DIFF
--- a/internal/server/server_loops.go
+++ b/internal/server/server_loops.go
@@ -287,6 +287,7 @@ func (s *Server) requeueMismatchedWorkflowJob(st state.RunnerState, observed git
 		if err := s.store.WriteState(next); err != nil {
 			return false, state.RunnerState{}, fmt.Errorf("write mismatched workflow job inspection: %w", err)
 		}
+		// Keep the returned state aligned with WriteState's CAS-persisted version.
 		next.Version++
 		s.store.AppendLog(st.ID, "control.log", []byte(fmt.Sprintf("runner completed different workflow job %d; original workflow job %d is no longer queued\n", observed.ID, st.WorkflowJobID)))
 		return false, next, nil
@@ -314,6 +315,7 @@ func (s *Server) requeueMismatchedWorkflowJob(st state.RunnerState, observed git
 	if err := s.store.WriteState(next); err != nil {
 		return false, state.RunnerState{}, fmt.Errorf("write mismatched workflow job requeue: %w", err)
 	}
+	// Keep the returned state aligned with WriteState's CAS-persisted version.
 	next.Version++
 	s.store.AppendLog(st.ID, "control.log", []byte(fmt.Sprintf("runner completed different workflow job %d; original workflow job %d is queued, requeued request\n", observed.ID, st.WorkflowJobID)))
 	s.signalQueue()

--- a/internal/server/server_loops.go
+++ b/internal/server/server_loops.go
@@ -287,6 +287,7 @@ func (s *Server) requeueMismatchedWorkflowJob(st state.RunnerState, observed git
 		if err := s.store.WriteState(next); err != nil {
 			return false, state.RunnerState{}, fmt.Errorf("write mismatched workflow job inspection: %w", err)
 		}
+		next.Version++
 		s.store.AppendLog(st.ID, "control.log", []byte(fmt.Sprintf("runner completed different workflow job %d; original workflow job %d is no longer queued\n", observed.ID, st.WorkflowJobID)))
 		return false, next, nil
 	}
@@ -313,6 +314,7 @@ func (s *Server) requeueMismatchedWorkflowJob(st state.RunnerState, observed git
 	if err := s.store.WriteState(next); err != nil {
 		return false, state.RunnerState{}, fmt.Errorf("write mismatched workflow job requeue: %w", err)
 	}
+	next.Version++
 	s.store.AppendLog(st.ID, "control.log", []byte(fmt.Sprintf("runner completed different workflow job %d; original workflow job %d is queued, requeued request\n", observed.ID, st.WorkflowJobID)))
 	s.signalQueue()
 	return true, next, nil

--- a/internal/server/server_runner_lifecycle.go
+++ b/internal/server/server_runner_lifecycle.go
@@ -737,8 +737,15 @@ func (s *Server) recoverActiveRunner(ctx context.Context, st state.RunnerState, 
 		hasJob = false
 	}
 	if hasJob && strings.EqualFold(strings.TrimSpace(job.Status), "completed") {
-		_, _, err := s.stopRunner(ctx, st.ID, job)
-		return err
+		latest, _, err := s.stopRunner(ctx, st.ID, job)
+		if err != nil {
+			return err
+		}
+		if latest.Status != state.StatusCreating && latest.Status != state.StatusRunning {
+			return nil
+		}
+		st = latest
+		stateVersion = latest.Version
 	}
 
 	timeout := s.remainingSandboxTimeout(st, time.Now().UTC())
@@ -937,6 +944,23 @@ func (s *Server) stopRunner(ctx context.Context, id string, job github.WorkflowJ
 		}
 		s.logger.Info("runner stop skipped because already completed", "id", id)
 		return st, recorded, nil
+	}
+	if workflowJobStopConflictsWithAssignment(st, job) {
+		s.logger.Warn(
+			"runner stop deferred because active runner ownership is unresolved or different",
+			"id", id,
+			"workflow_job_id", st.WorkflowJobID,
+			"assigned_job_id", st.AssignedJobID,
+			"assigned_job_name", st.AssignedJobName,
+			"completed_job_id", job.ID,
+		)
+		s.store.AppendLog(id, "control.log", []byte(fmt.Sprintf(
+			"runner stop deferred: workflow job %d completed while active runner assignment is id=%d name=%q\n",
+			job.ID,
+			st.AssignedJobID,
+			st.AssignedJobName,
+		)))
+		return st, false, nil
 	}
 	if shouldRecordAssignedJob(st, job) {
 		st.AssignedJobID = job.ID
@@ -1302,6 +1326,19 @@ func shouldRecordAssignedJob(st state.RunnerState, job github.WorkflowJob) bool 
 		return false
 	}
 	return st.AssignedJobID != job.ID || st.AssignedJobName != job.Name
+}
+
+func workflowJobStopConflictsWithAssignment(st state.RunnerState, job github.WorkflowJob) bool {
+	if job.ID == 0 {
+		return false
+	}
+	if runnerName := strings.TrimSpace(job.RunnerName); runnerName != "" && runnerName == strings.TrimSpace(st.RunnerName) {
+		return false
+	}
+	if st.AssignedJobID != 0 {
+		return st.AssignedJobID != job.ID
+	}
+	return st.AssignedJobName == runnerJobStartedMarker && st.WorkflowJobID == job.ID
 }
 
 func workflowJobMismatch(st state.RunnerState, job github.WorkflowJob) bool {

--- a/internal/server/server_runner_lifecycle.go
+++ b/internal/server/server_runner_lifecycle.go
@@ -931,6 +931,23 @@ func (s *Server) stopRunner(ctx context.Context, id string, job github.WorkflowJ
 		return state.RunnerState{}, false, err
 	}
 	s.logger.Info("runner stop requested", "id", id, "status", st.Status, "sandbox_id", st.SandboxID, "pid", st.ProcessPID, "job_id", job.ID)
+	if workflowJobStopConflictsWithAssignment(st, job) {
+		s.logger.Warn(
+			"runner stop deferred because runner ownership is unresolved or different",
+			"id", id,
+			"workflow_job_id", st.WorkflowJobID,
+			"assigned_job_id", st.AssignedJobID,
+			"assigned_job_name", st.AssignedJobName,
+			"completed_job_id", job.ID,
+		)
+		s.store.AppendLog(id, "control.log", []byte(fmt.Sprintf(
+			"runner stop deferred: workflow job %d completed while runner assignment is id=%d name=%q\n",
+			job.ID,
+			st.AssignedJobID,
+			st.AssignedJobName,
+		)))
+		return st, false, nil
+	}
 	if st.Status == state.StatusCompleted {
 		recorded := false
 		if shouldRecordAssignedJob(st, job) {
@@ -944,23 +961,6 @@ func (s *Server) stopRunner(ctx context.Context, id string, job github.WorkflowJ
 		}
 		s.logger.Info("runner stop skipped because already completed", "id", id)
 		return st, recorded, nil
-	}
-	if workflowJobStopConflictsWithAssignment(st, job) {
-		s.logger.Warn(
-			"runner stop deferred because active runner ownership is unresolved or different",
-			"id", id,
-			"workflow_job_id", st.WorkflowJobID,
-			"assigned_job_id", st.AssignedJobID,
-			"assigned_job_name", st.AssignedJobName,
-			"completed_job_id", job.ID,
-		)
-		s.store.AppendLog(id, "control.log", []byte(fmt.Sprintf(
-			"runner stop deferred: workflow job %d completed while active runner assignment is id=%d name=%q\n",
-			job.ID,
-			st.AssignedJobID,
-			st.AssignedJobName,
-		)))
-		return st, false, nil
 	}
 	if shouldRecordAssignedJob(st, job) {
 		st.AssignedJobID = job.ID
@@ -1328,6 +1328,10 @@ func shouldRecordAssignedJob(st state.RunnerState, job github.WorkflowJob) bool 
 	return st.AssignedJobID != job.ID || st.AssignedJobName != job.Name
 }
 
+// workflowJobStopConflictsWithAssignment reports whether a completed workflow
+// job must not stop or reassign this runner because its actual job ownership is
+// unresolved or already points at a different job. A matching non-empty
+// runner_name is authoritative and makes the completion safe to apply.
 func workflowJobStopConflictsWithAssignment(st state.RunnerState, job github.WorkflowJob) bool {
 	if job.ID == 0 {
 		return false

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4940,6 +4940,63 @@ func TestOriginalWorkflowJobCompletionKeepsRunnerAssignedToDifferentJob(t *testi
 	}
 }
 
+func TestWeakOriginalWorkflowJobCompletionKeepsCompletedRunnerAssignment(t *testing.T) {
+	ghServer := httptest.NewServer(githubRunnerAPI(t))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	fake := &fakeSandbox{}
+	srv := newTestServer(t, store, ghServer.URL, fake)
+	srv.Close()
+
+	_, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "1001",
+		Source:             "test",
+		JobID:              1001,
+		RepositoryFullName: "o/r",
+		Labels:             []string{"self-hosted", "e2b"},
+		ProfileName:        "default",
+		RunnerName:         "e2b-1001",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Status = state.StatusCompleted
+	st.SandboxID = "sb-1001"
+	st.ProcessPID = 42
+	st.RunningAt = time.Now().UTC().Add(-time.Minute)
+	st.CompletedAt = time.Now().UTC()
+	st.AssignedJobID = 2002
+	st.AssignedJobName = "actual job"
+	if err := store.WriteState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	completed := []byte(`{"action":"completed","repository":{"full_name":"o/r"},"workflow_job":{"id":1001,"name":"original job","status":"completed","conclusion":"cancelled","labels":["self-hosted","e2b"]}}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(completed))
+	req.Header.Set("X-GitHub-Event", "workflow_job")
+	req.Header.Set("X-Hub-Signature-256", sign("secret", completed))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("unexpected completed status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err := store.ReadState("1001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusCompleted {
+		t.Fatalf("weak original job completion changed terminal status to %s", got.Status)
+	}
+	if got.AssignedJobID != 2002 || got.AssignedJobName != "actual job" {
+		t.Fatalf("weak original job completion replaced completed runner assignment: id=%d name=%q", got.AssignedJobID, got.AssignedJobName)
+	}
+	if fake.stoppedCount() != 0 {
+		t.Fatalf("weak original job completion stopped an already completed runner %d times", fake.stoppedCount())
+	}
+}
+
 func TestOriginalWorkflowJobCompletionKeepsRunnerAfterJobStartedMarker(t *testing.T) {
 	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -5859,6 +5916,60 @@ func TestRecoverReattachesRunnerWhenOriginalJobCompletedButDifferentJobAssigned(
 	}
 	if fake.stoppedCount() != 0 {
 		t.Fatalf("recovery stopped sandbox assigned to another job %d times", fake.stoppedCount())
+	}
+}
+
+func TestRecoverReattachesRunnerWhenOriginalJobCompletedAfterJobStartedMarker(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/actions/jobs/1001" {
+			w.Write([]byte(`{"id":1001,"name":"original job","status":"completed","conclusion":"cancelled"}`))
+			return
+		}
+		t.Fatalf("unexpected github request: %s %s", r.Method, r.URL.String())
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	_, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "1001",
+		Source:             "test",
+		RepositoryFullName: "o/r",
+		JobID:              1001,
+		Labels:             []string{"self-hosted", "e2b"},
+		RunnerName:         "e2b-1001",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Status = state.StatusRunning
+	st.SandboxID = "sb-1001"
+	st.ProcessPID = 42
+	st.RunningAt = time.Now().UTC().Add(-time.Minute)
+	st.AssignedJobName = runnerJobStartedMarker
+	if err := store.WriteState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeSandbox{}
+	srv := newTestServer(t, store, ghServer.URL, fake)
+	srv.Close()
+	if err := srv.Recover(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.ReadState("1001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusRunning || got.AssignedJobID != 0 || got.AssignedJobName != runnerJobStartedMarker {
+		t.Fatalf("recovery changed unresolved active job assignment: %#v", got)
+	}
+	if fake.recoveredCount() != 1 {
+		t.Fatalf("recovery reattached sandbox %d times, want 1", fake.recoveredCount())
+	}
+	if fake.stoppedCount() != 0 {
+		t.Fatalf("recovery stopped sandbox after a job had already started %d times", fake.stoppedCount())
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4884,6 +4884,213 @@ func TestWebhookCompletedStopsActualRunnerAndRecordsJob(t *testing.T) {
 	}
 }
 
+func TestOriginalWorkflowJobCompletionKeepsRunnerAssignedToDifferentJob(t *testing.T) {
+	ghServer := httptest.NewServer(githubRunnerAPI(t))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	fake := &fakeSandbox{}
+	srv := newTestServer(t, store, ghServer.URL, fake)
+	srv.Close()
+
+	_, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "1001",
+		Source:             "test",
+		JobID:              1001,
+		RepositoryFullName: "o/r",
+		Labels:             []string{"self-hosted", "e2b"},
+		ProfileName:        "default",
+		RunnerName:         "e2b-1001",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Status = state.StatusRunning
+	st.SandboxID = "sb-1001"
+	st.ProcessPID = 42
+	st.RunningAt = time.Now().UTC()
+	st.AssignedJobID = 2002
+	st.AssignedJobName = "actual job"
+	if err := store.WriteState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	completed := []byte(`{"action":"completed","repository":{"full_name":"o/r"},"workflow_job":{"id":1001,"name":"original job","status":"completed","conclusion":"cancelled","labels":["self-hosted","e2b"]}}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(completed))
+	req.Header.Set("X-GitHub-Event", "workflow_job")
+	req.Header.Set("X-Hub-Signature-256", sign("secret", completed))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("unexpected completed status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err := store.ReadState("1001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusRunning {
+		t.Fatalf("original job completion changed active runner status to %s", got.Status)
+	}
+	if got.AssignedJobID != 2002 || got.AssignedJobName != "actual job" {
+		t.Fatalf("original job completion replaced actual assignment: id=%d name=%q", got.AssignedJobID, got.AssignedJobName)
+	}
+	if fake.stoppedCount() != 0 {
+		t.Fatalf("original job completion stopped sandbox assigned to another job %d times", fake.stoppedCount())
+	}
+}
+
+func TestOriginalWorkflowJobCompletionKeepsRunnerAfterJobStartedMarker(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/actions/jobs/1001":
+			w.Write([]byte(`{"id":1001,"name":"original job","status":"completed","conclusion":"cancelled","labels":["self-hosted","e2b"]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/actions/runners":
+			w.Write([]byte(`{"runners":[]}`))
+		default:
+			t.Fatalf("unexpected github request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	fake := &fakeSandbox{}
+	srv := newTestServer(t, store, ghServer.URL, fake)
+	srv.Close()
+
+	_, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "1001",
+		Source:             "test",
+		JobID:              1001,
+		RepositoryFullName: "o/r",
+		Labels:             []string{"self-hosted", "e2b"},
+		ProfileName:        "default",
+		RunnerName:         "e2b-1001",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Status = state.StatusRunning
+	st.SandboxID = "sb-1001"
+	st.ProcessPID = 42
+	st.RunningAt = time.Now().UTC()
+	st.AssignedJobName = runnerJobStartedMarker
+	if err := store.WriteState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	completed := []byte(`{"action":"completed","repository":{"full_name":"o/r"},"workflow_job":{"id":1001,"name":"original job","status":"completed","conclusion":"cancelled","labels":["self-hosted","e2b"]}}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(completed))
+	req.Header.Set("X-GitHub-Event", "workflow_job")
+	req.Header.Set("X-Hub-Signature-256", sign("secret", completed))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("unexpected completed status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err := store.ReadState("1001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusRunning {
+		t.Fatalf("original job completion changed active runner status to %s before assignment was identified", got.Status)
+	}
+	if got.AssignedJobID != 0 || got.AssignedJobName != runnerJobStartedMarker {
+		t.Fatalf("original job completion replaced the job-started marker: id=%d name=%q", got.AssignedJobID, got.AssignedJobName)
+	}
+	if fake.stoppedCount() != 0 {
+		t.Fatalf("original job completion stopped sandbox after a job had already started %d times", fake.stoppedCount())
+	}
+
+	inProgress := []byte(`{"action":"in_progress","repository":{"full_name":"o/r"},"workflow_job":{"id":2002,"name":"actual job","runner_name":"e2b-1001","workflow_name":"ci","labels":["self-hosted","e2b"]}}`)
+	req = httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(inProgress))
+	req.Header.Set("X-GitHub-Event", "workflow_job")
+	req.Header.Set("X-Hub-Signature-256", sign("secret", inProgress))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("unexpected in_progress status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	actualCompleted := []byte(`{"action":"completed","repository":{"full_name":"o/r"},"workflow_job":{"id":2002,"name":"actual job","runner_name":"e2b-1001","status":"completed","conclusion":"success","labels":["self-hosted","e2b"]}}`)
+	req = httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(actualCompleted))
+	req.Header.Set("X-GitHub-Event", "workflow_job")
+	req.Header.Set("X-Hub-Signature-256", sign("secret", actualCompleted))
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("unexpected actual job completed status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err = store.ReadState("1001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusCompleted {
+		t.Fatalf("actual job completion left runner in status %s", got.Status)
+	}
+	if fake.stoppedCount() != 1 {
+		t.Fatalf("actual job completion stopped sandbox %d times, want 1", fake.stoppedCount())
+	}
+}
+
+func TestCompletedWebhookWithRunnerNameStopsRunnerBeforeInProgressEvent(t *testing.T) {
+	ghServer := httptest.NewServer(githubRunnerAPI(t))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	fake := &fakeSandbox{}
+	srv := newTestServer(t, store, ghServer.URL, fake)
+	srv.Close()
+
+	_, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "1001",
+		Source:             "test",
+		JobID:              1001,
+		RepositoryFullName: "o/r",
+		Labels:             []string{"self-hosted", "e2b"},
+		ProfileName:        "default",
+		RunnerName:         "e2b-1001",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Status = state.StatusRunning
+	st.SandboxID = "sb-1001"
+	st.ProcessPID = 42
+	st.RunningAt = time.Now().UTC()
+	st.AssignedJobName = runnerJobStartedMarker
+	if err := store.WriteState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	completed := []byte(`{"action":"completed","repository":{"full_name":"o/r"},"workflow_job":{"id":1001,"name":"original job","runner_name":"e2b-1001","status":"completed","conclusion":"success","labels":["self-hosted","e2b"]}}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(completed))
+	req.Header.Set("X-GitHub-Event", "workflow_job")
+	req.Header.Set("X-Hub-Signature-256", sign("secret", completed))
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("unexpected completed status: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err := store.ReadState("1001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusCompleted {
+		t.Fatalf("completed event with runner_name left runner in status %s", got.Status)
+	}
+	if got.AssignedJobID != 1001 || got.AssignedJobName != "original job" {
+		t.Fatalf("completed event did not record its assignment: id=%d name=%q", got.AssignedJobID, got.AssignedJobName)
+	}
+	if fake.stoppedCount() != 1 {
+		t.Fatalf("completed event with runner_name stopped sandbox %d times, want 1", fake.stoppedCount())
+	}
+}
+
 func TestWorkflowJobMismatchRequeuesOriginalJob(t *testing.T) {
 	ghServer := httptest.NewServer(githubRunnerAPI(t))
 	defer ghServer.Close()
@@ -5597,6 +5804,61 @@ func TestRecoverCleansUpCompletedWorkflowJob(t *testing.T) {
 	}
 	if fake.recoveredCount() != 0 || fake.stoppedCount() != 1 {
 		t.Fatalf("expected completed workflow job to stop without reconnect, recovered=%d stopped=%d", fake.recoveredCount(), fake.stoppedCount())
+	}
+}
+
+func TestRecoverReattachesRunnerWhenOriginalJobCompletedButDifferentJobAssigned(t *testing.T) {
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/actions/jobs/1001" {
+			w.Write([]byte(`{"id":1001,"name":"original job","status":"completed","conclusion":"cancelled"}`))
+			return
+		}
+		t.Fatalf("unexpected github request: %s %s", r.Method, r.URL.String())
+	}))
+	defer ghServer.Close()
+
+	store := state.New(t.TempDir())
+	_, st, err := store.CreateRequest(state.RunnerRequest{
+		ID:                 "1001",
+		Source:             "test",
+		RepositoryFullName: "o/r",
+		JobID:              1001,
+		Labels:             []string{"self-hosted", "e2b"},
+		RunnerName:         "e2b-1001",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Status = state.StatusRunning
+	st.SandboxID = "sb-1001"
+	st.ProcessPID = 42
+	st.RunningAt = time.Now().UTC().Add(-time.Minute)
+	st.AssignedJobID = 2002
+	st.AssignedJobName = "actual job"
+	if err := store.WriteState(st); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeSandbox{}
+	srv := newTestServer(t, store, ghServer.URL, fake)
+	srv.Close()
+	if err := srv.Recover(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.ReadState("1001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != state.StatusRunning || got.AssignedJobID != 2002 || got.AssignedJobName != "actual job" {
+		t.Fatalf("recovery changed active job assignment: %#v", got)
+	}
+	if fake.recoveredCount() != 1 {
+		t.Fatalf("recovery reattached sandbox %d times, want 1", fake.recoveredCount())
+	}
+	if fake.stoppedCount() != 0 {
+		t.Fatalf("recovery stopped sandbox assigned to another job %d times", fake.stoppedCount())
 	}
 }
 


### PR DESCRIPTION
## Summary

- defer weak workflow-job completion events when the active runner is owned by another job
- keep trusted `runner_name` completion cleanup and reconnect deferred active runners after a runnerd restart
- keep returned state versions synchronized after mismatched-job inspection or requeue
- cover assigned-job, job-start marker, out-of-order webhook, and restart recovery paths

## Root cause

A runner registered for workflow job A can be claimed by another same-label job B. If A is then cancelled or completed without a `runner_name`, runnerd falls back to the original workflow job ID, overwrites the recorded assignment, and stops the Sandbox currently executing B. GitHub subsequently reports that B self-hosted runner lost communication.

The mismatched-job path also returned a stale state version after persisting its inspection result, which could cause a follow-up `state conflict`.

## Impact

Existing workflows, Runner Specs, database schema, and production configuration do not need changes. Weak completion events no longer stop a Sandbox owned by another job, while authoritative `runner_name` completions still clean up immediately. Active mismatched runners are reattached after runnerd restarts.

## Validation

- `go test ./internal/server -count=1 -timeout=5m`
- `task lint`
- `task test`
- `git diff --check`