### PR TITLE
fix(diagnostics): bound recent failure query

### DIFF
--- a/internal/server/server_diagnostics.go
+++ b/internal/server/server_diagnostics.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/qiniu/ci-runner/internal/redact"
-	"github.com/qiniu/ci-runner/internal/state"
 )
 
 func (s *Server) handleDiagnosticsPprof(w http.ResponseWriter, r *http.Request) {
@@ -19,19 +18,10 @@ func (s *Server) handleDiagnosticsPprof(w http.ResponseWriter, r *http.Request) 
 		DumpScript  string `json:"dump_script"`
 	}
 	addresses, scripts := discoverPprofArtifacts()
-	states, err := s.store.ListStates()
+	failures, err := s.store.ListRecentFailedStates(5)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
-	}
-	failures := make([]state.RunnerState, 0, 5)
-	for _, st := range states {
-		if st.Status == state.StatusFailed {
-			failures = append(failures, st)
-			if len(failures) == 5 {
-				break
-			}
-		}
 	}
 	out := make([]artifact, 0, len(addresses))
 	for i := range addresses {

--- a/internal/server/server_helpers_test.go
+++ b/internal/server/server_helpers_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -762,6 +763,25 @@ func TestPatchRepositoryPolicyReturns400ForInvalidID(t *testing.T) {
 
 // ---------- handleDiagnosticsPprof ----------
 
+type diagnosticsBoundedStore struct {
+	state.Store
+	listStatesCalls    int
+	recentFailedCalls  int
+	recentFailedLimit  int
+	recentFailedStates []state.RunnerState
+}
+
+func (s *diagnosticsBoundedStore) ListStates() ([]state.RunnerState, error) {
+	s.listStatesCalls++
+	return nil, errors.New("diagnostics must not scan all runner states")
+}
+
+func (s *diagnosticsBoundedStore) ListRecentFailedStates(limit int) ([]state.RunnerState, error) {
+	s.recentFailedCalls++
+	s.recentFailedLimit = limit
+	return append([]state.RunnerState(nil), s.recentFailedStates...), nil
+}
+
 func TestDiagnosticsPprofEndpointRequiresAuth(t *testing.T) {
 	store := state.New(t.TempDir())
 	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
@@ -793,6 +813,39 @@ func TestDiagnosticsPprofEndpointReturnsJSON(t *testing.T) {
 	}
 	if _, ok := body["github"]; !ok {
 		t.Error("GET /diagnostics/pprof: missing 'github' field in response")
+	}
+}
+
+func TestDiagnosticsPprofEndpointUsesBoundedRecentFailures(t *testing.T) {
+	store := &diagnosticsBoundedStore{
+		Store: state.New(t.TempDir()),
+		recentFailedStates: []state.RunnerState{
+			{ID: "failed-latest", Status: state.StatusFailed},
+			{ID: "failed-previous", Status: state.StatusFailed},
+		},
+	}
+	srv := newTestServer(t, store, "http://example.test", &fakeSandbox{})
+
+	req := adminRequest(http.MethodGet, "/diagnostics/pprof", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /diagnostics/pprof: expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if store.listStatesCalls != 0 {
+		t.Fatalf("ListStates calls = %d, want 0", store.listStatesCalls)
+	}
+	if store.recentFailedCalls != 1 || store.recentFailedLimit != 5 {
+		t.Fatalf("ListRecentFailedStates calls = %d limit = %d, want 1 call with limit 5", store.recentFailedCalls, store.recentFailedLimit)
+	}
+	var body struct {
+		RecentFailures []state.RunnerState `json:"recent_failures"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("GET /diagnostics/pprof: invalid JSON: %v", err)
+	}
+	if len(body.RecentFailures) != 2 || body.RecentFailures[0].ID != "failed-latest" || body.RecentFailures[1].ID != "failed-previous" {
+		t.Fatalf("recent_failures = %#v, want bounded store result", body.RecentFailures)
 	}
 }
 

--- a/internal/state/runner_requests.go
+++ b/internal/state/runner_requests.go
@@ -242,6 +242,33 @@ func (s *DBStore) ListStates() ([]RunnerState, error) {
 	return states, nil
 }
 
+func (s *DBStore) ListRecentFailedStates(limit int) ([]RunnerState, error) {
+	db, err := s.dbOrEnsure()
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	var records []runnerRequestRecord
+	if err := db.
+		Select(runnerRequestListSelectColumns).
+		Where("status = ?", StatusFailed).
+		Order("queued_at DESC, id ASC").
+		Limit(limit).
+		Find(&records).Error; err != nil {
+		return nil, err
+	}
+	states := make([]RunnerState, 0, len(records))
+	for _, record := range records {
+		states = append(states, recordToState(record))
+	}
+	return states, nil
+}
+
 func (s *DBStore) ListActiveStates() ([]RunnerState, error) {
 	db, err := s.dbOrEnsure()
 	if err != nil {

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -298,6 +298,7 @@ type RunnerRequestStore interface {
 	ReadState(id string) (RunnerState, error)
 	WriteState(st RunnerState) error
 	ListStates() ([]RunnerState, error)
+	ListRecentFailedStates(limit int) ([]RunnerState, error)
 	ListActiveStates() ([]RunnerState, error)
 	ListMismatchedCompletedStates(limit int) ([]RunnerState, error)
 	ListFailedWorkflowJobStates(limit int) ([]RunnerState, error)

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -2331,6 +2331,65 @@ func TestListStatesPage(t *testing.T) {
 	}
 }
 
+func TestListRecentFailedStatesBoundsOrdersAndProjects(t *testing.T) {
+	store := New(t.TempDir())
+	base := time.Date(2026, time.August, 20, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 7; i++ {
+		_, st, err := store.CreateRequest(RunnerRequest{
+			ID:                     fmt.Sprintf("failed-%d", i),
+			Source:                 "test",
+			Labels:                 []string{"self-hosted"},
+			RunnerName:             fmt.Sprintf("e2b-failed-%d", i),
+			SandboxAPIURL:          "https://sandbox-secret.example.test",
+			SandboxAPIKeyEncrypted: "encrypted-secret",
+			CreatedAt:              base.Add(time.Duration(i) * time.Minute),
+		}, []byte(`{"workflow_job":{"id":123}}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		st.Status = StatusFailed
+		st.FailureStage = "runner_registration"
+		st.FailureReason = fmt.Sprintf("fixture-%d", i)
+		if err := store.WriteState(st); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, completed, err := store.CreateRequest(RunnerRequest{
+		ID:         "newest-completed",
+		Source:     "test",
+		Labels:     []string{"self-hosted"},
+		RunnerName: "e2b-newest-completed",
+		CreatedAt:  base.Add(8 * time.Minute),
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed.Status = StatusCompleted
+	if err := store.WriteState(completed); err != nil {
+		t.Fatal(err)
+	}
+
+	states, err := store.ListRecentFailedStates(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantIDs := []string{"failed-6", "failed-5", "failed-4", "failed-3", "failed-2"}
+	if len(states) != len(wantIDs) {
+		t.Fatalf("len = %d, want %d", len(states), len(wantIDs))
+	}
+	for i, wantID := range wantIDs {
+		if states[i].ID != wantID {
+			t.Fatalf("states[%d].ID = %q, want %q", i, states[i].ID, wantID)
+		}
+		if states[i].Status != StatusFailed {
+			t.Fatalf("states[%d].Status = %q, want %q", i, states[i].Status, StatusFailed)
+		}
+		if states[i].SandboxAPIURL != "" || states[i].SandboxAPIKeyEncrypted != "" {
+			t.Fatalf("states[%d] loaded secret columns: %#v", i, states[i])
+		}
+	}
+}
+
 func TestRunnerRequestListProjectionExcludesHeavyAndSecretColumns(t *testing.T) {
 	projection := "," + strings.Join(runnerRequestListSelectColumns, ",") + ","
 	for _, excluded := range []string{


### PR DESCRIPTION
## Summary

- replace the Diagnostics full runner-state scan with a bounded recent-failure query
- reuse the runner-request list projection so heavy payload and Sandbox credential fields are not loaded
- preserve Admin authorization, database DSN redaction, and the existing JSON response contract

## Root cause

GET /diagnostics/pprof called ListStates and loaded every runner_requests row and its heavy fields only to select five failed records. As production history grew, this unbounded path could exceed the reverse-proxy timeout.

## Verification

- go test ./internal/state ./internal/server -count=1
- task test (173 UI tests plus Go race and coverage suites)
- git diff --check

## Deployment

No database migration or Admin configuration change is required.