### PR TITLE
fix(runner): make admission rejection atomic

### DIFF
--- a/docs/deployment-smoke.md
+++ b/docs/deployment-smoke.md
@@ -102,6 +102,7 @@ curl -fsS -b "$COOKIE_JAR" https://<runnerd-host>/diagnostics/pprof | jq
 curl -fsS -b "$COOKIE_JAR" https://<runnerd-host>/diagnostics/vars | jq
 test "$(curl -sS -o /dev/null -w '%{http_code}' -b "$COOKIE_JAR" https://<runnerd-host>/runner_groups)" = 404
 test "$(curl -sS -o /dev/null -w '%{http_code}' -b "$COOKIE_JAR" https://<runnerd-host>/runner_policies)" = 404
+test "$(curl -sS -o /dev/null -w '%{http_code}' -b "$COOKIE_JAR" https://<runnerd-host>/diagnostics/catalog-migration-readiness)" = 404
 ```
 
 Check:
@@ -110,7 +111,7 @@ Check:
 - `state.database` points at the intended sqlite, Postgres, or MySQL database.
 - pprof discovery files and dump scripts are visible when the local pprof service is available.
 - Recent failure summaries are empty or understood.
-- The retired Runner Group and Policy APIs return `404`; `/admin/runner_groups` and `/admin/runner_policies` still redirect harmlessly to Runner Specs.
+- The retired Runner Group, Policy, and temporary catalog migration readiness APIs return `404`; `/admin/runner_groups` and `/admin/runner_policies` still redirect harmlessly to Runner Specs.
 - A Runner Request persisted as `failed` with `failure_stage=admission` and `failure_reason=profile_labels_not_matched` is shown as **Not matched**, is excluded from the failed metric, can be filtered independently, and has no retry action. Genuine failed requests remain **Failed** and retryable where applicable.
 - Existing workflow `runs-on` labels and enabled Runner Spec matching remain unchanged. Do not edit Catalog or Sandbox configuration as part of the Release C deployment.
 - Legacy `runner_groups`, `runner_group_specs`, and `repository_policies` tables remain untouched for rollback. Dropping them requires a later, separately authorized database-maintenance window.

--- a/docs/zh/deployment-smoke.md
+++ b/docs/zh/deployment-smoke.md
@@ -100,6 +100,7 @@ curl -fsS -b "$COOKIE_JAR" https://<runnerd-host>/diagnostics/pprof | jq
 curl -fsS -b "$COOKIE_JAR" https://<runnerd-host>/diagnostics/vars | jq
 test "$(curl -sS -o /dev/null -w '%{http_code}' -b "$COOKIE_JAR" https://<runnerd-host>/runner_groups)" = 404
 test "$(curl -sS -o /dev/null -w '%{http_code}' -b "$COOKIE_JAR" https://<runnerd-host>/runner_policies)" = 404
+test "$(curl -sS -o /dev/null -w '%{http_code}' -b "$COOKIE_JAR" https://<runnerd-host>/diagnostics/catalog-migration-readiness)" = 404
 ```
 
 检查：
@@ -108,7 +109,7 @@ test "$(curl -sS -o /dev/null -w '%{http_code}' -b "$COOKIE_JAR" https://<runner
 - `state.database` 指向预期的 sqlite、Postgres 或 MySQL 数据库。
 - 当 local pprof service 可用时，可以看到 pprof discovery files 和 dump scripts。
 - Recent failure summaries 为空，或每一项都已理解。
