### PR TITLE
docs(ui): add Cache S3 user and operator guide

### DIFF
--- a/ui/src/app-load-policy.test.js
+++ b/ui/src/app-load-policy.test.js
@@ -88,6 +88,7 @@ describe("app load policy", () => {
     expect(appPolicy.appRouteAccess?.("/docs/getting-started/hosted")).toBe("public")
     expect(appPolicy.appRouteAccess?.("/docs/getting-started/deploy")).toBe("public")
     expect(appPolicy.appRouteAccess?.("/docs/guides/workflow")).toBe("public")
+    expect(appPolicy.appRouteAccess?.("/docs/guides/cache")).toBe("public")
     expect(appPolicy.appRouteAccess?.("/docs/guides/custom-templates")).toBe("public")
     expect(appPolicy.appRouteAccess?.("/docs/troubleshooting")).toBe("public")
     expect(appPolicy.appRouteAccess?.("/docs/reference/runner-labels")).toBe("public")

--- a/ui/src/components/docs-page.test.js
+++ b/ui/src/components/docs-page.test.js
@@ -35,6 +35,7 @@ describe("DocsPage", () => {
     expect(html).toContain('id="job-stays-queued"')
     expect(html).toContain('href="/docs/reference/runner-labels"')
     expect(html).toContain('href="/docs/guides/custom-templates"')
+    expect(html).toContain('href="/docs/guides/cache"')
   })
 
   test("keeps source links external while guide links stay on the site", () => {

--- a/ui/src/content/site-docs/en/cache.md
+++ b/ui/src/content/site-docs/en/cache.md
@@ -1,0 +1,134 @@
+# Configure and use Cache S3
+
+Save Cache S3 in Preferences, then use `qiniu/actions-cache@v5` in the workflow. Cache bytes go directly to the user bucket. runnerd does not proxy them.
+
+## Before you start
+
+You need:
+
+- a connected GitHub repository with an effective Sandbox service;
+- a bucket in the S3 region that matches the selected Sandbox region;
+- an access key and secret with object read and write permission on that bucket.
+
+Personal accounts use [Account Preferences](/account/preferences). Organization repositories are configured by an active member at `/organizations/{login}/preferences`. Outside collaborators can see readiness status but cannot save organization Cache S3 settings.
+
+Do not put Cache access keys in a workflow, repository secret, issue, or chat message.
+
+## How this differs from GitHub cache
+
+Official `actions/cache` stores objects in GitHub Cache Service. Sandbox runners do not receive that credential, so GitHub cache does not work here. Do not re-enable the built-in cache on `actions/setup-go`.
+
+`qiniu/actions-cache@v5` writes to the S3 bucket you save in the web UI:
+
+- cache bytes go directly to S3; runnerd does not proxy them;
+- credentials are short-lived STS tokens minted by runnerd, not long-lived access keys;
+- read and write prefixes are injected per repository and branch or PR, and workflow env changes cannot exceed the STS policy;
+- Fork PRs can only read the default-branch cache and cannot save.
+
+Keep the familiar `key` / `restore-keys` inputs, but change `uses` to `qiniu/actions-cache@v5`.
+
+## 1. Save Cache S3 in the web UI
+
+There is no global Cache S3 setting. Each account or organization fills in its own values. Personal accounts open [Account Preferences](/account/preferences). Organization repositories are configured by an active member at `/organizations/{login}/preferences`.
+
+Select and save the Sandbox service region first, then fill in **Cache S3**:
+
+| Field | Who sets it | Notes |
+| --- | --- | --- |
+| Region / Endpoint | Filled automatically | Taken from the selected Sandbox region; not editable |
+| Bucket | User | Must live in the S3 region mapped from that Sandbox region |
+| Prefix | Optional | Default `gh-actions-cache`. Objects are stored as `<prefix>/<owner>/<repo>/scopes/...` |
+| Access Key ID | User | An AK with object read and write permission on the bucket |
+| Secret Access Key | User | Matching SK. Stored encrypted; the page never shows it again |
+
+After save, the page only shows that Cache S3 is configured. Enter a new AK/SK to replace the saved values. If the page reports that the selected region has no S3 endpoint, ask the runnerd administrator to add `s3_region` and `s3_endpoint` under `sandbox.regions`.
+
+You can also use an IAM sub-account instead of the primary key. Create a user in [IAM Overview](https://portal.qiniu.com/iam/overview) and grant:
+
+- Bucket: read objects, upload objects, modify objects, and delete objects;
+- Security Token Service: get federation tokens.
+
+runnerd uses that AK/SK only to mint STS. The cache action in the sandbox receives the short-lived token.
+
+Use a dedicated bucket per GitHub installation when possible, and configure a bucket lifecycle rule so expired cache objects are deleted automatically.
+
+## 2. Use cache in a workflow
+
+Use [`qiniu/actions-cache@v5`](https://github.com/qiniu/actions-cache) instead of `actions/cache`. The workflow does not set bucket, endpoint, region, access key, or secret:
+
+```yaml
+jobs:
+  check:
+    runs-on: [qiniu, ubuntu-24.04]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      - uses: qiniu/actions-cache@v5
+        with:
+          path: |
+            ${{ github.workspace }}/.cache/go/pkg/mod
+            /tmp/go-build-cache
+          key: ${{ runner.os }}-go-check-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-check-
+            ${{ runner.os }}-go-
+```
+
+Keep `setup-go` for installing Go. Cache restore and save belong to `qiniu/actions-cache@v5`. Restore runs at the start of the step. Save runs in the post step only after the job succeeds. A failed job does not save.
+
+## 3. Cache isolation
+
+- A trusted branch reads its own scope, then the default branch, and writes only its own scope.
+- An internal PR reads the PR scope, then the base branch and default branch, and writes only its own `pr-N` scope.
+- A Fork PR can only read the default-branch cache and cannot save. `Cache save skipped: RUNS_ON_S3_CACHE_WRITE_PREFIX is not set` is expected, not a failure.
+- `pull_request_target`, `workflow_run`, `issue_comment`, and unverified metadata are also default-branch read-only.
+
+Do not share one write key across parallel jobs. Choose one of these options:
+
+1. Give each saving job its own key prefix, such as `Linux-go-tidy-` and `Linux-go-test-`.
+2. Create a dedicated warmup job that saves, and let other jobs restore only.
+
+Jobs in the same run do not wait for each other. A restore can start before another job finishes saving. Scripts that reuse images or artifacts must handle a cache miss.
+
+## 4. Verify
+
+A successful S3 cache job logs:
+
+```text
+The cache action detected a local S3 bucket cache. Using it.
+Cache restored successfully
+Cache saved successfully
+```
+
+A Fork PR save line is `Cache save skipped`. If `local S3 bucket cache` is missing, that job did not receive Cache S3 credentials and the action fell back to GitHub's cache.
+
+## runnerd administrator configuration
+
+The operator who deploys runnerd must provide the region catalog and STS endpoint in `runnerd.yaml`:
+
+```yaml
+sandbox:
+  regions:
+    - id: us-south-1
+      label: "United States · Dallas 1"
+      sandbox_api_url: https://us-south-1-sandbox.qiniuapi.com
+      s3_region: us-north-1
+      s3_endpoint: https://internal-s3-las-us-north-1-dal.qiniucs.com
+    - id: cn-yangzhou-1
+      label: "China · Yangzhou 1"
+      sandbox_api_url: https://cn-yangzhou-1-sandbox.qiniuapi.com
+      s3_region: cn-east-1
+      s3_endpoint: https://internal-s3-las-cn-east-1-yz.qiniucs.com
+
+cache:
+  sts_endpoint: https://sts-ov.qiniuapi.com
+```
+
+Each region requires `id`, `label`, and `sandbox_api_url`. `s3_region` and `s3_endpoint` must be set together; only regions with both fields support Cache S3. The endpoint may be private to the Sandbox network, so runnerd validates configuration shape only and does not probe the bucket from the control plane.
+
+On every sandbox start, runnerd verifies Workflow Run context, mints an STS token for the sandbox lifetime plus five minutes, and injects `RUNS_ON_S3_*` variables. There is no refresh.
+
+See [Deploy runnerd](/docs/getting-started/deploy) for the full operator path.

--- a/ui/src/content/site-docs/en/cache.md
+++ b/ui/src/content/site-docs/en/cache.md
@@ -23,7 +23,7 @@ Official `actions/cache` stores objects in GitHub Cache Service. Sandbox runners
 - cache bytes go directly to S3; runnerd does not proxy them;
 - credentials are short-lived STS tokens minted by runnerd, not long-lived access keys;
 - read and write prefixes are injected per repository and branch or PR, and workflow env changes cannot exceed the STS policy;
-- Fork PRs can only read the default-branch cache and cannot save.
+- Fork PRs read the PR, base-branch, and default-branch scopes, and write only their own `pr-N` scope.
 
 Keep the familiar `key` / `restore-keys` inputs, but change `uses` to `qiniu/actions-cache@v5`.
 
@@ -83,7 +83,7 @@ Keep `setup-go` for installing Go. Cache restore and save belong to `qiniu/actio
 
 - A trusted branch reads its own scope, then the default branch, and writes only its own scope.
 - An internal PR reads the PR scope, then the base branch and default branch, and writes only its own `pr-N` scope.
-- A Fork PR can only read the default-branch cache and cannot save. `Cache save skipped: RUNS_ON_S3_CACHE_WRITE_PREFIX is not set` is expected, not a failure.
+- A Fork PR reads the PR, base-branch, and default-branch scopes, and writes only its own `pr-N` scope. If GitHub does not expose trusted PR metadata, the job stays default-branch read-only and logs `Cache save skipped: RUNS_ON_S3_CACHE_WRITE_PREFIX is not set`.
 - `pull_request_target`, `workflow_run`, `issue_comment`, and unverified metadata are also default-branch read-only.
 
 Do not share one write key across parallel jobs. Choose one of these options:
@@ -103,7 +103,7 @@ Cache restored successfully
 Cache saved successfully
 ```
 
-A Fork PR save line is `Cache save skipped`. If `local S3 bucket cache` is missing, that job did not receive Cache S3 credentials and the action fell back to GitHub's cache.
+If a Fork PR cannot be verified, the save line is `Cache save skipped`. If `local S3 bucket cache` is missing, that job did not receive Cache S3 credentials and the action fell back to GitHub's cache.
 
 ## runnerd administrator configuration
 

--- a/ui/src/content/site-docs/en/getting-started-deploy.md
+++ b/ui/src/content/site-docs/en/getting-started-deploy.md
@@ -63,6 +63,8 @@ Ordinary users manage personal or organization Sandbox credentials under Prefere
 
 Do not put ordinary-user Sandbox credentials in `runnerd.yaml`. The application stores scoped API Keys encrypted and never returns their full value to the browser.
 
+Cache S3 is also user- or organization-owned in Preferences. Operators must set both `s3_region` and `s3_endpoint` on each cache-capable entry in `sandbox.regions`, plus `cache.sts_endpoint`. See [Configure and use Cache S3](/docs/guides/cache).
+
 ## 5. Verify managed runner specs
 
 runnerd reconciles managed specs for `ubuntu-slim`, `ubuntu-22.04`, `ubuntu-24.04`, preview `ubuntu-26.04`, and `ubuntu-latest`. Operators control whether each managed spec is enabled plus its concurrency and idle capacity. The catalog labels and public template names remain runnerd-owned.

--- a/ui/src/content/site-docs/en/getting-started-hosted.md
+++ b/ui/src/content/site-docs/en/getting-started-hosted.md
@@ -50,6 +50,8 @@ The `qiniu` label selects Qiniu-managed routing. The exact OS label selects the 
 
 [Copy a complete workflow](/docs/guides/workflow)
 
+To cache across runs, save Cache S3 in Preferences and use `qiniu/actions-cache@v5`. See [Configure and use Cache S3](/docs/guides/cache).
+
 ## 5. Run and verify the job
 
 Trigger the workflow from GitHub Actions. While the job runs:

--- a/ui/src/content/site-docs/en/index.md
+++ b/ui/src/content/site-docs/en/index.md
@@ -20,6 +20,12 @@ Copy a complete workflow using the current managed labels and learn what a succe
 
 [Run your first workflow](/docs/guides/workflow)
 
+## Configure cache
+
+Save Cache S3 in Preferences, then use `qiniu/actions-cache@v5` in the workflow.
+
+[Configure and use Cache S3](/docs/guides/cache)
+
 ## Build a custom runner template
 
 Add your own toolchain to a private Sandbox template, connect it to a custom Runner Spec, and verify the complete workflow path.

--- a/ui/src/content/site-docs/en/troubleshooting.md
+++ b/ui/src/content/site-docs/en/troubleshooting.md
@@ -65,7 +65,7 @@ Check:
 1. The repository owner saved Cache S3 in Preferences, and the selected Sandbox region has an S3 endpoint.
 2. The workflow uses `qiniu/actions-cache@v5`, and `actions/setup-go` sets `cache: false`.
 3. The log contains `The cache action detected a local S3 bucket cache.` Missing that line means the job fell back to GitHub's cache.
-4. Fork PRs are default-branch read-only; `Cache save skipped` is expected.
+4. Fork PRs write only their own `pr-N` scope. `Cache save skipped` means trusted PR metadata was unavailable, so the job stayed default-branch read-only.
 5. Parallel jobs do not share one write key.
 
 See [Configure and use Cache S3](/docs/guides/cache).

--- a/ui/src/content/site-docs/en/troubleshooting.md
+++ b/ui/src/content/site-docs/en/troubleshooting.md
@@ -58,6 +58,18 @@ Check the protocol, hostname, path, client ID, and client secret. A protected de
 
 The GitHub App webhook secret and `github.webhook_secret` must be identical. Copy the complete value without quotes or surrounding whitespace, save it, and redeliver a recent event.
 
+## Cache restore misses or save is skipped
+
+Check:
+
+1. The repository owner saved Cache S3 in Preferences, and the selected Sandbox region has an S3 endpoint.
+2. The workflow uses `qiniu/actions-cache@v5`, and `actions/setup-go` sets `cache: false`.
+3. The log contains `The cache action detected a local S3 bucket cache.` Missing that line means the job fell back to GitHub's cache.
+4. Fork PRs are default-branch read-only; `Cache save skipped` is expected.
+5. Parallel jobs do not share one write key.
+
+See [Configure and use Cache S3](/docs/guides/cache).
+
 ## Collect useful evidence
 
 When asking for help, include:

--- a/ui/src/content/site-docs/zh/cache.md
+++ b/ui/src/content/site-docs/zh/cache.md
@@ -23,7 +23,7 @@
 - 数据面直连 S3，runnerd 不转发缓存字节；
 - 凭证是 runnerd 签发的短期 STS，不是长期 AK/SK；
 - 读写范围由 runnerd 按仓库和分支 / PR 注入，workflow 改环境变量也无法超出 STS 授权；
-- Fork PR 只能只读默认分支缓存，不能 save。
+- Fork PR 先读 PR，再读 base 和默认分支，只写入自己的 `pr-N`。
 
 workflow 的 `key` / `restore-keys` 写法仍接近官方 cache，但 `uses` 必须换成 `qiniu/actions-cache@v5`。
 
@@ -83,7 +83,7 @@ jobs:
 
 - 分支 job 先读当前分支，再回退默认分支，只写入当前分支。
 - 内部 PR 先读 PR，再读 base 和默认分支，只写入自己的 `pr-N`。
-- Fork PR 只能只读默认分支缓存，不能 save。日志出现 `Cache save skipped: RUNS_ON_S3_CACHE_WRITE_PREFIX is not set` 不是失败。
+- Fork PR 先读 PR，再读 base 和默认分支，只写入自己的 `pr-N`。如果 GitHub 没有给出可信 PR 元数据，该 job 会保持默认分支只读，日志出现 `Cache save skipped: RUNS_ON_S3_CACHE_WRITE_PREFIX is not set`。
 - `pull_request_target`、`workflow_run`、`issue_comment` 以及无法验证的元数据也是默认分支只读。
 
 并行 job 不要共用同一个 write key。可选方案：
@@ -103,7 +103,7 @@ Cache restored successfully
 Cache saved successfully
 ```
 
-Fork PR 的 save 行是 `Cache save skipped`。如果没有 `local S3 bucket cache`，说明该 job 未注入 Cache S3，action 已回退到 GitHub 官方 cache。
+Fork PR 无法验证时，save 行是 `Cache save skipped`。如果没有 `local S3 bucket cache`，说明该 job 未注入 Cache S3，action 已回退到 GitHub 官方 cache。
 
 ## runnerd 管理员配置
 

--- a/ui/src/content/site-docs/zh/cache.md
+++ b/ui/src/content/site-docs/zh/cache.md
@@ -1,0 +1,134 @@
+# 配置并使用 Cache S3
+
+在 Preferences 中保存 Cache S3，然后在 workflow 中使用 `qiniu/actions-cache@v5`。缓存数据直接写入用户自己的 Bucket，runnerd 不转发字节。
+
+## 开始前
+
+需要准备：
+
+- 已连接的 GitHub 仓库，以及有效的 Sandbox 服务；
+- 位于所选 Sandbox Region 对应 S3 Region 的 Bucket；
+- 对该 Bucket 有对象读写权限的 AK / SK。
+
+个人账号在[账号 Preferences](/account/preferences) 配置。组织仓库由 active member 在 `/organizations/{login}/preferences` 配置。Outside collaborator 只能查看就绪状态，不能保存组织 Cache S3。
+
+不要把 Cache AK/SK 写入 workflow、仓库 Secrets、Issue 或聊天消息。
+
+## 与官方 cache 的区别
+
+官方 `actions/cache` 把缓存存在 GitHub Cache Service。沙箱 runner 不会签发那套凭证，所以官方 cache 在这里不可用，也不应再打开 `actions/setup-go` 自带 cache。
+
+`qiniu/actions-cache@v5` 把缓存写到你在网页上配置的 S3 Bucket：
+
+- 数据面直连 S3，runnerd 不转发缓存字节；
+- 凭证是 runnerd 签发的短期 STS，不是长期 AK/SK；
+- 读写范围由 runnerd 按仓库和分支 / PR 注入，workflow 改环境变量也无法超出 STS 授权；
+- Fork PR 只能只读默认分支缓存，不能 save。
+
+workflow 的 `key` / `restore-keys` 写法仍接近官方 cache，但 `uses` 必须换成 `qiniu/actions-cache@v5`。
+
+## 1. 在网页上配置 Cache S3
+
+Cache S3 没有全局配置，每个账号或组织都要自己填。个人账号打开[账号 Preferences](/account/preferences)；组织仓库由 active member 打开 `/organizations/{login}/preferences`。
+
+先选择并保存 Sandbox 服务区域，再填写 **Cache S3**：
+
+| 字段 | 谁填 | 说明 |
+| --- | --- | --- |
+| Region / Endpoint | 自动带出 | 由所选 Sandbox 区域决定，不能手改 |
+| Bucket | 用户填写 | 必须位于该 Sandbox Region 对应的 S3 Region |
+| Prefix | 可选 | 默认 `gh-actions-cache`。对象路径是 `<prefix>/<owner>/<repo>/scopes/...` |
+| Access Key ID | 用户填写 | 对该 Bucket 有对象读写权限的 AK |
+| Secret Access Key | 用户填写 | 对应 SK。保存后加密存储，页面不再回显 |
+
+保存后，页面只会显示“已配置”，不会再次给出完整密钥。替换时重新输入新的 AK/SK。如果提示所选区域未配置 S3 Endpoint，请联系 runnerd 管理员补齐 `sandbox.regions` 的 `s3_region` 和 `s3_endpoint`。
+
+也可以使用 IAM 子账号，而不是主账号密钥。在 [IAM 概览](https://portal.qiniu.com/iam/overview) 创建用户，并分配：
+
+- Bucket：读取文件、上传文件、修改文件、删除文件；
+- 安全凭证服务：获取临时身份凭证。
+
+runnerd 用这对 AK/SK 签发 STS，沙箱里的 cache action 只使用短期凭证。
+
+建议每个 GitHub installation 使用独立 Bucket，并在 Bucket 上配置生命周期规则，让过期缓存自动删除。
+
+## 2. 在 workflow 中使用缓存
+
+使用 [`qiniu/actions-cache@v5`](https://github.com/qiniu/actions-cache) 替代 `actions/cache`。workflow 不需要填写 Bucket、endpoint、region、AK、SK：
+
+```yaml
+jobs:
+  check:
+    runs-on: [qiniu, ubuntu-24.04]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      - uses: qiniu/actions-cache@v5
+        with:
+          path: |
+            ${{ github.workspace }}/.cache/go/pkg/mod
+            /tmp/go-build-cache
+          key: ${{ runner.os }}-go-check-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-check-
+            ${{ runner.os }}-go-
+```
+
+`setup-go` 只负责安装 Go；缓存统一走 `qiniu/actions-cache@v5`。step 开始时 restore，job 成功结束后由 post step save。job 失败不会 save。
+
+## 3. 缓存隔离
+
+- 分支 job 先读当前分支，再回退默认分支，只写入当前分支。
+- 内部 PR 先读 PR，再读 base 和默认分支，只写入自己的 `pr-N`。
+- Fork PR 只能只读默认分支缓存，不能 save。日志出现 `Cache save skipped: RUNS_ON_S3_CACHE_WRITE_PREFIX is not set` 不是失败。
+- `pull_request_target`、`workflow_run`、`issue_comment` 以及无法验证的元数据也是默认分支只读。
+
+并行 job 不要共用同一个 write key。可选方案：
+
+1. 每个会 save 的 job 使用独立 key，例如 `Linux-go-tidy-` 和 `Linux-go-test-`。
+2. 单独做一个预热 job 负责 save，其他 job 只 restore。
+
+同一次 run 里，A job 的 restore 可能发生在 B job 的 save 之前。需要复用镜像或产物时，脚本必须自带 miss 兜底。
+
+## 4. 验证
+
+成功时日志应包含：
+
+```text
+The cache action detected a local S3 bucket cache. Using it.
+Cache restored successfully
+Cache saved successfully
+```
+
+Fork PR 的 save 行是 `Cache save skipped`。如果没有 `local S3 bucket cache`，说明该 job 未注入 Cache S3，action 已回退到 GitHub 官方 cache。
+
+## runnerd 管理员配置
+
+部署 runnerd 的管理员需要在 `runnerd.yaml` 中提供区域目录和 STS 端点：
+
+```yaml
+sandbox:
+  regions:
+    - id: us-south-1
+      label: "United States · Dallas 1"
+      sandbox_api_url: https://us-south-1-sandbox.qiniuapi.com
+      s3_region: us-north-1
+      s3_endpoint: https://internal-s3-las-us-north-1-dal.qiniucs.com
+    - id: cn-yangzhou-1
+      label: "China · Yangzhou 1"
+      sandbox_api_url: https://cn-yangzhou-1-sandbox.qiniuapi.com
+      s3_region: cn-east-1
+      s3_endpoint: https://internal-s3-las-cn-east-1-yz.qiniucs.com
+
+cache:
+  sts_endpoint: https://sts-ov.qiniuapi.com
+```
+
+每个 region 必须包含 `id`、`label` 和 `sandbox_api_url`。`s3_region` 与 `s3_endpoint` 必须成对出现；只有两者都配置的区域才支持 Cache S3。Endpoint 可能只在 Sandbox 内网可达，所以 runnerd 保存用户配置时只校验格式，不从控制面探测 Bucket。
+
+每次启动沙箱时，runnerd 校验 Workflow Run 上下文，签发有效期为沙箱生命周期加五分钟的 STS，并注入 `RUNS_ON_S3_*` 环境变量。没有刷新机制。
+
+完整部署步骤见[部署 runnerd](/docs/getting-started/deploy)。

--- a/ui/src/content/site-docs/zh/getting-started-deploy.md
+++ b/ui/src/content/site-docs/zh/getting-started-deploy.md
@@ -63,6 +63,8 @@ Bootstrap 命令只更新账号角色并退出，不会启动服务。
 
 不要把普通用户的 Sandbox 凭据写入 `runnerd.yaml`。应用会加密保存 scoped API Key，并且不会向浏览器返回完整值。
 
+Cache S3 也由用户或组织在 Preferences 中配置。管理员需要在 `runnerd.yaml` 的 `sandbox.regions` 中为每个支持缓存的区域同时提供 `s3_region` 和 `s3_endpoint`，并设置 `cache.sts_endpoint`。完整说明见[配置并使用 Cache S3](/docs/guides/cache)。
+
 ## 5. 验证托管 Runner Spec
 
 runnerd 会协调 `ubuntu-slim`、`ubuntu-22.04`、`ubuntu-24.04`、预览版 `ubuntu-26.04` 和 `ubuntu-latest` 的托管 spec。Operator 可以控制每个托管 spec 是否启用，以及并发和 idle capacity；catalog 标签和公共模板名称仍由 runnerd 管理。

--- a/ui/src/content/site-docs/zh/getting-started-hosted.md
+++ b/ui/src/content/site-docs/zh/getting-started-hosted.md
@@ -50,6 +50,8 @@ runs-on: [qiniu, ubuntu-24.04]
 
 [复制完整 workflow](/docs/guides/workflow)
 
+需要跨运行缓存时，先在 Preferences 保存 Cache S3，再使用 `qiniu/actions-cache@v5`。见[配置并使用 Cache S3](/docs/guides/cache)。
+
 ## 5. 运行并验证任务
 
 从 GitHub Actions 触发 workflow。任务运行过程中：

--- a/ui/src/content/site-docs/zh/index.md
+++ b/ui/src/content/site-docs/zh/index.md
@@ -20,6 +20,12 @@
 
 [运行第一个工作流](/docs/guides/workflow)
 
+## 配置缓存
+
+在 Preferences 中保存 Cache S3，然后在 workflow 中使用 `qiniu/actions-cache@v5`。
+
+[配置并使用 Cache S3](/docs/guides/cache)
+
 ## 构建自定义 Runner 模板
 
 把自己的工具链加入私有 Sandbox 模板，关联到自定义 Runner Spec，并验证完整 workflow 链路。

--- a/ui/src/content/site-docs/zh/troubleshooting.md
+++ b/ui/src/content/site-docs/zh/troubleshooting.md
@@ -65,7 +65,7 @@ GitHub App Webhook Secret 必须与 `github.webhook_secret` 完全一致。复�
 1. 仓库 owner 的 Preferences 已保存 Cache S3，所选 Sandbox 区域配置了 S3 Endpoint。
 2. Workflow 使用 `qiniu/actions-cache@v5`，并且 `actions/setup-go` 设置了 `cache: false`。
 3. 日志包含 `The cache action detected a local S3 bucket cache.`。没有这行表示该 job 回退到了 GitHub 官方 cache。
-4. Fork PR 只能只读默认分支缓存；`Cache save skipped` 是预期行为。
+4. Fork PR 只写入自己的 `pr-N`。出现 `Cache save skipped` 表示未能验证 PR 元数据，该 job 保持默认分支只读。
 5. 并行 job 没有共用同一个 write key。
 
 完整说明见[配置并使用 Cache S3](/docs/guides/cache)。

--- a/ui/src/content/site-docs/zh/troubleshooting.md
+++ b/ui/src/content/site-docs/zh/troubleshooting.md
@@ -58,6 +58,18 @@ https://<runner-host>/auth/github/callback
 
 GitHub App Webhook Secret 必须与 `github.webhook_secret` 完全一致。复制完整值，不要带引号或前后空格，保存后重新投递最近的事件。
 
+## Cache restore 未命中或 save 被跳过
+
+检查：
+
+1. 仓库 owner 的 Preferences 已保存 Cache S3，所选 Sandbox 区域配置了 S3 Endpoint。
+2. Workflow 使用 `qiniu/actions-cache@v5`，并且 `actions/setup-go` 设置了 `cache: false`。
+3. 日志包含 `The cache action detected a local S3 bucket cache.`。没有这行表示该 job 回退到了 GitHub 官方 cache。
+4. Fork PR 只能只读默认分支缓存；`Cache save skipped` 是预期行为。
+5. 并行 job 没有共用同一个 write key。
+
+完整说明见[配置并使用 Cache S3](/docs/guides/cache)。
+
 ## 收集有效证据
 
 请求帮助时，请提供：

--- a/ui/src/site-doc-routes.ts
+++ b/ui/src/site-doc-routes.ts
@@ -3,6 +3,7 @@ export const siteDocumentRoutes = [
   "/docs/getting-started/hosted",
   "/docs/getting-started/deploy",
   "/docs/guides/workflow",
+  "/docs/guides/cache",
   "/docs/guides/custom-templates",
   "/docs/troubleshooting",
   "/docs/reference/runner-labels",

--- a/ui/src/site-docs.test.js
+++ b/ui/src/site-docs.test.js
@@ -14,6 +14,7 @@ describe("public site documentation catalog", () => {
       "/docs/getting-started/hosted",
       "/docs/getting-started/deploy",
       "/docs/guides/workflow",
+      "/docs/guides/cache",
       "/docs/guides/custom-templates",
       "/docs/troubleshooting",
       "/docs/reference/runner-labels",
@@ -28,6 +29,8 @@ describe("public site documentation catalog", () => {
     expect(siteDocumentForPath("/docs/guides/workflow", "zh-CN")?.title).toBe("运行第一个工作流")
     expect(siteDocumentForPath("/docs/guides/custom-templates", "en")?.title).toBe("Build and use a custom runner template")
     expect(siteDocumentForPath("/docs/guides/custom-templates", "zh-CN")?.title).toBe("构建并使用自定义 Runner 模板")
+    expect(siteDocumentForPath("/docs/guides/cache", "en")?.title).toBe("Configure and use Cache S3")
+    expect(siteDocumentForPath("/docs/guides/cache", "zh-CN")?.title).toBe("配置并使用 Cache S3")
     expect(siteDocumentForPath("/docs/not-a-guide", "en")).toBeNull()
   })
 
@@ -35,8 +38,8 @@ describe("public site documentation catalog", () => {
     const english = siteDocuments("en")
     const chinese = siteDocuments("zh")
 
-    expect(english).toHaveLength(7)
-    expect(chinese).toHaveLength(7)
+    expect(english).toHaveLength(8)
+    expect(chinese).toHaveLength(8)
     expect(english.map((document) => document.path)).toEqual(chinese.map((document) => document.path))
     expect(english.every((document) => document.title && document.summary && document.markdown.startsWith("# "))).toBe(true)
     expect(chinese.every((document) => document.title && document.summary && document.markdown.startsWith("# "))).toBe(true)

--- a/ui/src/site-docs.ts
+++ b/ui/src/site-docs.ts
@@ -4,6 +4,7 @@ import enHosted from "@/content/site-docs/en/getting-started-hosted.md?raw"
 import enIndex from "@/content/site-docs/en/index.md?raw"
 import enLabels from "@/content/site-docs/en/runner-labels.md?raw"
 import enTroubleshooting from "@/content/site-docs/en/troubleshooting.md?raw"
+import enCache from "@/content/site-docs/en/cache.md?raw"
 import enWorkflow from "@/content/site-docs/en/workflow.md?raw"
 import zhDeploy from "@/content/site-docs/zh/getting-started-deploy.md?raw"
 import zhCustomTemplates from "@/content/site-docs/zh/custom-templates.md?raw"
@@ -11,6 +12,7 @@ import zhHosted from "@/content/site-docs/zh/getting-started-hosted.md?raw"
 import zhIndex from "@/content/site-docs/zh/index.md?raw"
 import zhLabels from "@/content/site-docs/zh/runner-labels.md?raw"
 import zhTroubleshooting from "@/content/site-docs/zh/troubleshooting.md?raw"
+import zhCache from "@/content/site-docs/zh/cache.md?raw"
 import zhWorkflow from "@/content/site-docs/zh/workflow.md?raw"
 import { siteDocumentRoutes } from "@/site-doc-routes"
 
@@ -46,18 +48,19 @@ const definitions: SiteDocumentDefinition[] = [
     markdown: { en: enDeploy, zh: zhDeploy },
   },
   { path: siteDocumentRoutes[3], group: "guides", markdown: { en: enWorkflow, zh: zhWorkflow } },
+  { path: siteDocumentRoutes[4], group: "guides", markdown: { en: enCache, zh: zhCache } },
   {
-    path: siteDocumentRoutes[4],
+    path: siteDocumentRoutes[5],
     group: "guides",
     markdown: { en: enCustomTemplates, zh: zhCustomTemplates },
   },
   {
-    path: siteDocumentRoutes[5],
+    path: siteDocumentRoutes[6],
     group: "guides",
     markdown: { en: enTroubleshooting, zh: zhTroubleshooting },
   },
   {
-    path: siteDocumentRoutes[6],
+    path: siteDocumentRoutes[7],
     group: "reference",
     markdown: { en: enLabels, zh: zhLabels },
   },


### PR DESCRIPTION
Add a public Cache S3 guide for repository users and organization admins.

## User and organization admin

- Save Cache S3 in account or organization Preferences: Bucket, Prefix, AK/SK
- Region and endpoint come from the selected Sandbox region
- IAM sub-accounts can be used instead of the primary key
- Recommend a dedicated bucket plus a lifecycle rule for expired objects

## Workflow usage

- Use `qiniu/actions-cache@v5` instead of GitHub `actions/cache`
- Keep `actions/setup-go` with `cache: false`
- Document branch / internal PR / Fork PR isolation
- Parallel jobs should use separate write keys or a dedicated warmup job

## runnerd operator

- `sandbox.regions` must set `s3_region` and `s3_endpoint` together
- `cache.sts_endpoint` mints short-lived STS credentials

The new public route is `/docs/guides/cache`.