### PR TITLE
ci: pin staticcheck toolchain

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,11 +26,11 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache-dependency-path: go.sum
       - uses: oven-sh/setup-bun@v2
       - run: cd ui && bun install --frozen-lockfile && bun run build
-      - run: go install honnef.co/go/tools/cmd/staticcheck@latest
+      - run: go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
       - run: staticcheck ./cmd/... ./internal/...
 
   gofmt:


### PR DESCRIPTION
## Summary
- run Staticcheck with the Go version declared by `go.mod`
- pin Staticcheck to v0.7.0 instead of floating on `latest`
- keep the other CI jobs on stable Go for forward-compatibility coverage

## Root cause
GitHub Actions resolved `stable` to Go 1.27.0, while Staticcheck v0.7.0 could not decode that toolchain export-data version. The failure is independent of the Diagnostics changes in #78.

## Verification
- `staticcheck ./cmd/... ./internal/...`
- `go test ./... -count=1`
- workflow YAML parse
- `git diff --check`

## Related
Unblocks #78.