-- 已退役的 Runner Group 和 Policy API 返回 `404`；`/admin/runner_groups` 与 `/admin/runner_policies` 仍会安全重定向到 Runner Specs。
+- 已退役的 Runner Group、Policy 及临时 catalog migration readiness API 返回 `404`；`/admin/runner_groups` 与 `/admin/runner_policies` 仍会安全重定向到 Runner Specs。
 - 持久化为 `failed` 且 `failure_stage=admission`、`failure_reason=profile_labels_not_matched` 的 Runner 请求显示为**未匹配**，不计入失败指标，可单独筛选，也不显示重试操作；真正的失败请求仍显示为**失败**，并在适用时允许重试。
 - 现有 workflow `runs-on` labels 和已启用 Runner Spec 的匹配行为保持不变。Release C 部署不得同时修改 Catalog 或 Sandbox 配置。
 - 遗留的 `runner_groups`、`runner_group_specs` 和 `repository_policies` 表保持原样用于回滚；删除它们必须安排后续独立授权的数据库维护窗口。

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -197,7 +197,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func isRetiredCatalogAPIPath(path string) bool {
 	return path == "/runner_groups" || strings.HasPrefix(path, "/runner_groups/") ||
-		path == "/runner_policies" || strings.HasPrefix(path, "/runner_policies/")
+		path == "/runner_policies" || strings.HasPrefix(path, "/runner_policies/") ||
+		path == "/diagnostics/catalog-migration-readiness" || strings.HasPrefix(path, "/diagnostics/catalog-migration-readiness/")
 }
 
 type loggingResponseWriter struct {

--- a/internal/server/server_helpers_test.go
+++ b/internal/server/server_helpers_test.go
@@ -475,6 +475,8 @@ func TestReleaseCRemovesRetiredCatalogAPIs(t *testing.T) {
 		{http.MethodPost, "/runner_policies", `{}`},
 		{http.MethodPatch, "/runner_policies/1", `{}`},
 		{http.MethodDelete, "/runner_policies/1", ""},
+		{http.MethodGet, "/diagnostics/catalog-migration-readiness", ""},
+		{http.MethodGet, "/diagnostics/catalog-migration-readiness/", ""},
 		{http.MethodOptions, "/runner_groups/group", ""},
 		{"PURGE", "/runner_policies/1", ""},
 	}

--- a/internal/server/server_runner_lifecycle.go
+++ b/internal/server/server_runner_lifecycle.go
@@ -96,6 +96,8 @@ func (s *Server) enqueueRunnerRequest(req state.RunnerRequest, payload []byte) (
 }
 
 func (s *Server) rejectAdmission(req state.RunnerRequest, payload []byte, reason string) (state.RunnerState, error) {
+	// CreateRejectedRequest relies on database uniqueness for duplicate deliveries
+	// and inserts the terminal state without exposing a queued row.
 	created, st, err := s.store.CreateRejectedRequest(req, payload, reason)
 	if err != nil {
 		return state.RunnerState{}, err

--- a/internal/server/server_runner_lifecycle.go
+++ b/internal/server/server_runner_lifecycle.go
@@ -96,7 +96,7 @@ func (s *Server) enqueueRunnerRequest(req state.RunnerRequest, payload []byte) (
 }
 
 func (s *Server) rejectAdmission(req state.RunnerRequest, payload []byte, reason string) (state.RunnerState, error) {
-	created, st, err := s.store.CreateRequest(req, payload)
+	created, st, err := s.store.CreateRejectedRequest(req, payload, reason)
 	if err != nil {
 		return state.RunnerState{}, err
 	}
@@ -105,13 +105,6 @@ func (s *Server) rejectAdmission(req state.RunnerRequest, payload []byte, reason
 		return st, nil
 	}
 	metrics.RecordRunnerRequest(req.RepositoryFullName, req.ProfileName, req.Source, "rejected")
-	st.Status = state.StatusFailed
-	st.FailureStage = "admission"
-	st.FailureReason = reason
-	st.Error = "runner admission rejected"
-	if err := s.store.WriteState(st); err != nil {
-		return state.RunnerState{}, err
-	}
 	s.store.AppendLog(req.ID, "control.log", []byte("runner admission rejected: "+reason+"\n"))
 	s.logger.Info("runner admission rejected and recorded", "id", req.ID, "repository", req.RepositoryFullName, "reason", reason)
 	metrics.RecordWorkflowFailure(req.RepositoryFullName, "unknown", req.RunnerName, req.ProfileName, "admission", reason)

--- a/internal/state/runner_requests.go
+++ b/internal/state/runner_requests.go
@@ -68,6 +68,14 @@ type githubInstallationRepositoryAccessQueryBatch struct {
 }
 
 func (s *DBStore) CreateRequest(req RunnerRequest, payload []byte) (bool, RunnerState, error) {
+	return s.createRequest(req, payload, StatusQueued, "", "", "")
+}
+
+func (s *DBStore) CreateRejectedRequest(req RunnerRequest, payload []byte, reason string) (bool, RunnerState, error) {
+	return s.createRequest(req, payload, StatusFailed, "admission", strings.TrimSpace(reason), "runner admission rejected")
+}
+
+func (s *DBStore) createRequest(req RunnerRequest, payload []byte, status, failureStage, failureReason, errorMessage string) (bool, RunnerState, error) {
 	db, err := s.dbOrEnsure()
 	if err != nil {
 		return false, RunnerState{}, err
@@ -102,6 +110,10 @@ func (s *DBStore) CreateRequest(req RunnerRequest, payload []byte) (bool, Runner
 		RepositoryFullName: req.RepositoryFullName,
 		GitHubPayloadJSON:  string(payload),
 	})
+	var failedAt *time.Time
+	if status == StatusFailed {
+		failedAt = &now
+	}
 	record := runnerRequestRecord{
 		ID:                      req.ID,
 		Source:                  req.Source,
@@ -123,9 +135,13 @@ func (s *DBStore) CreateRequest(req RunnerRequest, payload []byte) (bool, Runner
 		SandboxAPIURL:           strings.TrimSpace(req.SandboxAPIURL),
 		SandboxAPIKeyEncrypted:  strings.TrimSpace(req.SandboxAPIKeyEncrypted),
 		SandboxConfigSource:     strings.TrimSpace(req.SandboxConfigSource),
-		Status:                  StatusQueued,
+		Status:                  status,
+		FailureStage:            failureStage,
+		FailureReason:           failureReason,
+		Error:                   errorMessage,
 		GitHubPayloadJSON:       string(payload),
 		QueuedAt:                req.CreatedAt,
+		FailedAt:                failedAt,
 		UpdatedAt:               now,
 		Version:                 0,
 	}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -270,6 +270,7 @@ type SandboxServiceDefaultAudience struct {
 type RunnerRequestStore interface {
 	Ensure() error
 	CreateRequest(req RunnerRequest, payload []byte) (bool, RunnerState, error)
+	CreateRejectedRequest(req RunnerRequest, payload []byte, reason string) (bool, RunnerState, error)
 	ReadRequest(id string) (RunnerRequest, error)
 	ReadState(id string) (RunnerState, error)
 	WriteState(st RunnerState) error

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -828,6 +828,48 @@ func TestCreateRequestIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestCreateRejectedRequestIsNeverRunnable(t *testing.T) {
+	store := New(t.TempDir())
+	req := RunnerRequest{
+		ID:                 "rejected",
+		Source:             "github_webhook",
+		JobID:              12345,
+		RepositoryFullName: "o/r",
+		RequestedLabels:    []string{"ubuntu-latest"},
+		Labels:             []string{"ubuntu-latest"},
+		RunnerName:         "e2b-rejected",
+	}
+	created, st, err := store.CreateRejectedRequest(req, []byte(`{"workflow_job":{"id":12345}}`), "profile_labels_not_matched")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("expected rejected request to be created")
+	}
+	if st.Status != StatusFailed || st.FailureStage != "admission" || st.FailureReason != "profile_labels_not_matched" {
+		t.Fatalf("unexpected rejected state: %#v", st)
+	}
+	if st.Error != "runner admission rejected" || st.FailedAt.IsZero() {
+		t.Fatalf("rejected state is missing terminal failure details: %#v", st)
+	}
+
+	_, _, claimed, err := store.ClaimNextRunnable("worker", time.Now().UTC().Add(time.Minute), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed {
+		t.Fatal("rejected request must never be visible to the runnable queue")
+	}
+
+	created, duplicate, err := store.CreateRejectedRequest(req, nil, "different_reason")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created || duplicate.Status != StatusFailed || duplicate.FailureReason != "profile_labels_not_matched" {
+		t.Fatalf("duplicate rejection must reuse the original terminal state: created=%v state=%#v", created, duplicate)
+	}
+}
+
 func TestCreateRequestConflictingWorkflowJobReturnsExistingState(t *testing.T) {
 	store := New(t.TempDir())
 	_, st, err := store.CreateRequest(RunnerRequest{


### PR DESCRIPTION
## Summary

- Persist admission-rejected workflow jobs as terminal records in the initial database insert, so queue workers can never claim unmatched requests.
- Preserve duplicate webhook idempotency and the original rejection evidence.
- Return an explicit `404` for the retired `/diagnostics/catalog-migration-readiness` endpoint, including its trailing-slash variant.

## Root cause

Release C displays `profile_labels_not_matched` as a neutral unmatched outcome. The previous rejection path first inserted a `queued` request and then updated it to `failed/admission`. A queue worker could claim the request between those writes, attempt to load an empty Runner Spec name, and replace the evidence with a misleading `profile_lookup` failure.

## Compatibility

- No workflow label or matching behavior changes.
- No database schema or data migration changes.
- No production configuration changes are required.
- Existing request records remain untouched.
- Normal matched requests keep the existing queued lifecycle; only newly rejected requests become terminal atomically.

## Verification

- `go test ./internal/state -run TestCreateRejectedRequestIsNeverRunnable -count=1`
- `go test ./internal/server -run TestReleaseCRemovesRetiredCatalogAPIs -count=1`
- `GOTOOLCHAIN=go1.26.3 task lint`
- `GOTOOLCHAIN=go1.26.3 task test`
- `GOTOOLCHAIN=go1.26.3 task build`
- `git diff --check`